### PR TITLE
Removing KubeVela project from GSoC 2024

### DIFF
--- a/programs/summerofcode/2024.md
+++ b/programs/summerofcode/2024.md
@@ -148,19 +148,6 @@ The task would include Automate the execution of benchmarks under various scenar
   - (Mattia Lavacca, @mlavacca)
 - Upstream Issue: https://github.com/kubernetes-sigs/ingress2gateway/issues/131
 
-#### KubeVela
-
-##### Support versioning for definitions
-
-- Description: In KubeVela, X-Definitions provide the foundation for users to construct their applications. Currently we will automatically upgrade the definitions' version for our users, however, we still need the capability of explicit versioning in definitions. With this feature, our users can now manage the version easily for application upgrades and migrations.
-- Expected Outcome: Support expilict versioning in definitions to help application upgrades and migrations.
-- Recommended Skills: Go, Kubernetes
-- Expected project size: Medium (175 hour project)
-- Mentor(s):
-  - Fog Dong (@FogDong, wuwuglu19@gmail.com)
-  - Zhongpei Qiao (@chivalryq, chivalry.pp@gmail.com)
-- Upstream Issue: https://github.com/kubevela/kubevela/issues/6435
-
 #### LitmusChaos
 
 ##### Integration of Fuzzing Test Suites for LitmusChaos(ChaosCenter) with OSS-FUZZ


### PR DESCRIPTION
Removing KubeVela project from GSoC 2024.

@FogDong, @chivalryq, as per my email, unfortunately, we need to remove this year's KubeVela project idea.