### PR TITLE
Adding LitmusChaos to GSoC 2022

### DIFF
--- a/summerofcode/2022.md
+++ b/summerofcode/2022.md
@@ -388,3 +388,13 @@ Description: The [in-toto Jenkins plugin](https://github.com/jenkinsci/in-toto-p
 - Recommended Skills: Golang, Kubernetes, observability tools (such as OpenTelemetry/Jaeger/Prometheus)
 - Mentor(s): Sedef Savas (@sedefsavas) Shivani Singhal (@shivi28)
 - Upstream Issue (URL): https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2178
+
+
+### LitmusChaos
+
+#### Develop a terraform provider or scripts to provision litmuschaos
+
+- Description: [LitmusChaos](https://litmuschaos.io) is an open-source Chaos Engineering platform that enables teams to identify weaknesses & potential outages in infrastructures by inducing chaos tests in a controlled way. This project aims to develop a terraform provider or scripts to provision litmuschaos functionalities.
+- Recommended Skills: Terraform, Kubernetes, Golang
+- Mentor(s): @Jonsy13 @rajdas98 @Adarshkumar14
+- Upstream Issue (URL): https://github.com/litmuschaos/litmus/issues/3456

--- a/summerofcode/2022.md
+++ b/summerofcode/2022.md
@@ -392,7 +392,7 @@ Description: The [in-toto Jenkins plugin](https://github.com/jenkinsci/in-toto-p
 
 ### LitmusChaos
 
-#### Develop a terraform provider or scripts to provision litmuschaos
+#### Develop a terraform provider or scripts to provision litmuschaos functionalities
 
 - Description: [LitmusChaos](https://litmuschaos.io) is an open-source Chaos Engineering platform that enables teams to identify weaknesses & potential outages in infrastructures by inducing chaos tests in a controlled way. This project aims to develop a terraform provider or scripts to provision litmuschaos functionalities.
 - Recommended Skills: Terraform, Kubernetes, Golang


### PR DESCRIPTION
### LitmusChaos

#### Develop a terraform provider or scripts to provision litmuschaos functionalities

- Description: [LitmusChaos](https://litmuschaos.io) is an open-source Chaos Engineering platform that enables teams to identify weaknesses & potential outages in infrastructures by inducing chaos tests in a controlled way. This project aims to develop a terraform provider or scripts to provision litmuschaos functionalities.
- Recommended Skills: Terraform, Kubernetes, Golang
- Mentor(s): @Jonsy13 @rajdas98 @Adarshkumar14
- Upstream Issue (URL): https://github.com/litmuschaos/litmus/issues/3456