### PR TITLE
Create page for GSoC 22

### DIFF
--- a/summerofcode/2022.md
+++ b/summerofcode/2022.md
@@ -1,0 +1,6 @@
+- [Project Ideas](#project-ideas)
+
+## Project Ideas
+
+If you are a project maintainer and consider mentoring during the GSoC 2022 cycle, please, submit your ideas below using the [template](/PROJECT_IDEA_TEMPLATE.md).
+


### PR DESCRIPTION
Changes:
- Created the "blank" ideas page for GSoC 22 so that we can tell potential mentors to add their ideas there
- Google requires an ideas page during the GSoC application anyway