### PR TITLE
Adding aliok as a repo maintainer (GSoC admin)

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -50,6 +50,10 @@ collaborators:
   - username: riaankl
     permission: maintain
 
+  # GSoC admin
+  - username: aliok
+    permission: maintain
+
 labels:
   - name: lfx mentorship
     color: a2dcf2


### PR DESCRIPTION
I offered my help to co-admin GSoC efforts at CNCF and it was accepted in the WG meeting [notes](https://hackmd.io/@tag-cs-mentoring-wg/monthly-meeting-2023#Notes).

Adding myself as a maintainer so that I can "officially" review GSoC related PRs.