### PR TITLE
adding CNCF GOSST GSoC Collaboration project idea

### DIFF
--- a/programs/summerofcode/2024.md
+++ b/programs/summerofcode/2024.md
@@ -42,7 +42,7 @@ You can find the project ideas from previous year [here](./2023.md).
   * Improved build/release security by automating builds, releases, added build provenance, signing and improved reproducibility
   * Enhanced [OpenSSF Scorecard](https://securityscorecards.dev/) and [CLOMonitor](https://clomonitor.io/search?foundation=cncf&page=1) scores for CNCF projects.
 - Recommended Skills: Security analysis, CI/CD practices, programming (preferably Go), knowledge of CNCF projects.
-- Expected project size: small (~90 hour projects)
+- Expected project size: large (~350 hour projects)
 - Mentor(s):
   - Nate Waddington (@nate-double-u, natew@cncf.io)
   - Dustin Ingram (dustiningram@google.com)

--- a/programs/summerofcode/2024.md
+++ b/programs/summerofcode/2024.md
@@ -31,6 +31,23 @@ You can find the project ideas from previous year [here](./2023.md).
 
 ### Proposals
 
+#### CNCF GOSST
+
+##### CNCF and Google Open Source Security Team GSoC Collaboration - Enhancing Security Across CNCF Ecosystem
+
+- Description: This project is a collaborative effort between the CNCF and Google's Open Source Security Team to improve security practices across various CNCF projects. The focus is on identifying and addressing security vulnerabilities, integrating security tools like OSS-Fuzz, and enhancing build and release security processes.
+- Expected Outcome:
+  * Integration or enhancement of fuzzing with [OSS-Fuzz](https://google.github.io/oss-fuzz/) for CNCF projects
+  * Remediation of known vulnerabilities within the CNCF ecosystem
+  * Improved build/release security by automating builds, releases, added build provenance, signing and improved reproducibility
+  * Enhanced [OpenSSF Scorecard](https://securityscorecards.dev/) and [CLOMonitor](https://clomonitor.io/search?foundation=cncf&page=1) scores for CNCF projects.
+- Recommended Skills: Security analysis, CI/CD practices, programming (preferably Go), knowledge of CNCF projects.
+- Expected project size: medium (~175 hour projects) or large (~350 hour projects)
+- Mentor(s):
+  - Nate Waddington (@nate-double-u, natew@cncf.io)
+  - Dustin Ingram (dustiningram@google.com)
+- Upstream Issue (URL): https://github.com/cncf/mentoring/issues/1196
+
 #### Falco
 
 ##### Upgrading event-generator and automating Falco performance testing

--- a/programs/summerofcode/2024.md
+++ b/programs/summerofcode/2024.md
@@ -37,10 +37,11 @@ You can find the project ideas from previous year [here](./2023.md).
 
 - Description: This project is a collaborative effort between the CNCF and Google's Open Source Security Team to improve security practices across various CNCF projects. The focus is identifying and addressing security vulnerabilities, integrating security tools like OSS-Fuzz, and enhancing build and release security processes. The goal is to get all CNCF projects to use scorecards (focusing on graduated/incubating projects first) and to remediate some of the findings.
 - Expected Outcome:
+  * All graduated and incubating CNCF projects using OpenSSF Scorecards to assess and enhance their security postures. Stretch goal: all (including sandbox) CNCF projects using OpenSFF Scorecards.
+    * Remediation of identified vulnerabilities based on scorecard findings
+    * Where CNCF projects are already using [OpenSSF Scorecard](https://securityscorecards.dev/), improved scores (remediating [various risk assessments](https://securityscorecards.dev/#the-checks)
   * Integration or enhancement of fuzzing with [OSS-Fuzz](https://google.github.io/oss-fuzz/) for CNCF projects
-  * Remediation of known vulnerabilities within the CNCF ecosystem
-  * Improved build/release security by automating builds, releases, added build provenance, signing and improved reproducibility
-  * Enhanced [OpenSSF Scorecard](https://securityscorecards.dev/) and [CLOMonitor](https://clomonitor.io/search?foundation=cncf&page=1) scores for CNCF projects.
+  * Improved build/release security by automating builds and releases, added build provenance, signing, and improved reproducibility
 - Recommended Skills: Security analysis, CI/CD practices, programming (preferably Go), knowledge of CNCF projects.
 - Expected project size: large (~350 hour projects)
 - Mentor(s):

--- a/programs/summerofcode/2024.md
+++ b/programs/summerofcode/2024.md
@@ -35,7 +35,7 @@ You can find the project ideas from previous year [here](./2023.md).
 
 ##### CNCF and Google Open Source Security Team GSoC Collaboration - Enhancing Security Across CNCF Ecosystem
 
-- Description: This project is a collaborative effort between the CNCF and Google's Open Source Security Team to improve security practices across various CNCF projects. The focus is on identifying and addressing security vulnerabilities, integrating security tools like OSS-Fuzz, and enhancing build and release security processes.
+- Description: This project is a collaborative effort between the CNCF and Google's Open Source Security Team to improve security practices across various CNCF projects. The focus is identifying and addressing security vulnerabilities, integrating security tools like OSS-Fuzz, and enhancing build and release security processes. The goal is to get all CNCF projects to use scorecards (focusing on graduated/incubating projects first) and to remediate some of the findings.
 - Expected Outcome:
   * Integration or enhancement of fuzzing with [OSS-Fuzz](https://google.github.io/oss-fuzz/) for CNCF projects
   * Remediation of known vulnerabilities within the CNCF ecosystem

--- a/programs/summerofcode/2024.md
+++ b/programs/summerofcode/2024.md
@@ -42,7 +42,7 @@ You can find the project ideas from previous year [here](./2023.md).
   * Improved build/release security by automating builds, releases, added build provenance, signing and improved reproducibility
   * Enhanced [OpenSSF Scorecard](https://securityscorecards.dev/) and [CLOMonitor](https://clomonitor.io/search?foundation=cncf&page=1) scores for CNCF projects.
 - Recommended Skills: Security analysis, CI/CD practices, programming (preferably Go), knowledge of CNCF projects.
-- Expected project size: medium (~175 hour projects) or large (~350 hour projects)
+- Expected project size: small (~90 hour projects)
 - Mentor(s):
   - Nate Waddington (@nate-double-u, natew@cncf.io)
   - Dustin Ingram (dustiningram@google.com)


### PR DESCRIPTION
Adding CNCF and Google Open Source Security Team GSoC Collaboration - Enhancing Security Across CNCF Ecosystem Google Summer of Code 2024 project.