### PR TITLE
Update Summer-of-Code mentor for 2021 CoreDNS project

### DIFF
--- a/summerofcode/2021.md
+++ b/summerofcode/2021.md
@@ -55,7 +55,7 @@ _Add your project ideas below:_
 
 - [CoreDNS](https://github.com/coredns/coredns) is a cloud-native DNS server with a focus on service discovery. While best known as the default DNS server for Kubernetes, CoreDNS is capable of handle many other scenarios within or outside of Kubernetes clusters for make easy infrastructure management. One such case is the certificate management. This project is to provide ACME protocol support so that it is possible to have automatic certificate management through CoreDNS. More details and discussions are available in https://github.com/coredns/coredns/issues/3460.
 - Recommended Skills: Golang, DNS, TLS, Certificate Management
-- Mentor(s): Yong Tang (@yongtang)
+- Mentor(s): Yong Tang (@yongtang), Paul Greenberg (@greenpau)
 - Issue: https://github.com/coredns/coredns/issues/3460
 
 ### Keptn


### PR DESCRIPTION
This PR updates Summer-of-Code mentor for 2021 CoreDNS project
and adds Paul (@greenpau) as mentor as well.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>