### PR TITLE
Wrong repository link for "CNCF - Konveyor AI: Data Querying for Kai & InstructLab Integration Potential"

### DIFF
--- a/programs/lfx-mentorship/2024/03-Sep-Nov/README.md
+++ b/programs/lfx-mentorship/2024/03-Sep-Nov/README.md
@@ -475,7 +475,7 @@ CNCF - Konveyor AI: Data Querying for Kai & InstructLab Integration Potential (2
   - Jonah Sussman (@JonahSussman, jsussman@redhat.com)
   - Fabian von Feilitzsch (@fabianvf, fvonfeil@redhat.com)
 
-- Upstream Issue: https://github.com/konveyor/enhancements/issues/187
+- Upstream Issue: https://github.com/konveyor/enhancements/issues/191
 - LFX URL: https://mentorship.lfx.linuxfoundation.org/project/8493016e-975f-4559-8833-db4c884b2fc5
 
 ### KubeArmor


### PR DESCRIPTION
Related to https://github.com/cncf/mentoring/issues/1297. Unsure if fixing the README also fixes the website, but this can't hurt. 

This slipped by, but I put https://github.com/konveyor/enhancements/issues/187 instead of the correct issue link https://github.com/konveyor/enhancements/issues/191 as the upstream issue for [CNCF - Konveyor AI: Data Querying for Kai & InstructLab Integration Potential](https://mentorship.lfx.linuxfoundation.org/project/8493016e-975f-4559-8833-db4c884b2fc5/mentees-past).