### PR TITLE
lfx-fall-2023: Add K8s SIG Release topic idea

### DIFF
--- a/programs/lfx-mentorship/2023/03-Sep-Nov/project_ideas.md
+++ b/programs/lfx-mentorship/2023/03-Sep-Nov/project_ideas.md
@@ -375,3 +375,16 @@
     - Wang YiKe (@wangyikewxgm, wangyike.wyk@gmail.com)
 - Upstream Issue: [kubevela/kubevela#5365](https://github.com/kubevela/kubevela/issues/5365)
 
+---
+
+### Kubernetes
+
+#### Build a Go library and CLI for interacting with OpenBuildService
+
+- Description: Kubernetes is set to start using [OpenBuildService](http://openbuildservice.org) as a platform for building, publishing, and hosting Kubernetes system (Debian and RPM) packages. The current integration with the OpenBuildService platform assumes a lot of manual tasks and depending on `osc` command-line tool written in Python. At SIG Release, we're striving to automate as many tasks as possible. We want to build a library and CLI written in Go for interacting with the OpenBuildService APIs and platform that can be integrated with our existing [release tooling (`krel`)](http://github.com/kubernetes/release).
+- Expected Outcome: Library and CLI tool for interacting with OpenBuildService platform via their publicly available APIs. Both library and CLI tool should be properly tested via unit, integration, and end-to-end tests, and properly documented.
+- Recommended Skills: Golang, working with APIs
+- Mentor(s):
+  - Carlos Panato (@cpanato, ctadeu@gmail.com)
+  - Marko Mudrinić (@xmudrii, mudrinic.mare@gmail.com)
+- Upstream Issue: https://github.com/kubernetes/sig-release/issues/2295


### PR DESCRIPTION
This PR adds a topic idea from Kubernetes SIG Release for building library and CLI for interacting with OpenBuildService platform that we use for building and publishing packages.

cc @cpanato @saschagrunert 