### PR TITLE
Fixed Automate labelling issue for fork PRs #559

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,22 @@
+#Add "2023" to any change to 2023 project files
+
+2023:
+  - summerofcode/2023.md
+  - lfx-mentorship/2023/*
+  - lfx-mentorship/2023/**/*
+  - TAGCS-Mentoring-WG/2023-meeting-minutes.md
+
+# Add 'summer of code' label to any files in the Summer of Code project
+'summer of code':
+  - summerofcode/*
+  - summerofcode/**/*
+
+# Add 'season of docs' label to any files in the season of docs project
+'season of docs':
+  - seasonofdocs/*
+  - seasonofdocs/**/*
+
+# Add 'lfx mentorship' label to any files in the lfx mentorship project
+'lfx mentorship':
+  - lfx-mentorship/*
+  - lfx-mentorship/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-#Add "2023" to any change to 2023 project files
+# Add '2023' to any change to 2023 project files
 
 2023:
   - summerofcode/2023.md

--- a/.github/workflows/prlabeler.yml
+++ b/.github/workflows/prlabeler.yml
@@ -1,0 +1,18 @@
+# This workflow is based on github action official label action v4.
+# This workflow action is triggered on pull request event(on both fork & inside repo)
+# Labels will be applied based on filepath modification in PR.
+# This workflow uses a regex based labeling config file(.github/labeler.yml) to take labeling decision.
+
+name: "PR Labeler"
+on:
+- pull_request_target
+jobs:
+  label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION

Please review and merge it, added pr labeling feature as per Open Issue [Automate labelling PRs #559](https://github.com/cncf/mentoring/issues/559)

- This workflow is based on github action official label action v4.
- This workflow action is triggered on pull request event(on both fork & inside repo)
- Labels will be applied based on filepath modification in PR.
- This workflow uses a regex based labeling config file(.github/labeler.yml) to take labeling decision.