### PR TITLE
Chaos Mesh GSoC 2022 Project Idea

### DIFF
--- a/summerofcode/2022.md
+++ b/summerofcode/2022.md
@@ -37,3 +37,11 @@ If you are a project maintainer and consider mentoring during the GSoC 2022 cycl
 - Mentor(s): ZhengXi Zhou (@zzxwill)
 - Upstream Issue (URL): https://github.com/oam-dev/kubevela/issues/2442
 
+### Chaos Mesh
+
+#### Single binary deployment outside kubernetes environment
+
+- Description: Integrate all dependencies into a single binary and deploy Chaos Mesh outside the kubernetes environment.
+- Recommended Skills: Golang, Kubernetes
+- Mentor(s): Yang Keao (@YangKeao)
+- Upstream Issue (URL): https://github.com/chaos-mesh/chaos-mesh/issues/2848


### PR DESCRIPTION
Add a project idea for Chaos Mesh GSoC 2022: deploy Chaos Mesh outside the Kubernetes cluster.