### PR TITLE
Mentoring Workspaces - GITHUBUSER.PROJECT.cncf.io

### DIFF
--- a/lfx-mentorship/2022/03-Sept-Nov/project_ideas.md
+++ b/lfx-mentorship/2022/03-Sept-Nov/project_ideas.md
@@ -69,3 +69,13 @@ The aim of the project is to analyse and reduce the system privileges required b
 - Recommended Skills: go, Kernel, k8s
 - Mentor(s): Ankur Kothiwal (@Ankurk99), Barun Acharya (@daemon1024), Rahul Jadhav (@nyrahul)
 - Issue: <https://github.com/kubearmor/KubeArmor/issues/781>
+
+#### CNCF Tag Contributor Strategy - ii
+
+##### Mentoring Workspaces - GITHUBUSER.PROJECT.cncf.io (w/ VSCode)
+
+- Description: pair.sharing.io is a mentoring / pair environment used by ii.nz that brings up clusters to co-learn and co-author via tmate+emacs and a live cluster with many features useful to cloud native development. However, while many folks find the ideas useful, it would be good to reach a wider audience by bringing up workspaces w/ VSCode as an alternative to emacs. The request is for a PoC deploying coder.com to CNCF Infrastructure (likely Packet) and bringing over some of the methods of collaboration learned by ii on pair to a wider audience.
+  "If you want to go fast, go by yourself. If you want to go far, go together." African Proverb – Martha Goedert
+- Recommended Skills: shell, terminals, VSCode, k8s, System Administration
+- Mentor(s): Hippie Hacker (@hh), Caleb Woodbine (@BobyMCBobs)
+- Issue: <https://github.com/sharingio/pair/issues/173>


### PR DESCRIPTION
Use coder.com on CNCF INfrastructure to bring up pairing/mentoring
environments for our projects.