### PR TITLE
Add LFX proposal for Parquet in PromQL

### DIFF
--- a/lfx-mentorship/2023/01-Mar-May/project_ideas.md
+++ b/lfx-mentorship/2023/01-Mar-May/project_ideas.md
@@ -163,7 +163,7 @@
 
 #### Querying Apache Parquet files with PromQL
 - Description: The new [Thanos PromQL Engine](https://github.com/thanos-community/promql-engine) has a sufficient separation between the syntax tree and the execution plan to allow us to query arbitrary data sources. In this project we would like to explore ways to query data stored in Apache Parquet files.
-- Expected Outcome: The Thanos PromQL engine can querytimeseries data from Apache Parquet files.
+- Expected Outcome: The Thanos PromQL engine can query timeseries data from Apache Parquet files.
 - Recommended Skills: Golang
 - Mentor: Filip Petkovski (@fpetkovski, filip.petkovsky@gmail.com), Prem Saraswat (@onprem, prmsrswt@gmail.com)
 - Upstream Issue: https://github.com/thanos-community/promql-engine/issues/167

--- a/lfx-mentorship/2023/01-Mar-May/project_ideas.md
+++ b/lfx-mentorship/2023/01-Mar-May/project_ideas.md
@@ -161,6 +161,13 @@
 - Mentor: Ben Ye (@yeya24, yb532204897@gmail.com)
 - Upstream Issue: https://github.com/thanos-io/thanos/issues/6007
 
+#### Querying Apache Parquet files with PromQL
+- Description: The new [Thanos PromQL Engine](https://github.com/thanos-community/promql-engine) has a sufficient separation between the syntax tree and the execution plan to allow us to query arbitrary data sources. In this project we would like to explore ways to query data stored in Apache Parquet files.
+- Expected Outcome: The Thanos PromQL engine can querytimeseries data from Apache Parquet files.
+- Recommended Skills: Golang
+- Mentor: Filip Petkovski (@fpetkovski, filip.petkovsky@gmail.com), Prem Saraswat (@onprem, prmsrswt@gmail.com)
+- Upstream Issue: https://github.com/thanos-community/promql-engine/issues/167
+
 
 ### WasmEdge
 


### PR DESCRIPTION
This commit adds an LFX project for querying Apache Parquet files with the new Thanos PromQL engine.

Signed-off-by: Filip Petkovski <filip.petkovsky@gmail.com>

cc @onprem @yeya24 @GiedriusS 
