### PR TITLE
Revert "GSoC 2022: update TiKV projects"

### DIFF
--- a/summerofcode/2022.md
+++ b/summerofcode/2022.md
@@ -317,11 +317,11 @@ socket.
 
 #### Latency Tracing
 
-- Description: [TiKV](https://github.com/tikv/tikv) is an open-source, distributed, and transactional key-value database. TiKV is widely used in many mission-critical scenarios that require request latency to be below a single millisecond level, so knowing where the latency has consumed is important. This project is going to let TiKV has the ability to observe the latency composition and diagnose slow requests. CPU-bound requests in TiKV, such as coprocessor requests, are executed at the requested granularity, which is relatively convenient to trace. However, for IO-bound requests in TiKV, such as prewrite requests, batch processing has been introduced to improve IO throughput, which will bring some challenges to trace since it's a scenario not covered by most tracing frameworks. Also, we need to fetch statistics from RocksDB, the storage engine powering TiKV, to provide further tracing details for IO-bound requests.
-- Expected outcome: Improve observability for IO-bound requests in TiKV. Concretely, we expect to learn about latency details of RaftStore and RocksDB from the improved tracing results.
-- Recommended Skills: Rust, C++, OpenTracing, RocksDB
+- Description: [TiKV](https://github.com/tikv/tikv) is an open-source, distributed, and transactional key-value database. TiKV is widely used in many mission-critical scenarios that require request latency to be below a single millisecond level, so knowing where the latency has consumed is important. 
+- Expected outcome: Provide TiKV the ability to observe latency composition and diagnose slow requests.
+- Recommended Skills: Rust, OpenTracing
 - Mentor(s): Jay Lee (@BusyJay), breeswish (@breeswish)
-- Expected project size: 350 Hours
+- Expected project size: 175 Hours
 - Difficulty: Medium
 - Upstream Issue (URL): https://github.com/tikv/tikv/issues/11872
 


### PR DESCRIPTION
Reverts cncf/mentoring#555

Undoing PR commit to check rules.