### PR TITLE
Add CoreDNS project for GSoC 2021

### DIFF
--- a/summerofcode/2021.md
+++ b/summerofcode/2021.md
@@ -23,3 +23,12 @@ _Add your project ideas below:_
 - Recommended Skills: Java
 - Mentor(s): Tom Bentley (@tombentley), Tom Cooper (@tomncooper)
 - Issue: https://github.com/strimzi/strimzi-kafka-operator/issues/191
+
+### CoreDNS
+
+#### Add ACME protocol support for certificate management with DNS
+
+- [CoreDNS](https://github.com/coredns/coredns) is a cloud-native DNS server with a focus on service discovery. While best known as the default DNS server for Kubernetes, CoreDNS is capable of handle many other scenarios within or outside of Kubernetes clusters for make easy infrastructure management. One such case is the certificate management. This project is to provide ACME protocol support so that it is possible to have automatic certificate management through CoreDNS. More details and discussions are available in https://github.com/coredns/coredns/issues/3460.
+- Recommended Skills: Golang, DNS, TLS, Certificate Management
+- Mentor(s): Yong Tang (@yongtang)
+- Issue: https://github.com/coredns/coredns/issues/3460


### PR DESCRIPTION
This PR add CoreDNS project for GSoC 2021.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>