### PR TITLE
GSOC: KubeVela IDE Plugins

### DIFF
--- a/summerofcode/2023.md
+++ b/summerofcode/2023.md
@@ -31,6 +31,8 @@ If you are a project maintainer and consider mentoring during the GSoC 2023 cycl
   - [Eventing Sender Identity](#eventing-sender-identity)
   - [NetworkPolicy support for Knative Serving](#networkpolicy-support-for-knative-serving)
   - [Improving Observability in Knative Eventing](#improving-observability-in-knative-eventing)
+- [KubeVela](#kubevela)
+  - [IDE Plugins](#vela-ide-plugins)
 
 ### Knative
 
@@ -73,3 +75,15 @@ If you are a project maintainer and consider mentoring during the GSoC 2023 cycl
 - Expected project size: 350h
 - Difficulty: Medium
 - Upstream Issue (URL): https://github.com/knative/eventing/issues/6247
+
+### KubeVela
+
+#### Vela IDE Plugins
+
+- Description: With more and more developers start writing KubeVela (OAM) application YAML file and CUE-based X-Definitions, it is increasingly important to provide some tools to help user make correct configurations. IDE plugin is one way to reach that. We can make VSCode/Jetbrains plugins for formatting and previewing the written applications and KubeVela's X-Definitions. The plugin should be able to sync environment data (including installed X-Definitions) and make dryrun preview for the rendering result of applications intelligently. It can also provide preview capability for the selected clusters when topology policy is written. Live-diff for the current application and remote application configuration is useful as well. In addition to the application, when users write X-Defintinitions based on CUELang, auto validating and previewing for rendering results under mock inputs can also support them.
+- Expected outcome: IDE Plugins for KubeVela, or standalone desktop apps
+- Recommended Skills: Golang, Kubernetes, NodeJS, KubeVela, CUELang
+- Mentor(s): Da Yin @Somefive
+- Expected project size: 350h
+- Difficulty: Hard
+- Upstream Issues (URL): https://github.com/kubevela/kubevela/issues/5366


### PR DESCRIPTION
Add a project of KubeVela in GSOC 2023.

Reference: https://github.com/kubevela/kubevela/issues/5366