### PR TITLE
Change CommunityBridge to LFX Program in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It's best if you use a public communication channel whenever possible; however, 
 
 | Program                                                               | Purpose                                                                         | Details and historical data                  |
 | --------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------------- |
-| [Community Bridge](https://people.communitybridge.org/)               | Mentoring initiative by the Linux Foundation                                    | [communitybridge](communitybridge/README.md) |
+| [LFX Mentorship](https://people.communitybridge.org/)               | Mentoring initiative by the Linux Foundation                                    | [communitybridge](communitybridge/README.md) |
 | [Google Summer of Code](https://summerofcode.withgoogle.com/)         | Mentoring program for the students                                              | [summerofcode](summerofcode/README.md)       |
 | [Google Season of Docs](https://developers.google.com/season-of-docs) | Mentoring initiative for the technical writers                                  | [seasonofdocs](seasonofdocs/README.md)       |
 | [Outreachy](https://www.outreachy.org)                                | Mentoring initiative for the communities traditionally underrepresented in tech | [outreachy](outreachy/README.md)             |


### PR DESCRIPTION
Hello CNCF 👋 
I found that the community bridge is now LFX mentorship, but it's updated only on the folder and not on main README. So yeah, I thought it'd be nice if I change the name, not the link ;)
You can review the PR and decide. Thanks a ton 