### PR TITLE
LFX: Add Knative eventing project for March - May term

### DIFF
--- a/programs/lfx-mentorship/2024/01-Mar-May/project_ideas.md
+++ b/programs/lfx-mentorship/2024/01-Mar-May/project_ideas.md
@@ -19,21 +19,18 @@
 ## Proposed Project ideas
 
 ---
-```
+
 ### Knative Eventing
 
 #### Cross Namespace Event Links
 
 - Description: One of the most requested features in Knative Eventing over the past few years has been for triggers in different namespaces than brokers, and for subscriptions
-  in different namespaces than channels. We recently completed a Proof of Concept for how to handle this properly with RBAC, and want your help building the rest of the feature,
-  across both the control plane and data plane of Knative Eventing.
-- Expected Outcome: By the end of the project, we expect to release Knative Eventing with experimental Alpha support for cross namespace event links, with support for triggers
-  and subscriptions.
-- Recommended Skills: Golang, Bash, Knowledge of Kubernetes
+  in different namespaces than channels. More information can be found in the upstream issue.
+- Expected Outcome: Knative Eventing Triggers and Subscriptions can reference Brokers or Channels in a namespace different from their own if the user possesses the necessary
+  permissions to do so.
+- Recommended Skills: Go, Kubernetes
 - Mentor(s):
-  - Mentor Name (@mentor_github, mentor@email.addy) - please use the same email address as you use on the LFX Mentorship Platform at https://mentorship.lfx.linuxfoundation.org
   - Calum Murray (@Cali0707, cmurray@redhat.com)
   - Pierangelo Di Pilato (@pierdipi, pierdipi@redhat.com)
 - Upstream Issue: https://github.com/knative/eventing/issues/7530
 
-```

--- a/programs/lfx-mentorship/2024/01-Mar-May/project_ideas.md
+++ b/programs/lfx-mentorship/2024/01-Mar-May/project_ideas.md
@@ -19,3 +19,21 @@
 ## Proposed Project ideas
 
 ---
+```
+### Knative Eventing
+
+#### Cross Namespace Event Links
+
+- Description: One of the most requested features in Knative Eventing over the past few years has been for triggers in different namespaces than brokers, and for subscriptions
+  in different namespaces than channels. We recently completed a Proof of Concept for how to handle this properly with RBAC, and want your help building the rest of the feature,
+  across both the control plane and data plane of Knative Eventing.
+- Expected Outcome: By the end of the project, we expect to release Knative Eventing with experimental Alpha support for cross namespace event links, with support for triggers
+  and subscriptions.
+- Recommended Skills: Golang, Bash, Knowledge of Kubernetes
+- Mentor(s):
+  - Mentor Name (@mentor_github, mentor@email.addy) - please use the same email address as you use on the LFX Mentorship Platform at https://mentorship.lfx.linuxfoundation.org
+  - Calum Murray (@Cali0707, cmurray@redhat.com)
+  - Pierangelo Di Pilato (@pierdipi, pierdipi@redhat.com)
+- Upstream Issue: https://github.com/knative/eventing/issues/7530
+
+```


### PR DESCRIPTION
Adding Knative Eventing's Cross-Namespace Event Links project to the LFX mentorship program for March - May 2024

cc @aliok @pierdipi