### PR TITLE
Remove labels that don't have any open/closed issues labeled with it

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -68,8 +68,6 @@ labels:
   - name: time-sensitive
     description: issues or PRs that have a due date
     color: b60205
-  - name: getting started
-    color: 3B8924
   - name: outreachy
     color: 7fd811
   - name: season of docs
@@ -96,31 +94,6 @@ labels:
     color: 0052CC
   - name: '2024'
     color: 0052CC
-  # project labels
-  - name: Argo
-  - name: Brigade
-  - name: Buildpacks
-  - name: cert-manager
-  - name: "Chaos Mesh"
-  - name: CoreDNS
-  - name: in-toto
-  - name: Karmada
-  - name: Keylime
-  - name: Knative
-  - name: KubeArmor
-  - name: KubeEdge
-  - name: Kubernetes
-  - name: KubeVela
-  - name: Kyverno
-  - name: LitmusChaos
-  - name: Meshery
-  - name: Pixie
-  - name: "Service Mesh Performance"
-  - name: Thanos
-  - name: "The Update Framework"
-  - name: TiKV
-  - name: Vitess
-  - name: WasmEdge
   # one "blank" line
   - name: blank
 

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -68,6 +68,8 @@ labels:
   - name: time-sensitive
     description: issues or PRs that have a due date
     color: b60205
+  - name: getting started
+    color: 3B8924
   - name: outreachy
     color: 7fd811
   - name: season of docs


### PR DESCRIPTION
Remove labels that don't have any* open/closed issues labeled with it.
Some labels like `hold` are like the same but I am keeping it.

Fixes #933