### PR TITLE
add proposal for KubeVela

### DIFF
--- a/lfx-mentorship/2021/03-Fall/project_ideas.md
+++ b/lfx-mentorship/2021/03-Fall/project_ideas.md
@@ -98,3 +98,12 @@ The Kubernetes policy working group focuses on developing tools and solutions th
 - Recommended Skills: golang, prometheus, grafana
 - Mentor(s): [@ZhiqiangZhou](https://github.com/strrl)
 - Issue: <https://github.com/chaos-mesh/chaos-mesh/issues/2198>
+
+#### KubeVela
+
+##### Integration with developing time to provide consistent experience
+
+- Description: Users can use KubeVela to do application delivery and management. In this project, we hope to integrate KubeVela with developing time. So developers can have a consitent experience between local development and production deploy. There're multiple developing tools such as Tilt or Nocalhost, both of them can integrate with KubeVela by supporting KubeVela Application YAML.
+- Recommended Skills: Golang, Kubernetes
+- Mentor(s): Jianbo Sun (@wonderflow)
+- Upstream Issue (URL): https://github.com/oam-dev/kubevela/issues/795


### PR DESCRIPTION
- Description: Users can use KubeVela to do application delivery and management. In this project, we hope to integrate KubeVela with developing time. So developers can have a consitent experience between local development and production deploy. There're multiple developing tools such as Tilt or Nocalhost, both of them can integrate with KubeVela by supporting KubeVela Application YAML.
- Recommended Skills: Golang, Kubernetes
- Mentor(s): Jianbo Sun (@wonderflow)
- Upstream Issue (URL): https://github.com/oam-dev/kubevela/issues/795