### PR TITLE
Adding GSoC 2022 ideas for the Devfile project (under `summerofcode`)

### DIFF
--- a/summerofcode/2022.md
+++ b/summerofcode/2022.md
@@ -80,6 +80,9 @@
   - [Knative](#knative)
     - [Improve Knative Eventing End-to-End Observability by addressing top issues identified by community](#improve-knative-eventing-end-to-end-observability-by-addressing-top-issues-identified-by-community)
     - [Make Knative running on Edge](#make-knative-running-on-edge)
+  - [Devfile](#devfile)
+    - [Add Compose file support in the spec API](#add-compose-file-support-in-the-spec-API)
+    - [Add some syntax sugar to speficy the components that are deployed at startup and those that are not](#add-some-syntax-sugar-to-speficy-the-components-that-are-deployed-at-startup-and-those-that-are-not)
 
 ---
 
@@ -721,3 +724,24 @@ of disk space in larger deployment.
 - Mentor(s):  Ali Ok @aliok, Carlos Santana @csantanapr
 - Upstream Issue (URL): https://github.com/knative/serving/issues/12718
 
+### Devfile
+
+#### Add Compose file support in the spec API
+
+- Description: Devfiles are YAML files that define development environment running in the cloud. The main part of a Devfile is the components section and specify the containers required to code, build and test an application. The Devfile can either include those containers defintions or reference external files such as Dockerfiles or Kubernetes manifests. [The Compose file](https://github.com/compose-spec/compose-spec/blob/master/spec.md) is a popular format in open source development projects to define runtime environments for testing the application but those cannot be referenced by a Devfile yet. The goal is to update the API specification to allow referencing a Compose file from a Devfile and to implement the support in the Devfile library.
+- Expected outcome: Create a PR against https://github.com/devfile/api to update the spec with the support for Compose files and a PR against https://github.com/devfile/libary to implement it using (the use of an external library such as [kompose](https://github.com/kubernetes/kompose) is recommended). As a stretch goal, implement Compose file support for the DevWorkspace Kubernetes operator too.
+- Expected size of the project: 350h
+- Difficulty rating: Medium
+- Recommended Skills: Golang, Compose, Kubernetes
+- Mentor(s): Mario Loriedo (@l0rd)
+- Upstream Issue (URL): https://github.com/devfile/api/issues/501
+
+#### Add some syntax sugar to speficy the components that are deployed at startup and those that are not
+
+- Description: Devfiles are YAML files that define development environment running in the cloud. The main part of a Devfile is the components section and specify the containers required to code, build and test an application. Some components, such as those to code and build the application, need to be deployed as soon as development environment is provisioned. Others instead are supposed to be started later, usually when a command is triggered by the developer to test the applicaiton she is working on (a database for example). The current definition of the latter type of coponents is complicated and not self explanatory. The goal of this project is to add a new component field to specify if the component should be included at startup or not.
+- Expected outcome: Create a PR against https://github.com/devfile/api to update the component spec and a PR against https://github.com/devfile/libary to implement it using. As a stretch goal, implement the support for the new field for the DevWorkspace Kubernetes operator too.
+- Expected size of the project: 350h
+- Difficulty rating: Medium
+- Recommended Skills: Golang, Kubernetes
+- Mentor(s): Mario Loriedo (@l0rd)
+- Upstream Issue (URL): https://github.com/devfile/api/issues/852


### PR DESCRIPTION
Added a couple of ideas for the [Devfile project](https://devfile.io).

Related to https://github.com/cncf/mentoring/discussions/632

I then created a second PR to update `lfx-mentorship/2022/02-Summer/README.md` as I wasn't sure in what file I should provide the proposals (https://github.com/cncf/mentoring/pull/652).