### PR TITLE
Planning for LFX 2024 Term 02 Jun-Aug

### DIFF
--- a/programs/lfx-mentorship/2024/01-Mar-May/README.md
+++ b/programs/lfx-mentorship/2024/01-Mar-May/README.md
@@ -1,6 +1,6 @@
 # Term 01 - 2024 March - May
 
-Status: In Progress
+Status: Planning
 
 Mentorship duration - three months (12 weeks - full-time schedule)
 

--- a/programs/lfx-mentorship/2024/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2024/02-Jun-Aug/README.md
@@ -1,0 +1,28 @@
+# Term 02 - 2024 June - August 
+
+Status: Planning
+
+Mentorship duration - three months (12 weeks - full-time schedule)
+
+### Timeline
+
+| activity | date |
+| --- | --- |   
+| project proposals | Monday April 8 - Wed April 24, 2024, 5:00 PM PDT |
+| mentee applications open | Monday April 29 - Tues May 14, 5:00 PM PDT |
+| application review/admission decisions | Wed May 15 - Tues June 29, 5:00 PM PDT |
+| selection notifications | Tues May 29, 5:00 PM PDT |
+| Mentorship program begins with the initial work assignments | Monday June 3 (Week 1) | 
+| Midterm mentee evaluations and first stipend payments | Wednesday July 10 10 (Week 6) |
+| Final mentee evaluations and mentee feedback/blog submission due, second and final stipend payment approvals | Wed Aug 21, 5:00 PM PST (Week 12) |
+| Last day of term | Friday Aug 30 |
+
+### Project Instructions
+
+Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/2024/02-Jun-Aug/project_ideas.md, by April 24, 2024.
+
+### Application instructions
+
+Mentee application instructions can be found on the [Program Guidelines](https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md#program-guidelines) page.
+
+---

--- a/programs/lfx-mentorship/2024/02-Jun-Aug/project_ideas.md
+++ b/programs/lfx-mentorship/2024/02-Jun-Aug/project_ideas.md
@@ -1,0 +1,21 @@
+## Template
+
+```
+### CNCF Project Name
+
+#### Mentorship project Title
+
+- Description:
+- Expected Outcome:
+- Recommended Skills:
+- Mentor(s):
+  - Mentor Name (@mentor_github, mentor@email.addy) - please use the same email address as you use on the LFX Mentorship Platform at https://mentorship.lfx.linuxfoundation.org
+- Upstream Issue:
+
+```
+
+---
+
+## Proposed Project ideas
+
+---


### PR DESCRIPTION
Planning LFX 2024 Term 2, Jun-Aug

previous timeline for term 2: https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2023/02-Jun-Aug

| activity | date |
| --- | --- |   
| project proposals | Monday April 8 - Wed April 24, 2024, 5:00 PM PDT |
| mentee applications open | Monday April 29 - Tues May 14, 5:00 PM PDT |
| application review/admission decisions | Wed May 15 - Tues June 29, 5:00 PM PDT |
| selection notifications | Tues May 29, 5:00 PM PDT |
| Mentorship program begins with the initial work assignments | Monday June 3 (Week 1) | 
| Midterm mentee evaluations and first stipend payments | Wednesday July 10 10 (Week 6) |
| Final mentee evaluations and mentee feedback/blog submission due, second and final stipend payment approvals | Wed Aug 21, 5:00 PM PST (Week 12) |
| Last day of term | Friday Aug 30 |

