### PR TITLE
 setting up CNCF LFX Mentorship 2023 Terms 02 & 03

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -82,9 +82,13 @@ labels:
     color: FBCA04
   - name: fall
     color: C5DEF5
+  - name: "Term 2: June-Aug"
+    color: C5DEF5
   - name: '2022'
     color: 0052CC
   - name: '2023'
+    color: 0052CC
+  - name: '2024'
     color: 0052CC
   # project labels
   - name: Argo

--- a/lfx-mentorship/2023/02-Jun-Aug/README.md
+++ b/lfx-mentorship/2023/02-Jun-Aug/README.md
@@ -1,0 +1,29 @@
+# Term 02 - 2023 June - August
+
+Status: Planning
+
+Mentorship duration - three months (12 weeks - full-time schedule)
+
+### Timeline
+
+| activity | date |
+| --- | --- |   
+| project proposals due | Fri, April 28, 5:00 PM PDT |
+| mentee applications open | Wed May 3 - Tue May 16, 5:00 PM PDT |
+| application review/admission decisions | Wed May 17 - Mon May 29, 5:00 PM PDT |
+| Mentorship program begins with the initial work assignments |  Thur June 1 (Week 1) | 
+| Midterm mentee evaluations and first stipend payments | Wed July 12 (Week 6) |
+| Final mentee evaluations and mentee feedback/blog submission due, second and final stipend payment approvals | Wed Aug 23, 5:00 PM PST (Week 12) |
+| Last day of term | Thur Aug 31 |
+
+### Project Instructions
+
+Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/lfx-mentorship/2023/02-Jun-Aug/project_ideas.md, by Friday, April 28, 2023.
+
+### Application instructions
+
+Mentee application instructions can be found on the [Program Guidelines](https://github.com/cncf/mentoring/blob/main/lfx-mentorship/README.md#program-guidelines) page.
+
+---
+
+

--- a/lfx-mentorship/2023/02-Jun-Aug/project_ideas.md
+++ b/lfx-mentorship/2023/02-Jun-Aug/project_ideas.md
@@ -1,0 +1,20 @@
+## Template
+
+```
+### CNCF Project Name
+
+#### Mentorship project Title
+
+- Description:
+- Expected Outcome:
+- Recommended Skills:
+- Mentor(s): Mentor Name (@mentor_github, mentor@email.addy)
+- Upstream Issue:
+
+```
+
+---
+
+## Proposed Project ideas
+
+---

--- a/lfx-mentorship/2023/03-Sep-Nov/README.md
+++ b/lfx-mentorship/2023/03-Sep-Nov/README.md
@@ -1,0 +1,29 @@
+# Term 03 - 2023 September - November
+
+Status: Planning
+
+Mentorship duration - three months (12 weeks - full-time schedule)
+
+### Timeline
+
+| activity | date |
+| --- | --- |   
+| project proposals | Thur July 27, 5:00 PM PDT |
+| mentee applications open | Wed Aug 2 - Tues 15, 5:00 PM PDT |
+| application review/admission decisions | Wed Aug 16 - Tues Aug 29, 5:00 PM PDT |
+| Mentorship program begins with the initial work assignments | Mon Sept 4 (Week 1) | 
+| Midterm mentee evaluations and first stipend payments | Wed Oct 11 (Week 6) |
+| Final mentee evaluations and mentee feedback/blog submission due, second and final stipend payment approvals | Wed Nov 22, 5:00 PM PST (Week 12) |
+| Last day of term | Thur Nov 30 |
+
+### Project Instructions
+
+Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/lfx-mentorship/2023/03-Sep-Nov/project_ideas.md, by Thursday, July 27, 2023.
+
+### Application instructions
+
+Mentee application instructions can be found on the [Program Guidelines](https://github.com/cncf/mentoring/blob/main/lfx-mentorship/README.md#program-guidelines) page.
+
+---
+
+

--- a/lfx-mentorship/2023/03-Sep-Nov/project_ideas.md
+++ b/lfx-mentorship/2023/03-Sep-Nov/project_ideas.md
@@ -1,0 +1,20 @@
+## Template
+
+```
+### CNCF Project Name
+
+#### Mentorship project Title
+
+- Description:
+- Expected Outcome:
+- Recommended Skills:
+- Mentor(s): Mentor Name (@mentor_github, mentor@email.addy)
+- Upstream Issue:
+
+```
+
+---
+
+## Proposed Project ideas
+
+---


### PR DESCRIPTION
Adding LFX Mentorship 2023 terms 2 & 3 timelines.

Things to note:
* KubeCon EU: 18 – 21 April 2023
* KubeCon NA: 6-9 November 2023
* This timeline doesn't set out a project proposals "open" timeline, just when they are due. I'd expect that two weeks out we'd still make a call for proposals like we normally do, but if projects want to submit proposals earlier they are able.

Deploy previews:
* https://github.com/nate-double-u/cncf-mentoring/tree/adding-lfx-2023-term-2-3/lfx-mentorship/2023/02-Jun-Aug
* https://github.com/nate-double-u/cncf-mentoring/tree/adding-lfx-2023-term-2-3/lfx-mentorship/2023/03-Sep-Nov