### PR TITLE
updating GSoC 2023

### DIFF
--- a/summerofcode/2023.md
+++ b/summerofcode/2023.md
@@ -2,14 +2,16 @@
 
 If you are a project maintainer and consider mentoring during the GSoC 2023 cycle, please, submit your ideas below using the template.
 
+[Google summer of code timeline](https://developers.google.com/open-source/gsoc/timeline).
+
 ---
 
 ### Template
 
 ```
-#### CNCF Project Name
+### CNCF Project Name
 
-##### Title
+#### Title
 
 - Description: (2-5+ sentences)
 - Expected outcome:
@@ -21,5 +23,4 @@ If you are a project maintainer and consider mentoring during the GSoC 2023 cycl
 ```
 
 ---
-
 

--- a/summerofcode/README.md
+++ b/summerofcode/README.md
@@ -19,5 +19,6 @@ It's best if you use a public communication channel whenever possible; however, 
 
 ## Current Year
 
-Details about the 2022 program are available [here](https://github.com/cncf/mentoring/blob/main/summerofcode/2022.md).
+Details about the 2023 program are available [here](https://github.com/cncf/mentoring/blob/main/summerofcode/2023.md).
 
+[Google summer of code timeline](https://developers.google.com/open-source/gsoc/timeline).


### PR DESCRIPTION
Adding link to timeline, correcting formatting, updating README.

Signed-off-by: Nate W <natew@cncf.io>