### PR TITLE
Adding GSoC 2024 to auto labeller for "2024" label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,6 +31,7 @@
 
 # Add '2024' to any change to 2024 project files
 2024:
+  - programs/summerofcode/2024.md
   - programs/lfx-mentorship/2024/*
   - programs/lfx-mentorship/2024/**/*
 


### PR DESCRIPTION
Fixes: https://github.com/cncf/mentoring/issues/1161
Adding GSoC 2024 to automatic labeller for "2024" label.