### PR TITLE
GSoC 2022: update TiKV projects

### DIFF
--- a/summerofcode/2022.md
+++ b/summerofcode/2022.md
@@ -27,10 +27,8 @@
     - [Observability and policy discovery helper tool](#observability-and-policy-discovery-helper-tool)
     - [Supporting KubeArmor for ARM platforms](#supporting-kubearmor-for-arm-platforms)
   - [TiKV](#tikv)
-    - [Add APM tracing functionality to TiKV Java client](#add-apm-tracing-functionality-to-tikv-java-client)
     - [Normalize TiKV Java client for TiSpark](#normalize-tikv-java-client-for-tispark)
     - [Latency Tracing](#latency-tracing)
-    - [Cross Cluster Replication](#cross-cluster-replication)
   - [Karmada](#karmada)
     - [Refactor community official website](#refactor-community-official-website)
   - [Pixie](#pixie)
@@ -295,16 +293,6 @@ socket.
 
 ### TiKV
 
-#### Add APM tracing functionality to TiKV Java client
-
-- Description: Add APM tracing functionality to TiKV Java client. Allow send metrics to APM system like jaeger.
-- Expected outcome: TiKV Java client would issue queries with trace context carried.
-- Recommended Skills: Java, OpenTracing
-- Mentor(s): Xiang Zhang (@zhangyangyu), Xin Yang (@xuanyu66)
-- Expected project size: 175 Hours
-- Difficulty: Easy
-- Upstream Issue (URL): https://github.com/tikv/client-java/issues/513
-
 #### Normalize TiKV Java client for TiSpark
 
 - Description: TiSpark maintains a fork of TiKV Java client of little use and could use the upstream TiKV Java client.
@@ -320,20 +308,10 @@ socket.
 - Description: [TiKV](https://github.com/tikv/tikv) is an open-source, distributed, and transactional key-value database. TiKV is widely used in many mission-critical scenarios that require request latency to be below a single millisecond level, so knowing where the latency has consumed is important. This project is going to let TiKV has the ability to observe the latency composition and diagnose slow requests. CPU-bound requests in TiKV, such as coprocessor requests, are executed at the requested granularity, which is relatively convenient to trace. However, for IO-bound requests in TiKV, such as prewrite requests, batch processing has been introduced to improve IO throughput, which will bring some challenges to trace since it's a scenario not covered by most tracing frameworks. Also, we need to fetch statistics from RocksDB, the storage engine powering TiKV, to provide further tracing details for IO-bound requests.
 - Expected outcome: Improve observability for IO-bound requests in TiKV. Concretely, we expect to learn about latency details of RaftStore and RocksDB from the improved tracing results.
 - Recommended Skills: Rust, C++, OpenTracing, RocksDB
-- Mentor(s): Jay Lee (@BusyJay), breeswish (@breeswish)
+- Mentor(s): Zhenchi (@zhongzc), breeswish (@breeswish)
 - Expected project size: 350 Hours
 - Difficulty: Medium
 - Upstream Issue (URL): https://github.com/tikv/tikv/issues/11872
-
-#### Cross Cluster Replication
-
-- Description: [TiKV](https://github.com/tikv/tikv) is an open-source, distributed, and transactional key-value database. Cross Cluster Replication is an fundamental feature to provide the ability of cross region read replica and cross region disaster recovery. This project is going to build cross cluster replication ability of TiKV.
-- Expected outcome: The cross region replication ability of TiKV, TiKV-CDC as a service for incremental replicating between TiKV clusters, and TiKV-BR as a tool for statically Backup & Restore TiKV data.
-- Recommended Skills: Rust, Golang
-- Mentor(s): pingyu (@pingyu)
-- Expected project size: 350 Hours
-- Difficulty: Hard
-- Upstream Issue (URL): https://github.com/tikv/tikv/issues/11745
 
 ### Karmada
 


### PR DESCRIPTION
While providing more info about the GSoC projects, we think more about the projects. Currently we send 4 projects, but project 1 is a part of project3, and project 4 is not suitable for a GSoC project. So we'd like to refactor the applied projects. Is it acceptable currently @nate-double-u? Sorry for the work. 