### PR TITLE
Fix broken link

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.enableCommitSigning": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "git.enableCommitSigning": true
-}

--- a/mentoring-wg/gsoc-org-admin-guide.md
+++ b/mentoring-wg/gsoc-org-admin-guide.md
@@ -38,7 +38,7 @@ The following are not responsibilities of a GSoC admin:
 At this stage, Google announces it will have GSoC in the upcoming year. There is no guarantee from Google that CNCF will be accepted to GSoC.
 
 Tasks:
-* Create GSoC ideas page in [`cncf/mentoring`](https://github.com/cncf/mentoring/tree/main/summerofcode) repository. An ideas page will be necessary during the organization application.
+* Create GSoC ideas page in [`cncf/mentoring`](https://github.com/cncf/mentoring/tree/main/summerofcode/2023.md#project-ideas) repository. An ideas page will be necessary during the organization application.
 * [Announce](#Announcements) the intention to participate in the program ([example announcement](https://github.com/cncf/mentoring/discussions/777)). Mention these:
     * Deadline to add ideas is the contributor application period start date.
     * CNCF has not yet been accepted into the program.

--- a/mentoring-wg/gsoc-org-admin-guide.md
+++ b/mentoring-wg/gsoc-org-admin-guide.md
@@ -38,7 +38,7 @@ The following are not responsibilities of a GSoC admin:
 At this stage, Google announces it will have GSoC in the upcoming year. There is no guarantee from Google that CNCF will be accepted to GSoC.
 
 Tasks:
-* Create GSoC ideas page in [`cncf/mentoring`](https://github.com/cncf/mentoring/tree/main/summerofcode/2023.md#project-ideas) repository. An ideas page will be necessary during the organization application.
+* Create GSoC ideas page in [`cncf/mentoring`](https://github.com/cncf/mentoring/tree/main/programs/summerofcode) repository. An ideas page will be necessary during the organization application.
 * [Announce](#Announcements) the intention to participate in the program ([example announcement](https://github.com/cncf/mentoring/discussions/777)). Mention these:
     * Deadline to add ideas is the contributor application period start date.
     * CNCF has not yet been accepted into the program.


### PR DESCRIPTION
## Fix link
Checked all hyperlink in the repo.Found only one broken link which is fixed by this PR.
Some links in the meeting agendas do not work anymore, but this was part of work in progress. As it is part of historical agenda items, it should likely not be updated.

Fixes: #901 
