### PR TITLE
updating lfx 2023 term 2 description

### DIFF
--- a/programs/lfx-mentorship/2024/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2024/02-Jun-Aug/README.md
@@ -2,7 +2,7 @@
 
 Status: Planning
 
-Mentorship duration - three months (12 weeks - full-time schedule)
+Mentorship duration - three months (11 weeks - full-time schedule)
 
 ### Timeline
 


### PR DESCRIPTION
Fixes #1302

The description of term 2 was not updated from 12 weeks to 11 weeks when the dates were added.

The dates are correct, the description was too long.