### PR TITLE
adding Catherine P. to settings.yml file as repo maintainer

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -41,6 +41,9 @@ collaborators:
   - username: jberkus
     permission: maintain
 
+  - username: CathPag
+    permission: maintain
+
   - username: carolynvs
     permission: maintain
 


### PR DESCRIPTION
Adding new TAG Contributor Strategy co-chair,  Catherine P. (@CathPag), to settings.yml file as repo maintainer.