### PR TITLE
Add emails for some Knative mentors

### DIFF
--- a/summerofcode/2023.md
+++ b/summerofcode/2023.md
@@ -39,7 +39,7 @@ If you are a project maintainer and consider mentoring during the GSoC 2023 cycl
 - Description: We see more users asking for complete isolation in Knative Eventing deployments. While there are Knative Eventing components that support isolated data planes, we are interested in to see isolated control planes as well. There were discussions about this in the community before and many of the asks were left unadressed. However, we have tools that support multitenancy today, such as [kcp](https://github.com/kcp-dev/kcp). We see this project as an experiment.
 - Expected outcome: Finding issues blocking multiple control planes, and possibly fixing them.
 - Recommended Skills: Golang, Kubernetes, Knative, Kubernetes Controllers
-- Mentor(s):  Ali Ok @aliok
+- Mentor(s):  Ali Ok @aliok (aliok AT redhat DOT com)
 - Expected project size: 350h
 - Difficulty: Hard
 - Upstream Issue (URL): https://github.com/knative/eventing/issues/6601
@@ -69,7 +69,7 @@ If you are a project maintainer and consider mentoring during the GSoC 2023 cycl
 - Description: We see users struggling to observe what happens inside Knative Eventing and we want that to be improved by providing easy to use tools. The idea is divided into stages. First stage is to write code (python and/or golang) that implements a plugin for Knative command-line interface (kn CLI). The plugin takes output from observability data gathered by Knative and answers simple questions such as: where did my event go based on event id? Show clusters/groups of common traces and show exceptions? The plugin should be able to verify that necessary Knative configuration for observability is enabled, access server side components. Possible next stages may be to create active probes that add to CLI capability to send probe events to specific Knative components (such as Kafka source or broker) and report if they work as expected (health checks). Another area to explore is using conversational AI to improve the plugin by using AI to parse natural language input and/or process available observability data for common Knative questions. As part of the work there may be proposed fixes and improvements for identified gaps in Knative observability that may be discovered when testing the plugin.
 - Expected outcome: Improved Knative Eventing observability, improved documentation and published one or more blog posts
 - Recommended Skills: Python, data science skills, Golang, Kubernetes
-- Mentor(s): Aleksander Slominski @aslom, Ansu Varghese @aavarghese, and Lionel Villard @lionelvillard
+- Mentor(s): Aleksander Slominski @aslom (aslomins AT redhat DOT com), Ansu Varghese @aavarghese (anvarghe AT redhat DOT com), and Lionel Villard @lionelvillard (lvillard AT redhat DOT com)
 - Expected project size: 350h
 - Difficulty: Medium
 - Upstream Issue (URL): https://github.com/knative/eventing/issues/6247


### PR DESCRIPTION
Adding email addresses for some Knative mentors. Addressing the comment here: https://github.com/cncf/mentoring/pull/779/files#r1088070416

Signed-off-by: Ali Ok <aliok@redhat.com>