### PR TITLE
KubeVela: Add GitOps addon for KubeVela

### DIFF
--- a/summerofcode/2022.md
+++ b/summerofcode/2022.md
@@ -37,6 +37,13 @@ If you are a project maintainer and consider mentoring during the GSoC 2022 cycl
 - Mentor(s): ZhengXi Zhou (@zzxwill)
 - Upstream Issue (URL): https://github.com/oam-dev/kubevela/issues/2442
 
+#### Add GitOps addon for KubeVela
+
+- Description: Improve the capabilities of KubeVela GitOps to make it a standalone Addon.
+- Recommended Skills: Golang, Kubernetes, Cue
+- Mentor(s): FogDong (@FogDong)
+- Upstream Issue (URL): https://github.com/oam-dev/kubevela/issues/3205
+
 ### Chaos Mesh
 
 #### Single binary deployment outside kubernetes environment


### PR DESCRIPTION
Add GSoC KubeVela idea: Improve the capabilities of KubeVela GitOps to make it a standalone Addon