### PR TITLE
[GSoC] Update Kubebuilder project mentor list

### DIFF
--- a/programs/summerofcode/2024.md
+++ b/programs/summerofcode/2024.md
@@ -121,7 +121,6 @@ You can find the project ideas from previous year [here](./2023.md).
 - Expected Project Size: Large (350 hour project)
 - Mentor(s):
   - Camila Macedo (@camilamacedo86, camilamacedo86@email.com) - Primary
-  - Varsha (@varshaprasad96, vnarsing@redhat.com)
   - Tony Jin (@Kavinjsir, kavinjsir@gmail.com)
   - Junhao Liu (@yyy1000, junhaoliu2023@gmail.com)
 - Upstream Issue (URL): WIP: PR for the design proposal: https://github.com/kubernetes-sigs/kubebuilder/pull/3632


### PR DESCRIPTION
I would not be able to mentor the 2024 GSoC project due to time constraints. Hence updating the mentor list. Apologies for the inconvenience.