### PR TITLE
removing toc from GSoC 2023 proposed ideas page

### DIFF
--- a/summerofcode/2023.md
+++ b/summerofcode/2023.md
@@ -26,19 +26,6 @@ If you are a project maintainer and consider mentoring during the GSoC 2023 cycl
 
 ## Ideas
 
-- [Jaeger](#jaeger)
-  - [Implement ClickHouse support](#implement-clickhouse-support)
-- [Knative](#knative)
-  - [Multiple Knative Eventing control planes](#multiple-knative-eventing-control-planes)
-  - [Eventing Sender Identity](#eventing-sender-identity)
-  - [NetworkPolicy support for Knative Serving](#networkpolicy-support-for-knative-serving)
-  - [Improving Observability in Knative Eventing](#improving-observability-in-knative-eventing)
-  - [Dataplane migration for Apache Kafka communications: From Vert.x to Project Loom](#dataplane-migration-for-apache-kafka-communications-from-vertx-to-project-loom)
-  - [Porting Knative Serving to Microshift](#porting-knative-serving-to-microshift)
-  - [Self-Balancing Knative Kafka Broker partitions](#self-balancing-knative-kafka-broker-partitions)
-- [KubeVela](#kubevela)
-  - [IDE Plugins](#vela-ide-plugins)
-
 ### Jaeger
 
 Jaeger (https://jaegertracing.io) is a popular platform for distributed tracing.


### PR DESCRIPTION
Removing the ToC from the proposed ideas page as it's causing too many merge conflicts.

We'll add it back at the end of the process. For now, just add the ideas to the list 🙂