### PR TITLE
Added prometheus/test-infra CommunityBridge Q2 project

### DIFF
--- a/communitybridge/2020/q2/project_ideas.md
+++ b/communitybridge/2020/q2/project_ideas.md
@@ -94,3 +94,11 @@ Recommended Skills: go, distributed systems, Linux
 - Mentor(s): Bartek Plotka (@bwplotka), Kemal Akkoyun (@kakkoyun)
 - Issue: https://github.com/thanos-io/thanos/issues/1706 and https://github.com/thanos-io/thanos/issues/2527
 
+### Prometheus
+
+#### Allow running prombench locally
+
+- Description: Currently prombench development requires the user to setup GKE environment. Having prombench to run in a local k8s cluster would make adding changes much easier and faster. Support for kubeconfig and a proper way to switch local and GKE environment is not available yet. Adding these features will be essential to the completion of the project.
+- Recommended Skills: CI, Golang, Kubernetes
+- Mentor(s): Hrishikesh Barman (@geekodour)
+- Issue: https://github.com/prometheus/test-infra/issues/333.


### PR DESCRIPTION
One of the projects listed for `prometheus/test-infra` didn't find good fit in SoC2020. I was thinking about adding it to the list for community-bridge projects.

Unfortunately, I think Prometheus is not enlisted as a project in the community-bridge website, nor have I applied to be a mentor for community-bridge. Is there any possibility to add this project and enroll prometheus as a project for it now? considering the fact that the submission deadline is close.

cc: @idvoretskyi 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>