### PR TITLE
Added missing Strimzi to the overall list

### DIFF
--- a/programs/lfx-mentorship/2023/02-Jun-Aug/project_ideas.md
+++ b/programs/lfx-mentorship/2023/02-Jun-Aug/project_ideas.md
@@ -28,6 +28,7 @@
 * [Tetragon](#tetragon)
 * [WasmEdge](#wasmedge)
 * [Konveyor](#konveyor)
+* [Strimzi](#strimzi)
 * [Thanos](#thanos)
 * [KubeArmor](#kubearmor)
 * [LitmusChaos](#litmuschaos)


### PR DESCRIPTION
When adding the Strimzi idea on the page, I forgot to add Strimzi on the list as well.
This PR fixes it.