### PR TITLE
Adding "time-sensitive" label for issues and PRs with due dates

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -53,6 +53,9 @@ labels:
     color: ffff54
   - name: good first issue
     color: ff8c00
+  - name: time-sensitive
+    description: issues or PRs that have a due date
+    color: b60205
   - name: outreachy
     color: 7fd811
   - name: season of docs


### PR DESCRIPTION
Signed-off-by: Nate W <natew@cncf.io>