### PR TITLE
Mentor guide

### DIFF
--- a/mentors/README.md
+++ b/mentors/README.md
@@ -1,78 +1,127 @@
-**Draft - contributions welcome**
+# Introduction
 
-# Become a Mentor
+CNCF participates in and organizes a variety of mentoring programs. CNCF is a great place to spend time learning, coding, documenting, participating, and contributing. We look forward to your application and your project ideas!
 
+In this guide, we would like to share some information about why you should be a mentor, how to become a mentor, and what to expect as a mentor. We also provide some resources to help you get started and make the most of your mentoring experience.
 
+## Why become a mentor?
 
-## Mentor Expectations
+Mentoring is a great way to give back to the community and help others learn. Furthermore, it is also a great way to learn new skills and improve your own knowledge. Mentoring is a rewarding experience that can help you grow as a person and as a professional.
 
+It is also a good way to recruit new contributors to your project and community and improve them.
 
+## Expectations from Mentors
 
-## Support Networks
+Mentors are expected to:
+- Come up with project ideas for potential mentees, before the program starts
+- Evaluate mentees and proposals submitted by mentees for acceptance into the program
+- Be available to answer questions and provide guidance to mentees
+- Help mentees get involved in the community, including code reviews, documentation, and other contributions
+- Help mentees learn some soft skills, such as communication, teamwork, time management and community mechanics
+- Provide feedback on the mentee's work
 
+All the mentorship programs CNCF participates in or organizes are full time mentorship programs. While the mentees are expected to spend 30-40 hours per week on the programs, mentors are expected to spend 3-6 hours per week per mentee. This includes time spent on project ideas, reviewing proposals, answering questions, and providing feedback. Please note that not every project/mentee/mentor is the same, and the time commitment may vary. Teaming up with other mentors can help share the time commitment.
 
+In general, anyone can become a mentor. However, we require that you have good experience with the project you are mentoring for. You should also be familiar with the community and the community processes. You should be able to answer questions and provide guidance to the mentees.
+
+## Non-duties of Mentors
+
+Following are not within the scope of the mentor's duties:
+- Do the work for the mentees
+- Be available 24/7
+- Find a job for the mentees
+- Push mentees to do the project tasks
+
+## How to become a mentor?
+
+Short answer: come up with a project idea that is suitable for a mentorship and inform the CNCF mentoring group by sending a PR!
+
+Long answer:
+1. Watch out for the announcements: CNCF mentoring programs are announced on CNCF Twitter ([@CloudNativeFdn](https://twitter.com/CloudNativeFdn)), and CNCF Slack ([#mentoring](https://cloud-native.slack.com/archives/CGPK98JNQ)). You can also watch the [announcements](https://github.com/cncf/mentoring/discussions/categories/announcements) on CNCF mentoring repository.
+2. Find a project idea: Either come up with a new mentorship project idea, or find an existing mentorship project idea that you would like to mentor for. Definition of what is a good project idea varies from program to program. For example, while LFX Mentorship project ideas are more focused on coding, Google Season of Docs project ideas are more focused on documentation.
+3. Submit your project idea: Submit your project idea to the [CNCF mentoring repository](https://github.com/cncf/mentoring). You can use the [project idea template](https://github.com/cncf/mentoring/blob/main/PROJECT_IDEA_TEMPLATE.md). There will be information on how to submit your project idea in the announcement that will be sent for the program.
+4. Review mentee profiles and proposals: Once the mentee profiles and proposals are submitted for your project idea, you will be able to review them. Program administrators will provide you with more information on how to review the proposals and the main criteria for acceptance will be your feedback.
+5. Mentor the mentees: Once the mentees are accepted into the program, you will be able to start mentoring them! 
+
+The processes may vary from program to program, however you will be informed at every step about what to do and how to do it by the program administrators, including a timeline!
 
 ## Programs
 
+For the up-to-date list of programs, please check the [CNCF mentoring repository](https://github.com/cncf/mentoring).
 
+## Example mentoring timeline
 
-## Project Idea (Template)
-
-
+* GSoC at CNCF 2023 is [announced](https://github.com/cncf/mentoring/discussions/848)
+  * Mentors send their project idea PRs ([example](https://github.com/cncf/mentoring/pull/810))
+* Mentee applications start ([announcement](https://github.com/cncf/mentoring/discussions/892))
+  * Mentee candidates interact with the community and the mentors
+  * Mentee candidates submit their proposals to the GSoC platform
+*  Mentee applications close ([announcement](https://github.com/cncf/mentoring/discussions/918))
+  * Mentors review the proposals and provide feedback
+* Accepted mentees are [announced](https://github.com/cncf/mentoring/discussions/954)
+  * Mentees bond with the community and the mentors
+  * Mentors and mentees start working on their projects
+* TBA: (we're in the middle of the program)
 
 ## Success Stories
 
+TBD
+
+## Best Practices
+
+### Attracting Mentees
+
+In order to attract mentees to your project idea, we recommend the following best practices:
+* Make sure you have a good project idea that is suitable for the mentorship program you're targeting to participate in
+* Submit your project idea early, to give mentee candidates enough time to learn more about the project and also interact with the community
+* Be available to answer questions when candidates ask questions about your project idea
+
+### Reviewing Mentee Applications and Proposals
+
+To make the mentoring experience pleasant for you and for your mentee:
+* Do not accept "OK" applications and proposals. Look for enthusiastic candidates and high quality proposals.
+* Do not accept more mentees than you can handle. If you are not sure how many mentees you can handle, ask the program administrators.
+* Set your expectations right in the project idea. You would want to avoid to be in the situation where you have a mismatch of expectations with your mentee.
+* Provide feedback to the candidates and help them improve their proposals. This will help you and your mentee in the long run.
+
+### Mentoring Mentees
+
+To make the most of your mentoring experience, we recommend the following best practices:
+* Be available for the mentee! This is the most important thing you can do for your mentee and it will be the most rewarding thing for you.
+* Introduce your mentee to the community and help them get familiar with the community processes.
+* Encourage your mentee to interact with the community, and not just with you. While you will be the main responsible person for the mentee, a mentee interacting with the community will help you share the load.
+* Ask your mentee to submit their work early and often, and also ask them to look for community feedback.
+* Look for opportunities to retain the mentee in the community after the program ends. This can be done by helping them find a new project to work on.
+* Share your mentoring experience with your community and the wider open source community by writing a blog post together, giving a talk together or preparing a demo together. This will help you and your community to attract more mentees in the future.
+
+## Support
+
+Mentors have a direct line to us!
+
+If you have any questions, please reach out to the CNCF mentoring group on [CNCF Slack](https://cloud-native.slack.com/archives/CGPK98JNQ) or on [CNCF Mentoring repository discussions](https://github.com/cncf/mentoring/discussions). We are happy to help you mentor your mentees!
+
+## Mentor Resources
+
+### Google Summer of Code
+
+In addition to Google Summer of Code [official documentation](https://summerofcode.withgoogle.com/help), Google provides a lot of resources targeting mentors. We recommend you to check out the following resources:
+
+- [GSoC Mentor Guide](https://google.github.io/gsocguides/mentor/)
+- [GSoC FAQ for Mentors](https://developers.google.com/open-source/gsoc/faq#mentorsorganization_administrators)
+- [GSoC Mentor Responsibilities](https://developers.google.com/open-source/gsoc/help/responsibilities#mentor_responsibilities)
 
 
-## FAQs
+### LFX Mentorship
 
+LFX Mentorship [official documentation](https://docs.linuxfoundation.org/lfx/mentorship) has specific information for mentors. We encourage you to check out the following documents:
 
+- [LFX Mentorship - Mentor Information](https://docs.linuxfoundation.org/lfx/mentorship/mentors)
+- [LFX Mentorship - Mentor Guide](https://docs.linuxfoundation.org/lfx/mentorship/mentor-guide)
 
+### Google Season of Docs
 
----
+- [Google Season of Docs documentation](https://developers.google.com/season-of-docs/docs)
 
-Mentees - Frequently Asked Questions (FAQs)
-FAQs: New Mentees and Contributors
-General Questions
+### Outreachy
 
-
-
-If you have some basic experience, check out the CNCF Contributor page. It has a list of projects that may suit your skillset.
-
-
-
-The Linux Foundation also offers a free short course for Beginners which can help you get familiar with the fundamentals of Open Source and started on your contributor journey.
-
-
-
-## FAQs: Returning Mentees - Full List
-
-1. I've graduated a mentorship program. What's next?
-1. How do I become a Mentor for a project?
-1. I'm having trouble finding a job now I've graduated. What steps should I take?
-1. I didn't finish a program in the past. Can I still take part in mentorship opportunities?
-1. Can I apply for the LFX Mentorship again after successfully completing a Semester?
-1. I've submitted my application or requested information and haven't heard back by the expected timeframe. How can I follow up?
-
-
-
-
----
-
-
-
-Participating in the community: Join mailing lists, attend virtual events, and engage in discussions to get involved with the community.
-
-Contributing code: Find a project that you're interested in and submit a pull request to start contributing code.
-
-Reporting bugs: If you find a bug, report it on the project's issue tracker.
-
-Writing documentation: Many CNCF projects are in need of clear, up-to-date documentation. You can help by writing or improving documentation.
-
-Providing feedback: Participate in design reviews, provide feedback on feature proposals, and engage with the project community.
-
-Organizing events: You can help the project by organizing or participating in meetups, workshops, or other events.
-
-Mentoring: Share your knowledge and experience by mentoring new contributors to the project.
-
-Testing: Help test new features, validate bug fixes, and provide feedback to improve the quality of the project.
+Outreachy's [mentor CFP page](https://www.outreachy.org/communities/cfp/) has all the information specific to mentors.


### PR DESCRIPTION
Fixes https://github.com/cncf/mentoring/issues/736

cc @Riaankl 
I see there's more in https://github.com/cncf/mentoring/issues/736 like instructions about program specific things, but I didn't write them. ...well, I can't write them anyway as I don't know how the platforms work other than GSoC.

IMO, we should keep our mentor guide generic. Platform related instructions are sent with each announcement anyway (like, "It is time to review mentee applications. Use this page / that form to inform us with your selection", etc.)