### PR TITLE
Fix date mismatch with actual timeline

### DIFF
--- a/programs/lfx-mentorship/2023/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2023/02-Jun-Aug/README.md
@@ -18,7 +18,7 @@ Mentorship duration - three months (12 weeks - full-time schedule)
 
 ### Project Instructions
 
-Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/2023/02-Jun-Aug/project_ideas.md, by Thursday, May 4, 2023.
+Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/2023/02-Jun-Aug/project_ideas.md, by Tuesday, May 9, 2023.
 
 ### Application instructions
 


### PR DESCRIPTION
The date for proposal due for mentors is Tuesday, 9th may. But there was a typo where it was mentioned the proposal due date is 4th May.

Tried to fix the issue in this PR :)