### PR TITLE
adding plans for LFX 2025 T2 & T3

### DIFF
--- a/programs/lfx-mentorship/2025/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2025/02-Jun-Aug/README.md
@@ -6,16 +6,16 @@ Mentorship duration - three months (full-time schedule)
 
 ### Timeline
 
-| **Activity**                                                 | **Dates (2025)**                      | **Notes**                                                                                              |
-|--------------------------------------------------------------|---------------------------------------|--------------------------------------------------------------------------------------------------------|
-| **Project Proposals Open**                                   | Wed, April 9 – Tue, May 6             | ~4 weeks for mentors/orgs to propose and refine projects                                               |
-| **Mentee Applications Open**                                 | Mon, May 12 – Tue, May 27             | Starts the Monday after GSoC acceptance announcements (May 8)                                          |
-| **Application Review/Admission Decisions**                   | Wed, May 28 – Tue, June 3             | 1 week to review applications                                                                          |
-| **Selection Notifications**                                  | Wed, June 4                           |                                                                                                        |
-| **Mentorship Program Begins (Work Phase, Week 1)**           | Mon, June 9                           |                                                                                                        |
-| **Midterm Mentee Evaluations & First Stipend Payment**       | Wed, July 16 (Week 6)                 |                                                                                                        |
-| **Final Mentee Evaluations & Second Stipend Payment**        | Wed, August 27 (Week 12)              |                                                                                                        |
-| **Last Day of Term**                                        | Fri, August 29                        | End of Week 12 (just before the weekend and end of the month)                                          |
+| **Activity**                                                  | **Dates (2025)**                      |
+|---------------------------------------------------------------|---------------------------------------|
+| **Project Proposals Open**                                    | Wed, April 9 – Tue, May 6             |
+| **Mentee Applications Open**                                  | Mon, May 12 – Tue, May 27             |
+| **Application Review/Admission Decisions**                    | Wed, May 28 – Tue, June 3             |
+| **Selection Notifications**                                   | Wed, June 4                           |
+| **Mentorship Program Begins (Work Phase, Week 1)**            | Mon, June 9                           |
+| **Midterm Mentee Evaluations & First Stipend Payment**        | Wed, July 16 (Week 6)                 |
+| **Final Mentee Evaluations & Second Stipend Payment**         | Wed, August 27 (Week 12)              |
+| **Last Day of Term**                                          | Fri, August 29                        |
 
 ### Project instructions
 

--- a/programs/lfx-mentorship/2025/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2025/02-Jun-Aug/README.md
@@ -6,16 +6,16 @@ Mentorship duration - three months (full-time schedule)
 
 ### Timeline
 
-| **Activity**                                                  | **Dates (2025)**                      |
-|---------------------------------------------------------------|---------------------------------------|
-| **Project Proposals Open**                                    | Wed, April 9 – Tue, May 6             |
-| **Mentee Applications Open**                                  | Mon, May 12 – Tue, May 27             |
-| **Application Review/Admission Decisions**                    | Wed, May 28 – Tue, June 3             |
-| **Selection Notifications**                                   | Wed, June 4                           |
-| **Mentorship Program Begins (Work Phase, Week 1)**            | Mon, June 9                           |
-| **Midterm Mentee Evaluations & First Stipend Payment**        | Wed, July 16 (Week 6)                 |
-| **Final Mentee Evaluations & Second Stipend Payment**         | Wed, August 27 (Week 12)              |
-| **Last Day of Term**                                          | Fri, August 29                        |
+| **Activity**                                                  | **Dates (2025)**            |
+|---------------------------------------------------------------|-----------------------------|
+| **Project Proposals Open**                                    | Wed, April 16 – Tue, May 13 |
+| **Mentee Applications Open**                                  | Wed, May 14 – Tue, May 27   |
+| **Application Review/Admission Decisions**                    | Wed, May 28 – Tue, June 3   |
+| **Selection Notifications**                                   | Wed, June 4                 |
+| **Mentorship Program Begins (Work Phase, Week 1)**            | Mon, June 9                 |
+| **Midterm Mentee Evaluations & First Stipend Payment**        | Wed, July 16 (Week 6)       |
+| **Final Mentee Evaluations & Second Stipend Payment**         | Wed, August 27 (Week 12)    |
+| **Last Day of Term**                                          | Fri, August 29              |
 
 ### Project instructions
 

--- a/programs/lfx-mentorship/2025/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2025/02-Jun-Aug/README.md
@@ -1,0 +1,29 @@
+# Term 02 - 2025 March - May
+
+Status: Planning
+
+Mentorship duration - three months (full-time schedule)
+
+### Timeline
+
+| **Activity**                                                 | **Dates (2025)**                      | **Notes**                                                                                              |
+|--------------------------------------------------------------|---------------------------------------|--------------------------------------------------------------------------------------------------------|
+| **Project Proposals Open**                                   | Wed, April 9 – Tue, May 6             | ~4 weeks for mentors/orgs to propose and refine projects                                               |
+| **Mentee Applications Open**                                 | Mon, May 12 – Tue, May 27             | Starts the Monday after GSoC acceptance announcements (May 8)                                          |
+| **Application Review/Admission Decisions**                   | Wed, May 28 – Tue, June 3             | 1 week to review applications                                                                          |
+| **Selection Notifications**                                  | Wed, June 4                           |                                                                                                        |
+| **Mentorship Program Begins (Work Phase, Week 1)**           | Mon, June 9                           |                                                                                                        |
+| **Midterm Mentee Evaluations & First Stipend Payment**       | Wed, July 16 (Week 6)                 |                                                                                                        |
+| **Final Mentee Evaluations & Second Stipend Payment**        | Wed, August 27 (Week 12)              |                                                                                                        |
+| **Last Day of Term**                                        | Fri, August 29                        | End of Week 12 (just before the weekend and end of the month)                                          |
+
+### Project instructions
+
+Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/2025/02-Jun-Aug/project_ideas.md, by May 6, 2025.
+
+### Application instructions
+
+Mentee application instructions can be found on the [Program Guidelines](https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md#program-guidelines) page.
+
+---
+

--- a/programs/lfx-mentorship/2025/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2025/02-Jun-Aug/README.md
@@ -1,4 +1,4 @@
-# Term 02 - 2025 March - May
+# Term 02 - 2025 Jun - Aug
 
 Status: Planning
 

--- a/programs/lfx-mentorship/2025/02-Jun-Aug/project_ideas.md
+++ b/programs/lfx-mentorship/2025/02-Jun-Aug/project_ideas.md
@@ -1,0 +1,19 @@
+## Template
+
+```
+### CNCF Project Name
+
+#### Mentorship project Title
+
+- Description:
+- Expected Outcome:
+- Recommended Skills:
+- Mentor(s):
+  - Mentor Name (@mentor_github, mentor@email.addy) - please use the same email address as you use on the LFX Mentorship Platform at https://mentorship.lfx.linuxfoundation.org
+- Upstream Issue:
+
+```
+
+---
+
+## Proposed Project ideas

--- a/programs/lfx-mentorship/2025/03-Sep-Nov/README.md
+++ b/programs/lfx-mentorship/2025/03-Sep-Nov/README.md
@@ -1,0 +1,29 @@
+# Term 03 - 2025 Sept - Nov
+
+Status: Planning
+
+Mentorship duration - three months (full-time schedule)
+
+### Timeline
+
+| **Activity**                                                 | **Dates (2025)**                      | **Notes**                                                                                          |
+|--------------------------------------------------------------|---------------------------------------|----------------------------------------------------------------------------------------------------|
+| **Project Proposals Open**                                   | Wed, July 2 – Tue, July 29            | ~4 weeks for mentors to propose and finalize projects                                              |
+| **Mentee Applications Open**                                 | Wed, July 30 – Tue, August 12         | 2 weeks                                                                                           |
+| **Application Review/Admission Decisions**                   | Wed, August 13 – Tue, August 26       | 2 weeks                                                                                           |
+| **Selection Notifications**                                  | Wed, August 27                        |                                                                                                    |
+| **Mentorship Program Begins (Work Phase, Week 1)**           | Mon, September 8                      | Avoiding US Labor Day (Sep 1)                                                                      |
+| **Midterm Mentee Evaluations & First Stipend Payment**       | Wed, October 15 (Week 6)              | Occurs after China’s National Day (Oct 1–7)                                                        |
+| **Final Mentee Evaluations & Second Stipend Payment**        | Wed, November 26 (Week 12)            | Day before US Thanksgiving (Nov 27)                                                                |
+| **Last Day of Term**                                        | Fri, November 28                      | The Friday of Thanksgiving week in the US                                                          |
+
+### Project instructions
+
+Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/2025/03-Sep-Nov/project_ideas.md, by July 29, 2025.
+
+### Application instructions
+
+Mentee application instructions can be found on the [Program Guidelines](https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md#program-guidelines) page.
+
+---
+

--- a/programs/lfx-mentorship/2025/03-Sep-Nov/README.md
+++ b/programs/lfx-mentorship/2025/03-Sep-Nov/README.md
@@ -6,16 +6,16 @@ Mentorship duration - three months (full-time schedule)
 
 ### Timeline
 
-| **Activity**                                                 | **Dates (2025)**                      | **Notes**                                                                                          |
-|--------------------------------------------------------------|---------------------------------------|----------------------------------------------------------------------------------------------------|
-| **Project Proposals Open**                                   | Wed, July 2 – Tue, July 29            | ~4 weeks for mentors to propose and finalize projects                                              |
-| **Mentee Applications Open**                                 | Wed, July 30 – Tue, August 12         | 2 weeks                                                                                           |
-| **Application Review/Admission Decisions**                   | Wed, August 13 – Tue, August 26       | 2 weeks                                                                                           |
-| **Selection Notifications**                                  | Wed, August 27                        |                                                                                                    |
-| **Mentorship Program Begins (Work Phase, Week 1)**           | Mon, September 8                      | Avoiding US Labor Day (Sep 1)                                                                      |
-| **Midterm Mentee Evaluations & First Stipend Payment**       | Wed, October 15 (Week 6)              | Occurs after China’s National Day (Oct 1–7)                                                        |
-| **Final Mentee Evaluations & Second Stipend Payment**        | Wed, November 26 (Week 12)            | Day before US Thanksgiving (Nov 27)                                                                |
-| **Last Day of Term**                                        | Fri, November 28                      | The Friday of Thanksgiving week in the US                                                          |
+| **Activity**                                                  | **Dates (2025)**                      |
+|---------------------------------------------------------------|---------------------------------------|
+| **Project Proposals Open**                                    | Wed, July 2 – Tue, July 29            |
+| **Mentee Applications Open**                                  | Wed, July 30 – Tue, August 12         |
+| **Application Review/Admission Decisions**                    | Wed, August 13 – Tue, August 26       |
+| **Selection Notifications**                                   | Wed, August 27                        |
+| **Mentorship Program Begins (Work Phase, Week 1)**            | Mon, September 8                      |
+| **Midterm Mentee Evaluations & First Stipend Payment**        | Wed, October 15 (Week 6)              |
+| **Final Mentee Evaluations & Second Stipend Payment**         | Wed, November 26 (Week 12)            |
+| **Last Day of Term**                                          | Fri, November 28                      |
 
 ### Project instructions
 

--- a/programs/lfx-mentorship/2025/03-Sep-Nov/project_ideas.md
+++ b/programs/lfx-mentorship/2025/03-Sep-Nov/project_ideas.md
@@ -1,0 +1,19 @@
+## Template
+
+```
+### CNCF Project Name
+
+#### Mentorship project Title
+
+- Description:
+- Expected Outcome:
+- Recommended Skills:
+- Mentor(s):
+  - Mentor Name (@mentor_github, mentor@email.addy) - please use the same email address as you use on the LFX Mentorship Platform at https://mentorship.lfx.linuxfoundation.org
+- Upstream Issue:
+
+```
+
+---
+
+## Proposed Project ideas


### PR DESCRIPTION
Proposed timelines for Term 2 & 3. We should double check the dates against Kubecons and Various national holidays.

# Term 02 - 2025 Jun - Aug

### Timeline

| **Activity**                                                 | **Dates (2025)**                      | **Notes**                                                                                              |
|--------------------------------------------------------------|---------------------------------------|--------------------------------------------------------------------------------------------------------|
| **Project Proposals Open**                                   | Wed, April 16 – Tue, May 13             | ~4 weeks for mentors/orgs to propose projects. Ends the tuesday after GSoC projects are announced                                                |
| **Mentee Applications Open**                                 | Wed, May 14 – Tue, May 27             |                                           |
| **Application Review/Admission Decisions**                   | Wed, May 28 – Tue, June 3             | 1 week to review applications                                                                          |
| **Selection Notifications**                                  | Wed, June 4                           |                                                                                                        |
| **Mentorship Program Begins (Work Phase, Week 1)**           | Mon, June 9                           |                                                                                                        |
| **Midterm Mentee Evaluations & First Stipend Payment**       | Wed, July 16 (Week 6)                 |                                                                                                        |
| **Final Mentee Evaluations & Second Stipend Payment**        | Wed, August 27 (Week 12)              |                                                                                                        |
| **Last Day of Term**                                        | Fri, August 29                        | End of Week 12 (just before the weekend and end of the month)                                          |

# Term 03 - 2025 Sept - Nov

### Timeline

| **Activity**                                                 | **Dates (2025)**                      | **Notes**                                                                                          |
|--------------------------------------------------------------|---------------------------------------|----------------------------------------------------------------------------------------------------|
| **Project Proposals Open**                                   | Wed, July 2 – Tue, July 29            | ~4 weeks for mentors to propose and finalize projects                                              |
| **Mentee Applications Open**                                 | Wed, July 30 – Tue, August 12         | 2 weeks                                                                                           |
| **Application Review/Admission Decisions**                   | Wed, August 13 – Tue, August 26       | 2 weeks                                                                                           |
| **Selection Notifications**                                  | Wed, August 27                        |                                                                                                    |
| **Mentorship Program Begins (Work Phase, Week 1)**           | Mon, September 8                      | Avoiding US Labor Day (Sep 1)                                                                      |
| **Midterm Mentee Evaluations & First Stipend Payment**       | Wed, October 15 (Week 6)              | Occurs after China’s National Day (Oct 1–7)                                                        |
| **Final Mentee Evaluations & Second Stipend Payment**        | Wed, November 26 (Week 12)            | Day before US Thanksgiving (Nov 27)                                                                |
| **Last Day of Term**                                        | Fri, November 28                      | The Friday of Thanksgiving week in the US                                                          |