### PR TITLE
Updating LFX 03-Sept-Nov project proposal date range

### DIFF
--- a/lfx-mentorship/2022/03-Sept-Nov/README.md
+++ b/lfx-mentorship/2022/03-Sept-Nov/README.md
@@ -22,5 +22,5 @@ Mentorship duration - three months (12 weeks - full-time schedule)
 
 Project proposals open August 1st, 2022.
 
-Once opened, Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/lfx-mentorship/2022/03-Sept-Nov/project_ideas.md, by August 10th, 2022.
+Once opened, Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/lfx-mentorship/2022/03-Sept-Nov/project_ideas.md, by August 12th, 2022.
 


### PR DESCRIPTION
Followup to https://github.com/cncf/mentoring/pull/676, extending 03-Sept-Nov `project proposal` date range by two days due to missed announcement. (again, missed a reference the first time)