### PR TITLE
updating 2024 TAG Mentoring WG meeting minutes

### DIFF
--- a/mentoring-wg/2024-meeting-minutes.md
+++ b/mentoring-wg/2024-meeting-minutes.md
@@ -3,95 +3,285 @@ title: TAGCS Mentoring Working Group Monthly Meeting (2024)
 tags: Meeting Minutes, 2024
 ---
 
-## Mentoring Working Group
+# Mentoring Working Group
 
-This file’s location: [1. Technical Advisory Groups / TAG Contributor Strategy / Mentoring](https://drive.google.com/drive/folders/1IlgEbbspQTpSthEuXgZqZsUCEJxH5NBZ?usp=drive_link)
-
+This file’s location: [1\. Technical Advisory Groups / TAG Contributor Strategy / Mentoring](https://drive.google.com/drive/folders/1IlgEbbspQTpSthEuXgZqZsUCEJxH5NBZ?usp=drive\_link)  
 GitHub location: [https://github.com/cncf/mentoring/blob/main/mentoring-wg/2024-meeting-minutes.md](https://github.com/cncf/mentoring/blob/main/mentoring-wg/2024-meeting-minutes.md) 
 
-## About TAGCS Mentorship Working Group
+# About TAGCS Mentorship Working Group
 
-* [Primary repository](https://github.com/cncf/mentoring)
-* CNCF Slack: [#tag-contributor-strategy](https://cloud-native.slack.com/archives/CT6CWS1JN)
-* [Discussion boards](https://github.com/cncf/mentoring/discussions)
+* [Primary repository](https://github.com/cncf/mentoring)  
+* CNCF Slack: [\#tag-contributor-strategy](https://cloud-native.slack.com/archives/CT6CWS1JN)  
+* [Discussion boards](https://github.com/cncf/mentoring/discussions)  
 * [Email list](https://lists.cncf.io/g/tag-cs-mentoring-wg/)
 
-### Meeting details
+## Meeting details
 
-#### Recurring monthly
+### Recurring monthly
 
-2nd Tuesday of the month at 9PM UTC
+3rd Thursday of the month at 10AM Pacific Time  
+[CNCF Public Events \- TAG CS Mentoring WG](https://tockify.com/cncf.public.events/monthly?search=CNCF%20TAG%20Contributor%20Strategy%20Mentoring%20WG)
 
-[CNCF Public Events - TAG CS Mentoring WG](https://tockify.com/cncf.public.events/monthly?search=CNCF%20TAG%20Contributor%20Strategy%20Mentoring%20WG)
+### Zoom
 
-#### Zoom
-
-Zoom Meeting: [https://zoom.us/my/cncftagcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09](https://zoom.us/my/cncftagcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09)
-
-Passcode: 77777
+Zoom Meeting: [https://zoom.us/my/cncftagcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09](https://zoom.us/my/cncftagcontributorstrategy?pwd=TnI0WU9Eb2I1RlRWdkl1R0k1WkZXUT09)  
+Passcode: 77777  
 
 ---
 
-## Upcoming Meetings
+# Upcoming Meetings
 
-### February 13, 2024
+## September 19, 2024
 
-21:00 UTC (1:00 PM PDT on 2024-02-13; 10:00 AM NZST on 2024-02-14)
+10:00 Pacific Time (17:00 UTC on 2024-08-15)
 
-#### Attendance
+### Attendance
 
-* Nate W.
-* Josh Berkus
-* Riaan Kleinhans
-* Jay Tihema
+* 
 
-#### Updates/reminders
+### Updates/reminders
 
-*  
+* 
 
-#### Agenda
+### Agenda
 
-* LFX
-    * Mentee candidate applications due today!
-* GSoC
-    * Org application in, we have several proposals. More welcome.
-    * Josh to include GSoC info in newsletter
-* Outreachy
-    * OTel?
-    * Josh to help recruit admin
+* 
 
-#### Notes
+### Notes
 
-* Google doc vs Hackmd?
-    * We might have to switch
-    * Discussed issues for sharing, Chinese contributors
-    * Need to put stuff into TAG shared drive	Document created to move to for 2024 in [CNCF/TAG_CS/Mentoring](https://docs.google.com/document/d/1sSYRo-5yxJggGg3JVATxMKdxVWbY_ZGD2mhKlPNW7qM/edit)
+* 
 
----
+# Past Meetings
 
-## Past Meetings
+## August 15, 2024
 
----
+10:00 Pacific Time (17:00 UTC on 2024-08-15)
 
-## Meeting Template
+### Attendance
 
-### March 14, 2024
+* Nate W.   
+* Josh B.  
+* Vesyl
+
+### Agenda
+
+* LFX Mentorship  
+  * Term 2  
+    * Ending Aug 28, mentors and mentees should be thinking about how to finish up  
+  * Term 3	  
+    * Applications closed, mentors making candidate selections  
+  * 2025 Term 1  
+    * We’re holding the [2024 term 1 umbrella issue](https://github.com/cncf/mentoring/issues/1077) open still because we’ve not planned 2025 Term 1 yet. We should plan Term 1\.  
+  * \[NW\] Proof of work  
+    * Now that we’re able to monitor mentees productivity more closely, [https://mentorship-monitor-ui.netlify.app/](https://mentorship-monitor-ui.netlify.app/), I’d like to discuss the possibility of requiring proof of work in order for mentees to pass the evaluations.  
+    * Historically, the administrators have always deferred to the mentors  
+      * If the mentors say that the work submitted isn’t sufficient to pass the evaluation, the administrators could not overrule that, and I’d like to keep that part the same.  
+      * Moving forward, *I’d like the mentors and administrators to agree that the work is sufficient*. In most cases this is obvious, and if the mentors say the work is good it is; however, in some cases we see that some mentors have said the work is good but the public record appears to show a lack of progress. This can be due to several factors  
+        * Not all projects lend themselves to GitHub (for instance UI projects will often use Figma to do the work).  
+        * Some projects require a lot of research before changes can be made in GitHub
+
+        If a mentor is able to explain this then I’m happy for the mentee to be passed, receive their stipend, and continue.
+
+        
+
+        What then would the criteria for disagreeing with the mentors be, and how could we override the mentors while preserving the trust of the maintainers?
+
+  * Revisit blog post requirements  
+    * \[NW\] We’ve discussed this before, but CNCF leadership has asked if we are requiring blog posts. I told them the reasons we don’t, but I’d like to revisit what recommendations we make around end of term blog posts and how we make them.  
+    * \[JB\] Need to provide a template \- currently folks write about the program, and a little about what they did. We’re interested in what they did primarily.  
+      * Video option?
+
+### Notes
+
+* NW to invite LFX team to meet with mentoring wg  
+* Clotributor chat: [https://clotributor.dev/](https://clotributor.dev/)
+
+## July 9, 2024
+
+21:00 UTC (2:00 PM PDT on 2024-07-09; 10:00 AM NZST on 2024-07-10)
+
+### Attendance
+
+* Nate W.  
+* Faseela K  
+* Josh B
+
+### Agenda
+
+* LFX Term 3  
+  * [https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2024/03-Sep-Nov](https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2024/03-Sep-Nov)   
+* Issues with LFX platform ([https://github.com/cncf/mentoring/issues/1262](https://github.com/cncf/mentoring/issues/1262))  
+  * LFX team says upload issues should be resolved no later than July 19, meaning we don’t have to postpone the term  
+  * Much better responsiveness, fixing things from LFX team  
+  * Issues: please report at [https://community.lfx.dev/](https://community.lfx.dev/)   
+* Changing Meeting times:  
+  * Move to 3rd Thursday of the month starting August  
+    * First meeting on new schedule: August 15, 10am PDT / 7pm CET / 10:30pm IST  
+* RCOS  
+  * Nate had a meeting with [https://new.rcos.io/](https://new.rcos.io/) folks  
+  * RedHat quite involved – Nate & Josh to chat offline  
+* GSoC 2024  
+  * Midterm evals this week
+
+## June 11, 2024
+
+21:00 UTC (2:00 PM PDT on 2024-01-11; 10:00 AM NZST on 2024-01-12)
+
+### Attendance
+
+* Nate W.  
+* Ali Ok  
+* Josh Berkus  
+* Kushal Agrawal  
+* Sunil Ravipati
+
+### Agenda
+
+* \[aliok\] Changing time for the Mentoring WG meeting  
+  * Nate is going to create a Doodle  
+    * One slot should be the empty TAG thursday slot (TAG meets 3 times a month, we can grab the 4th)  
+* \[aliok\] Discussion around mandatory blogposts / webinars / recordings for mentees  
+  * [https://github.com/cncf/mentoring/issues/1216](https://github.com/cncf/mentoring/issues/1216)   
+  * We already encourage mentees to write blog posts  
+  * We don’t want to mandate it to block the stipend payments  
+  * We already have a few mentees every term writing blog posts  
+  * Mentors/mentees might not have the skills  
+    * We would need to provide assistance, which might be hard due to resource constraints  
+    * We might provide a blogpost template, which might help with mentees to write the blog posts. This might help with having more blog posts.  
+  * Ali [commented](https://github.com/cncf/mentoring/issues/1216\#issuecomment-2161620387) on the issue, and asked the issue author if they’re interested in providing such a template.  
+    * Also created [a ticket](https://github.com/cncf/mentoring/issues/1256)  
+* \[Sunil\] Anything to participate in or help with this WG?  
+  * Josh’s suggestion: a semi-structured mentoring program for security tasks on CNCF projects, as Sunil is part of TAG Security  
+* \[Nate W.\] Need to schedule info sessions for LFX term 2 (Mentors, mentees, whole group)  
+  * Invite alumni to attend mentee info session  
+* \[aliok\] How to recruit more people to this WG?  
+  * Target alumni  
+    * Mentees might be better candidates than mentors, as mentors are busy  
+  * Ambassadors can also help  
+  * Find curated tasks (e.g. find out about / run Outreachy)  
+  * Ask help, similar to: [https://github.com/kubernetes-sigs/lwkd/issues/205](https://github.com/kubernetes-sigs/lwkd/issues/205)  
+  * When we get more people, we can:  
+    * Formalize/structure various Kubernetes mentoring programs  
+    * Participate in other mentorship programs (Outreachy, etc)  
+* \[Josh\] Collecting mentorship proposals continuously  
+  * Perhaps with issues with specific labels  
+  * Fork Clotributor? Or, talk to Chris  
+  * Ali to create a ticket  
+* \[aliok\] Ali is on PTO next 3 weeks  
+* \[Nate W.\] One Kubernetes project dropped out of LFX, cited lack of time to make selections  
+* \[Nate W.\] GSoC Mentor Summit
+
+## May 14, 2024
 
 21:00 UTC (2:00 PM PDT on 2024-01-10; 10:00 AM NZST on 2024-01-11)
 
-#### Attendance
+### Attendance
+
+* Nate W.
+
+### Updates/reminders
+
+* Meeting canceled due to lack of attendance.
+
+### Agenda
+
+* \[aliok\] Discussion around mandatory blogposts / webinars / recordings for mentees  
+  * [https://github.com/cncf/mentoring/issues/1216](https://github.com/cncf/mentoring/issues/1216)   
+* \[Nate W.\] Need to schedule info sessions for LFX term 2 (Mentors, mentees, whole group)
+
+## April 09, 2024
+
+21:00 UTC (2:00 PM PDT on 2024-01-10; 10:00 AM NZST on 2024-01-11)
+
+### Attendance
+
+* Nate W.  
+* Victor L.
+
+### Updates/reminders
+
+* LFX  
+  * Term 1 \- midterms  
+  * Term 2 \- open for proposals ([https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2024/02-Jun-Aug](https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2024/02-Jun-Aug))  
+    * Maintainers email went out, will also forward to TOC email list as well as work with socials team to boost  
+  * Term 3 \- planning ([https://github.com/cncf/mentoring/issues/1107](https://github.com/cncf/mentoring/issues/1107) review requested)  
+* GSoC  
+  * Mentors making “I want to mentor this” selections (due April 16\)  
+    * Reminder email to go out tomorrow
+
+## March 12
+
+### Attendance
+
+* Nate W  
+* Ali Ok  
+* Riaan K
+
+### Agenda
+
+* \[aliok\] GSoC \- applications start next week  
+  * Need to add mentors  
+  * Next steps:  
+    * Mentors to make their selections by 16th April latest  
+    * Mail to send to mentors about this after 2nd April (applications closed)  
+* \[aliok\] GSoDocs [https://developers.google.com/season-of-docs/docs/timeline](https://developers.google.com/season-of-docs/docs/timeline)  
+  * Some projects interested: Buildpacks  
+* \[aliok\] KubeCon mini-summit  
+* \[aliok\] KubeCon TAG CS canvassing  
+  *  [KubeCon EU 2024 - Project booth visit pairing](https://docs.google.com/spreadsheets/d/1NyUSu1F5OKL4VYpWrf6735wb34x4BwTkcQZt1KYipbw/edit\#gid=0)  
+  * [KubeCon EU 2024 - Project Pavillion Canvass Details](https://docs.google.com/document/d/1PLkN6ZM5kndrfiNP6HchbzQsI2XF-qLZ\_Q0BkRgG\_fs/edit\#heading=h.uc3pmzl4kaa)  
+* Details about keeping an eye on mentees?
+
+## February 13, 2024
+
+21:00 UTC (1:00 PM PDT on 2024-02-13; 10:00 AM NZST on 2024-02-14)
+
+### Attendance
+
+* Nate W.  
+* Josh Berkus  
+* Riaan Kleinhans  
+* Jay Tihema
+
+### Agenda
+
+* LFX  
+  * Mentee candidate applications due today\!  
+* GSoC  
+  * Org application in, we have several proposals. More welcome.  
+  * Josh to include GSoC info in newsletter  
+* Outreachy  
+  * OTel?  
+  * Josh to help recruit admin
+
+### Notes
+
+* Google doc vs Hackmd?  
+  * We might have to switch  
+  * Discussed issues for sharing, Chinese contributors  
+  * Need to put stuff into TAG shared drive	Document created to move to for 2024 in [CNCF/TAG\_CS/Mentoring](https://docs.google.com/document/d/1sSYRo-5yxJggGg3JVATxMKdxVWbY\_ZGD2mhKlPNW7qM/edit)
+
+---
+
+# Meeting Template
+
+## August 15, 2024
+
+10:00 Pacific Time (17:00 UTC on 2024-08-15)
+
+### Attendance
 
 * 
 
-#### Updates/reminders
+### Updates/reminders
 
 * 
 
-#### Agenda
+### Agenda
 
 * 
 
-#### Notes
+### Notes
 
 * 
 
@@ -99,7 +289,8 @@ Passcode: 77777
 
 Archives
 
-* [2023 Meeting Minutes](https://hackmd.io/zNzH0LTMQ16Lkjg16FZEcw?both)
-* [2022 Meeting Minutes](https://hackmd.io/zNzH0LTMQ16Lkjg16FZEcw?both)
-* [June 30, July 12, July 26, 2022](https://docs.google.com/document/d/1ZVFf_GRB5yrcTQieudtk3W-gWL6KuwHn1QG8XKdrARo/edit?usp=sharing)
+* [2023 Meeting Minutes](https://hackmd.io/zNzH0LTMQ16Lkjg16FZEcw?both)  
+* [2022 Meeting Minutes](https://hackmd.io/zNzH0LTMQ16Lkjg16FZEcw?both)  
+* [June 30, July 12, July 26, 2022](https://docs.google.com/document/d/1ZVFf\_GRB5yrcTQieudtk3W-gWL6KuwHn1QG8XKdrARo/edit?usp=sharing)
+
 


### PR DESCRIPTION
Been a while since we've updated these. Easier now since Google docs allows markdown exports.