### PR TITLE
Removing collaborator section of settings.yml

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -10,50 +10,6 @@ repository:
   # A URL with more information about the repository
   homepage: https://mentoring.cncf.io
 
-  # Collaborators: give specific users access to this repository.
-collaborators:
-  # CNCF repo admins
-  - username: caniszczyk
-    permission: admin
-
-  - username: idvoretskyi
-    permission: admin
-    
-  - username: amye
-    permission: admin
-
-  - username: nate-double-u
-    permission: admin
-    
-  - username: jeefy
-    permission: admin
-
-  - username: thisisobate
-    permission: maintain
-
-  # CNCF TAG Contributor Strategy & Mentoring WG chairs, leads
-  - username: jaytiaki
-    permission: maintain
-
-  - username: geekygirldawn
-    permission: maintain
-
-  - username: jberkus
-    permission: maintain
-
-  - username: CathPag
-    permission: maintain
-
-  - username: carolynvs
-    permission: maintain
-   
-  - username: riaankl
-    permission: maintain
-
-  # GSoC admin
-  - username: aliok
-    permission: maintain
-
 labels:
   - name: lfx mentorship
     color: a2dcf2


### PR DESCRIPTION
removing collaborator section of settings.yml as access is managed by sheriff over in https://github.com/cncf/people/commits/main/config.yaml now.

Are there other parts of this settings.yml file that should be updated/removed based on the sheriff setup?