### PR TITLE
LFX 2023 01-Mar-May admin updates

### DIFF
--- a/lfx-mentorship/2023/01-Mar-May/README.md
+++ b/lfx-mentorship/2023/01-Mar-May/README.md
@@ -77,6 +77,7 @@
       - [A Rust library crate for mediapipe models for WasmEdge NN](#a-rust-library-crate-for-mediapipe-models-for-wasmedge-nn)
       - [Unified WasmEdge tools](#unified-wasmedge-tools)
       - [WasmEdge C++ SDK](#wasmedge-c-sdk)
+
 # Term 01 - 2023 March - May
 
 Status: Planning
@@ -86,12 +87,12 @@ Mentorship duration - three months (12 weeks - full-time schedule)
 | activity | date |
 | --- | --- |   
 | project proposals | January 16 - 31, 5:00 PM PDT |
-| mentee applications open | February 1 - 14, 5:00 PM PDT |
-| application review/admission decisions/HR paperwork | February 15 - 28, 5:00 PM PDT |
-| Mentorship program begins with the initial work assignments | March 1 (Week 1) | 
-| Midterm mentee evaluations and first stipend payments | April 5 (Week 6) |
-| Final mentee evaluations and mentee feedback/blog submission due, second and final stipend payment approvals | May 17, 5:00 PM PST (Week 12) |
-| Last day of term | May 26 |
+| mentee applications open | February 1 - 21, 5:00 PM PDT |
+| application review/admission decisions/HR paperwork | February 22 - March 7, 5:00 PM PDT |
+| Mentorship program begins with the initial work assignments | March 8 (Week 1) | 
+| Midterm mentee evaluations and first stipend payments | April 12 (Week 6) |
+| Final mentee evaluations and mentee feedback/blog submission due, second and final stipend payment approvals | May 24, 5:00 PM PST (Week 12) |
+| Last day of term | May 31 |
 
 
 ### Project Instructions

--- a/lfx-mentorship/README.md
+++ b/lfx-mentorship/README.md
@@ -22,7 +22,8 @@ LFX Mentorship is actively used by the Cloud Native Computing Foundation as a me
 
 | Year | Term   | Status    | Announcement                                                                                                                                                         | Details                                 |
 | ---- | ------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| 2022 | Term 3: Sept-Nov | Planning   |                                                                                                                                                                      | [2022 Term 3: Sept-Nov](2022/03-Sept-Nov/README.md) |
+| 2023 | Term 1: Sept-Nov | Planning   |                                                                                                                                                                      | [2023 Term 1: Mar-May](2023/01-Mar-May/README.md) |
+| 2022 | Term 3: Sept-Nov | Completed   |                                                                                                                                                                      | [2022 Term 3: Sept-Nov](2022/03-Sept-Nov/README.md) |
 | 2022 | Summer | In progress   |                                                                                                                                                                      | [Summer'2022](2022/02-Summer/README.md) |
 | 2022 | Spring | Completed   | [CNCF Blog](https://www.cncf.io/blog/2022/07/07/cncf-congratulates-36-successful-interns-with-spring-term-lfx-program/)                                                                                                                                                                      | [Spring'2022](2022/01-Spring/README.md) |
 | 2021 | Fall   | Completed | [CNCF Blog](https://www.cncf.io/blog/2021/08/16/cncf-lfx-projects-are-open-for-fall-2021-apply-by-august-22nd)                                                       | [Fall'2021](2021/03-Fall/README.md)     |
@@ -35,7 +36,7 @@ LFX Mentorship is actively used by the Cloud Native Computing Foundation as a me
 
 ### Current cycle
 
-The LFX Mentorship program is completed for 2021. The current cycle is Spring 2022, and more details are coming in Q1'2022.
+The LFX Mentorship program is completed for 2022. The current cycle is 01-Mar-May 2023.
 
 ## Program Maintainers
 


### PR DESCRIPTION
Moving dates back one week across the term.

* updating LFX 2023 01-Mar-May dates. 
* Updating lfx-mentorship README with current term info.
