### PR TITLE
Fix email on mentoring projects

### DIFF
--- a/programs/lfx-mentorship/2024/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2024/02-Jun-Aug/README.md
@@ -637,7 +637,7 @@ Understand that your challenges will be promoted through CNCF channels, reviewed
 - Recommended Skills: Go, some familiarity with Prometheus or metrics, basic Docker knowledge
 - Mentor(s):
     - Callum Styan (@cstyan, callumstyan@gmail.com),
-    - Jesús Vázquez (@jesusvazquez, jesus.vazquez@grafana.com)
+    - Jesús Vázquez (@jesusvazquez, jesusvzpg@grafana.com)
     - Nico Pazos and Alex Greenbank from Grafana also available to help
 - Upstream Issue: https://github.com/prometheus/prometheus/issues/13995
 - LFX URL: https://mentorship.lfx.linuxfoundation.org/project/0462446f-aeea-4a19-9bd6-f4241ee5e8f2
@@ -648,7 +648,7 @@ Understand that your challenges will be promoted through CNCF channels, reviewed
 - Recommended Skills: Go, familiarity with Prometheus TSDB.
 - Mentor(s):
     - Bryan Boreham (@bboreham, bjboreham@gmail.com)
-    - Jesus Vazquez (@jesusvazquez, jesus.vazquez@grafana.com)
+    - Jesus Vazquez (@jesusvazquez, jesusvzpg@grafana.com)
 - Upstream Issue: https://github.com/prometheus/prometheus/issues/12631
 - LFX URL: https://mentorship.lfx.linuxfoundation.org/project/454caa5a-6fd5-4e27-bde4-7649abf6d8ca
 

--- a/programs/lfx-mentorship/2024/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2024/02-Jun-Aug/README.md
@@ -637,7 +637,7 @@ Understand that your challenges will be promoted through CNCF channels, reviewed
 - Recommended Skills: Go, some familiarity with Prometheus or metrics, basic Docker knowledge
 - Mentor(s):
     - Callum Styan (@cstyan, callumstyan@gmail.com),
-    - Jesús Vázquez (@jesusvazquez, jesusvzpg@grafana.com)
+    - Jesús Vázquez (@jesusvazquez, jesusvzpg@gmail.com)
     - Nico Pazos and Alex Greenbank from Grafana also available to help
 - Upstream Issue: https://github.com/prometheus/prometheus/issues/13995
 - LFX URL: https://mentorship.lfx.linuxfoundation.org/project/0462446f-aeea-4a19-9bd6-f4241ee5e8f2
@@ -648,7 +648,7 @@ Understand that your challenges will be promoted through CNCF channels, reviewed
 - Recommended Skills: Go, familiarity with Prometheus TSDB.
 - Mentor(s):
     - Bryan Boreham (@bboreham, bjboreham@gmail.com)
-    - Jesus Vazquez (@jesusvazquez, jesusvzpg@grafana.com)
+    - Jesus Vazquez (@jesusvazquez, jesusvzpg@gmail.com)
 - Upstream Issue: https://github.com/prometheus/prometheus/issues/12631
 - LFX URL: https://mentorship.lfx.linuxfoundation.org/project/454caa5a-6fd5-4e27-bde4-7649abf6d8ca
 


### PR DESCRIPTION
Hello 👋 , 

Made a mistake setting up my email when my LFX account to be used was under my personal email. I was trying to look at the list of applicants on the projects and realized I couldn't see either applicants or projects.

My bad for not suggesting the right email 🙏  Please let me know if there is anything else to do to fix this. 