### PR TITLE
GSoC 2022: CAPA project update

### DIFF
--- a/summerofcode/2022.md
+++ b/summerofcode/2022.md
@@ -133,12 +133,16 @@ The idea is to create a component that is capable of translating OCI format to V
 
 ##### Improve observability of CAPA
 
-- Description: Cluster API Provider AWS (CAPA) is a subproject of SIG Cluster Lifecycle that extends Cluster API to simplify lifecycle management of Kubernetes clusters on AWS. The focus of this project is to improve the observability of CAPA by integrating it with observability tools such as OpenTelemetry/Jaeger/Prometheus. With the help of metrics/traces emitted by these observability integrations, users will easily analyze CAPA's behaviour and performance.
-- Expected outcome:
+- Description: Cluster API Provider AWS (CAPA) is a subproject of SIG Cluster Lifecycle that extends Cluster API to simplify lifecycle management of Kubernetes clusters on AWS.
+  The focus of this project is to improve the observability of CAPA by integrating it with observability tools such as OpenTelemetry/Jaeger/Prometheus.
+  With the help of metrics/traces emitted by these observability integrations, users will easily analyze CAPA's behaviour and performance.
+  This project will also focus on improving developer experience with OpenTelemetry collectors and by documenting the integration steps.
+- Expected outcome: The main outcome is to instrument CAPA to export OpenTelemetry trace and improve the metrics exposed.
+  Another outcome is to improve development environment by deploying OpenTelemetry for collecting traces, Jaeger and Prometheus for viewing traces and visualizing metrics.
 - Recommended Skills: Golang, Kubernetes, observability tools (such as OpenTelemetry/Jaeger/Prometheus)
 - Mentor(s): Sedef Savas (@sedefsavas) Richard Case (@richcase)
-- Expected project size: 175 or 350 Hours
-- Difficulty: Easy, Medium, or Hard
+- Expected project size: 350 Hours
+- Difficulty: Medium
 - Upstream Issue (URL): https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2178
 
 ### KubeVela


### PR DESCRIPTION
This PR updates details for Cluster API Provider AWS GSoC 22 according to https://github.com/cncf/mentoring/issues/523.

