### PR TITLE
Added username w/ 'maintain' permission

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -28,6 +28,9 @@ collaborators:
   - username: jeefy
     permission: admin
 
+  - username: jaytiaki
+    permission: maintain
+
 labels:
   - name: lfx mentorship
     color: a2dcf2


### PR DESCRIPTION
Added details in 'collaborators' section as suggested by @nate-double-u re Mentoring initiative.