### PR TITLE
Create a Github Action to auto add Issues and PRs to the PRoject board

### DIFF
--- a/.github/workflows/add_to_project_board
+++ b/.github/workflows/add_to_project_board
@@ -1,0 +1,17 @@
+name: Add to Project Board
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add_to_project_board:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add To GitHub projects
+        uses: actions/add-to-project@v0.5.0
+        with:
+           project-url: https://github.com/orgs/cncf/projects/25
+           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Why
This PR is created to add a GH Action to automatically add Issues and PR to the project board
The code was tested on another repo, project board and with another token. - Worked as expected

### What
I replaced the project URL and token to make it work here.
The token I have picked off the [prlabeler.yml](.github/workflows/prlabeler.yml) This is new to me, hope it work. Else we would just have to work out the correct token.
Another concern for me could be the repo's permission to add objects to the project board.  :crossed_fingers: 

### Next step
Once this merge and prove to work as expected I will do the same for CNCF/TAG-CS Repo.
