### PR TITLE
Add LFX Project Idea: DNS-over-QUIC (DoQ) and/or DNS-over-HTTP/3 (DoH3) support for CoreDNS

### DIFF
--- a/programs/lfx-mentorship/2023/02-Jun-Aug/project_ideas.md
+++ b/programs/lfx-mentorship/2023/02-Jun-Aug/project_ideas.md
@@ -17,6 +17,16 @@
 
 ## Proposed Project ideas
 
+### CoreDNS
+
+#### Add DNS-over-QUIC (DoQ) and/or DNS-over-HTTP/3 (DoH3) support
+
+- Description: DNS-over-QUIC (DoQ) and DNS-over-HTTP/3 (DoH3) are relatively new protocols for transmitting DNS queries with security and privacy. Additionally, DoQ and DoH3 also offers other benefits such as improved latency and better error detection. The goal of this proposal is to add DoQ and/or DoH3 support to CoreDNS.
+- Expected Outcome: An implementation of DoQ or DoH3 for CoreDNS. A stretch goal of adding both DoQ and DoH3 is also within scope.
+- Recommended Skills: Golang, DNS.
+- Mentor(s): Yong Tang @yongtang (yong.tang.github@outlook.com); Chris O'Haver @chrisohaver (cohaver@infoblox.com)
+- Upstream Issue (URL): https://github.com/coredns/coredns/issues/5583, https://github.com/coredns/coredns/issues/5539
+
 ### Jaeger
 
 #### Upgrade Jaeger's internal telemtery to OpenTelemetry


### PR DESCRIPTION
Since the project idea was not selected in the GSoC program, I am proposing the project idea here.