### PR TITLE
GSoC 2025: add an idea for Lima

### DIFF
--- a/programs/summerofcode/2025.md
+++ b/programs/summerofcode/2025.md
@@ -227,6 +227,25 @@ Note that the initial idea is to solve this with **3-way Git merges**. However, 
   - Fabrizio Sestito (@fabriziosestito, fabrizio.sestito@suse.com)
 - Upstream Issue (URL): https://github.com/kubewarden/policy-sdk-dotnet/issues/47
 
+#### Lima
+
+##### VM plugin subsystem
+
+- Description: Lima (<https://lima-vm.io>) is a project that provides Linux virtual machines with a focus on running containers.
+  Lima supports several VM backends via built-in drivers: `qemu`, `vz` (Apple Virtualization.framework), and `wsl2` (see [`lima/pkg/driverutil/instance.go`](https://github.com/lima-vm/lima/blob/v1.0.5/pkg/driverutil/instance.go#L11-L20)).
+  The idea for GSoC is to make a plugin subsystem that decouples the built-in VM drivers into separate binaries that communicate with the main Lima binary via some RPC (probably gRPC).
+  This idea will improve the maintainability of the code base, and also help supporting additional VM backends (e.g., `vfkit` and cloud-based drivers).
+- Expected Outcome:
+  - Design the plugin subsystem and its RPC (probably gRPC)
+  - Migrate the existing built-in VM drivers to the new plugin subsystem
+  - Implement additional VM plugins if the time allows
+- Recommended Skills: Go, gRPC, QEMU, macOS
+- Expected project size: medium (~175 hour projects)
+- Mentor(s):
+  - Akihiro Suda (@AkihiroSuda, suda.kyoto@gmail.com) - primary
+  - Anders Björklund (@afbjorklund, anders.f.bjorklund@gmail.com)
+- Upstream Issue (URL): https://github.com/lima-vm/lima/discussions/2007
+
 #### LitmusChaos
 
 #### Terraform Support for LitmusChaos


### PR DESCRIPTION
#### Lima

##### VM plugin subsystem

- Description: Lima (<https://lima-vm.io>) is a project that provides Linux virtual machines with a focus on running containers.
  Lima supports several VM backends via built-in drivers: `qemu`, `vz` (Apple Virtualization.framework), and `wsl2` (see [`lima/pkg/driverutil/instance.go`](https://github.com/lima-vm/lima/blob/v1.0.5/pkg/driverutil/instance.go#L11-L20)).
  The idea for GSoC is to make a plugin subsystem that decouples the built-in VM drivers into separate binaries that communicate with the main Lima binary via some RPC (probably gRPC).
  This idea will improve the maintainability of the code base, and also help supporting additional VM backends (e.g., `vfkit` and cloud-based drivers).
- Expected Outcome:
  - Design the plugin subsystem and its RPC (probably gRPC)
  - Migrate the existing built-in VM drivers to the new plugin subsystem
  - Implement additional VM plugins if the time allows
- Recommended Skills: Go, gRPC, QEMU, macOS
- Expected project size: medium (~175 hour projects)
- Mentor(s):
  - Akihiro Suda (@AkihiroSuda) - primary
  - Anders Björklund (@afbjorklund)
- Upstream Issue (URL): https://github.com/lima-vm/lima/discussions/2007