### PR TITLE
Update settings.yml with new label

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -59,6 +59,8 @@ labels:
   - name: time-sensitive
     description: issues or PRs that have a due date
     color: b60205
+  - name: getting started
+    color: 3B8924
   - name: outreachy
     color: 7fd811
   - name: season of docs


### PR DESCRIPTION
Adding 'getting started' label for a common discussion thread topic.

Supercedes https://github.com/cncf/mentoring/pull/721. Sorry for the duplicated PR, didn't have time to hunt down  the DCO issues on the last one.