### PR TITLE
Update GSoC org admin guide with a reminders for mentors and project idea template for LFX to have multiple mentors

### DIFF
--- a/PROJECT_IDEA_TEMPLATE.md
+++ b/PROJECT_IDEA_TEMPLATE.md
@@ -19,8 +19,9 @@
 ##### Refactor the APIs for better readability and less maintenance overhead
 
 - Description: Currently the HTTP API is not very well organized and needs some tidying up. The actual course of action is not decided yet, but [go-kit](https://github.com/go-kit/kit) looks like a good fit.
+- Expected Outcome: A refactored HTTP API that is easier to maintain and extend.
 - Recommended Skills: golang
 - Mentor(s):
   - Jane Doe (@jane-github, jane@email.address) - primary
   - John Doe (@john-github, john@email.address)
-- Issue: https://github.com/prometheus/prometheus/issues/3416
+- Upstream Issue: https://github.com/prometheus/prometheus/issues/3416

--- a/PROJECT_IDEA_TEMPLATE.md
+++ b/PROJECT_IDEA_TEMPLATE.md
@@ -20,5 +20,7 @@
 
 - Description: Currently the HTTP API is not very well organized and needs some tidying up. The actual course of action is not decided yet, but [go-kit](https://github.com/go-kit/kit) looks like a good fit.
 - Recommended Skills: golang
-- Mentor(s): Krasi Georgiev (@krasi-georgiev) - primary, John Doe(@johndoe)
+- Mentor(s):
+  - Jane Doe (@jane-github) - primary
+  - John Doe (@john-github)
 - Issue: https://github.com/prometheus/prometheus/issues/3416

--- a/PROJECT_IDEA_TEMPLATE.md
+++ b/PROJECT_IDEA_TEMPLATE.md
@@ -8,8 +8,8 @@
 - Expected Outcome:
 - Recommended Skills:
 - Mentor(s): # It is recommended to have at least 2 mentors, and at least one of them should be the primary mentor. For GSoC, it is **required** to have at least 2 mentors.
-  - Jane Doe (@jane-github) - primary
-  - John Doe (@john-github)
+  - Jane Doe (@jane-github, jane@email.address) - primary
+  - John Doe (@john-github, john@email.address)
 - Upstream Issue (URL):
 ```
 
@@ -21,6 +21,6 @@
 - Description: Currently the HTTP API is not very well organized and needs some tidying up. The actual course of action is not decided yet, but [go-kit](https://github.com/go-kit/kit) looks like a good fit.
 - Recommended Skills: golang
 - Mentor(s):
-  - Jane Doe (@jane-github) - primary
-  - John Doe (@john-github)
+  - Jane Doe (@jane-github, jane@email.address) - primary
+  - John Doe (@john-github, john@email.address)
 - Issue: https://github.com/prometheus/prometheus/issues/3416

--- a/PROJECT_IDEA_TEMPLATE.md
+++ b/PROJECT_IDEA_TEMPLATE.md
@@ -7,7 +7,9 @@
 - Description:
 - Expected Outcome:
 - Recommended Skills:
-- Mentor(s): It is recommended to have at least 2 mentors, and at least one of them should be the primary mentor. For GSoC, it is **required** to have at least 2 mentors.
+- Mentor(s): # It is recommended to have at least 2 mentors, and at least one of them should be the primary mentor. For GSoC, it is **required** to have at least 2 mentors.
+  - Jane Doe (@jane-github) - primary
+  - John Doe (@john-github)
 - Upstream Issue (URL):
 ```
 

--- a/PROJECT_IDEA_TEMPLATE.md
+++ b/PROJECT_IDEA_TEMPLATE.md
@@ -7,7 +7,7 @@
 - Description:
 - Expected Outcome:
 - Recommended Skills:
-- Mentor(s):
+- Mentor(s): It is recommended to have at least 2 mentors, and at least one of them should be the primary mentor. For GSoC, it is **required** to have at least 2 mentors.
 - Upstream Issue (URL):
 ```
 
@@ -18,5 +18,5 @@
 
 - Description: Currently the HTTP API is not very well organized and needs some tidying up. The actual course of action is not decided yet, but [go-kit](https://github.com/go-kit/kit) looks like a good fit.
 - Recommended Skills: golang
-- Mentor(s): Krasi Georgiev (@krasi-georgiev)
+- Mentor(s): Krasi Georgiev (@krasi-georgiev) - primary, John Doe(@johndoe)
 - Issue: https://github.com/prometheus/prometheus/issues/3416

--- a/mentoring-wg/gsoc-org-admin-guide.md
+++ b/mentoring-wg/gsoc-org-admin-guide.md
@@ -152,9 +152,9 @@ Tasks:
 * Make sure that the description provides a good sense of context and motivation for the idea to attract contributors.
 * Ensure the expected outcome benefits contributors (e.g. learning, growth) and the project (e.g. new features/functionality, bug fixes).
 * Check if the idea is a coding project. Projects such as documentation-only tasks are not accepted to GSoC per [program rules](https://summerofcode.withgoogle.com/rules).
-* Ask the mentor to have a co-mentor.
 * Remind the mentor about the deadlines with this text, before merging their PR:
 > Please note that GSoC is a program known for its strict deadlines. In addition to responding to your mentee on time, you will be required to submit evaluations on time. Failures to meet the deadlines might affect CNCF's future participation in GSoC.
+* Make sure the proposal has at least to mentors and one is noted as the primary mentor.
 
 ## Contributor+proposal selection and ranking process
 

--- a/mentoring-wg/gsoc-org-admin-guide.md
+++ b/mentoring-wg/gsoc-org-admin-guide.md
@@ -116,7 +116,6 @@ Tasks:
 * Inform mentors and contributors about the following:
     * Coding starting date
     * Midterm evaluation date
-    * TODO: anything to inform around monitoring their progress? While GSoC admins cannot technically review the progress, we can ask biweekly/monthly reports from mentors
 
 ### Midterm evaluations
 * Inform mentors and contributors about:
@@ -140,7 +139,7 @@ Tasks:
 
 ### Additional tasks
 
-* Mentor stipend: TODO
+* Mentor stipend: This can be only done by CNCF staff.
 * Maintain this guide
 
 ## Project idea proposal review guidelines
@@ -153,6 +152,9 @@ Tasks:
 * Make sure that the description provides a good sense of context and motivation for the idea to attract contributors.
 * Ensure the expected outcome benefits contributors (e.g. learning, growth) and the project (e.g. new features/functionality, bug fixes).
 * Check if the idea is a coding project. Projects such as documentation-only tasks are not accepted to GSoC per [program rules](https://summerofcode.withgoogle.com/rules).
+* Ask the mentor to have a co-mentor.
+* Remind the mentor about the deadlines with this text, before merging their PR:
+> Please note that GSoC is a program known for its strict deadlines. In addition to responding to your mentee on time, you will be required to submit evaluations on time. Failures to meet the deadlines might affect CNCF's future participation in GSoC.
 
 ## Contributor+proposal selection and ranking process
 


### PR DESCRIPTION
- Update GSoC org admin guide with a reminders for mentors
- Update project template to encourage having a co-mentor (required for GSoC)
- Remove some obsolete content in org admin guide

GSoC support said that we are allowed to say that we require at least 2 mentors in an email.