### PR TITLE
Add ORAS Java SDK GSoC 2025 mentorship idea

### DIFF
--- a/programs/summerofcode/2025.md
+++ b/programs/summerofcode/2025.md
@@ -45,3 +45,20 @@ You can find the project ideas from previous year [here](./2024.md).
   - Yuri Shkuro (@yurishkuro, github@ysh.us) - primary
   - Jonah Kowall (@jkowall, jkowall@kowall.net)
 - Upstream Issue (URL): https://github.com/jaegertracing/jaeger/issues/6641
+
+#### ORAS
+
+##### Enhance Java ORAS SDK
+
+- Description: The ORAS project aims to enhance its Java SDK to support a broader range of features from the OCI Distribution spec. This involves implementing missing functionality, improving existing features, and expanding the SDK’s overall capabilities.
+- Expected Outcome:
+  - Implement missing features from the OCI Distribution and Image Specifications, such as [chunked uploads](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-blobs) and the [Referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#endpoints)
+  - Improve existing features, robustness and tests to ensure full compatibility with the OCI Distribution and Image Specifications.
+  - Enhance documentation and provide more comprehensive examples.
+  - Add support for additional authentication methods, including using credentials from docker config.json
+- Recommended Skills: java, oci
+- Expected project size: medium (~175 hour projects)
+- Mentor(s):
+  - Valentin Delaye (@jonesbusy, jonesbusy@gmail.com) - primary
+  - Feynman Zhou (@FeynmanZhou, zpf0610@gmail.com)
+- Upstream Issues: https://github.com/oras-project/oras-java/issues


### PR DESCRIPTION
Hi,

As discussed with @FeynmanZhou we would like to submit a mentorship idea for the ORAS Java SDK

I already mentored during GSoC 2024 for the jenkinsci organisation (https://www.jenkins.io/blog/2024/08/26/gsoc-using-openrewrite-for-plugin-modernization/) and volonteer to be mentor for this project if the CNCF organisation is accepted for 2025

Hope this PR is the correct way to submit an idea. 

Regards,