### PR TITLE
Kick off GSoC 2024

### DIFF
--- a/programs/summerofcode/2024.md
+++ b/programs/summerofcode/2024.md
@@ -1,0 +1,33 @@
+## Project Ideas
+
+If you are a project maintainer and consider mentoring during the GSoC 2024 cycle, please, submit your ideas below using the template.
+
+[Google summer of code timeline](https://developers.google.com/open-source/gsoc/timeline).
+
+You can find the project ideas from previous year [here](./2023.md).
+
+> **NOTE:** Please note that GSoC is a program known for its strict deadlines. In addition to responding to your mentee on time, you will be required to submit evaluations on time. Failures to meet the deadlines might affect CNCF's future participation in GSoC.
+
+---
+
+### Template
+
+```
+#### CNCF Project Name
+
+##### Project Title
+
+- Description:
+- Expected Outcome:
+- Recommended Skills:
+- Expected project size: # one of small (~90 hour projects), medium (~175 hour projects) and large (~350 hour projects)
+- Mentor(s): #For GSoC, it is **required** to have at least 2 mentors with 1 being a primary mentor.
+  - Jane Doe (@jane-github, jane@email.address) - primary
+  - John Doe (@john-github, john@email.address)
+- Upstream Issue (URL):
+```
+
+---
+
+## Ideas
+

--- a/programs/summerofcode/README.md
+++ b/programs/summerofcode/README.md
@@ -17,6 +17,6 @@ It's best if you use a public communication channel whenever possible; however, 
 
 ## Current Year
 
-Details about the 2023 program are available [here](https://github.com/cncf/mentoring/blob/main/programs/summerofcode/2023.md).
+Details about the 2024 program are available [here](https://github.com/cncf/mentoring/blob/main/programs/summerofcode/2024.md).
 
 [Google summer of code timeline](https://developers.google.com/open-source/gsoc/timeline).


### PR DESCRIPTION
Once merged, post this message as an announcement:

```
Hello!

CNCF has been participating in the Google Summer of Code during the and now we are ready to start the 2024 program cycle.
 
All CNCF projects are eligible to apply to participate in the Google Summer of Code. Please start working on the project ideas, and submit them via pull request: https://github.com/cncf/mentoring/blob/main/summerofcode/2024.md#project-ideas. 

The deadline to submit project ideas is March 11, 2024 (though we'd be happy for project ideas to come in sooner than that if possible to increase our chance of getting accepted as an org).

[Google Summer of Code 2024 Timeline](https://developers.google.com/open-source/gsoc/timeline)

Thanks!
```