### PR TITLE
Add Cluster API Provider vSphere proposal to LFX Mentorship Spring 2022

### DIFF
--- a/lfx-mentorship/2022/01-Spring/project_ideas.md
+++ b/lfx-mentorship/2022/01-Spring/project_ideas.md
@@ -237,3 +237,10 @@ Project maintainers and mentors, please submit the ideas below (under the Propos
 - **Recommended Skills**: Golang, GitHub, Test, Automation, CI/CD pipelines
 - **Mentor(s)**: Sedef Savas (@sedefsavas)
 - **Upstream Issue (URL)**: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1982
+
+##### Improvising unit test coverage(CAPV)
+
+- **Description**: Cluster API (CAPI) is a Kubernetes sub-project focused on providing declarative APIs and tooling to simplify lifecycle management of Kubernetes clusters. CAPV is the infrastructure provider that extends Cluster API to manage Kubernetes clusters on vSphere. As a mentee, you will start with learning CAPI/CAPV concepts and then, will work on the main project which is to improve unit test coverage. The ideal percentage is 70%. This project aims to either achieve that or come close to it.
+- **Recommended Skills**: Golang, GitHub, Test, Automation, CI/CD pipelines
+- **Mentor(s)**: Ankita Swamy(@Ankitasw),Geetika Batra(@geetikabatra)
+- **Upstream Issue (URL)**: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1392


### PR DESCRIPTION
This PR adds a project for improvising unit test coverage in Cluster API Provider vSphere, which is a Kubernetes SIG Cluster Lifecycle sub-project, to LFX spring term.
Signed-off-by: geetikab@vmware.com <geetikab@vmware.com>