### PR TITLE
GsoC 2025: Add Kubewarden proposal 

### DIFF
--- a/programs/summerofcode/2025.md
+++ b/programs/summerofcode/2025.md
@@ -211,3 +211,52 @@ In the next phase, which will be implemented in this Summer Of Code (SOC) projec
   - yi (@0yi0 yi@secondstate.io)
 - Upstream Issue (URL): https://github.com/WasmEdge/WasmEdge/issues/4011
 
+#### Kubewarden
+
+##### Allow policies to be written using JavaScript
+
+- Description: Kubewarden is a Policy Engine powered by WebAssembly policies
+  that enforces security and compliance in Kubernetes clusters. Its policies can
+  be written in CEL, Rego (OPA & Gatekeeper flavours), Rust, Go, YAML, and
+  others.
+
+  Kubewarden does not have a JavaScript SDK yet. Recent work done inside of the Bytecode Alliance made possible to compile Javascript code into WebAssembly . This means
+  It's now possible to create such a SDK. This task consists
+  on writing a JavaScript SDK that provides an idiomatic way to write Kubewarden policies.
+
+- Expected Outcome: A new JavaScript SDK is created. The SDK API is documented, and the policy tutorial as well.
+- Recommended Skills: JavaScript, Kubernetes.
+- Expected project size: big
+- Mentor(s):
+  - Victor Cuadrado (@viccuad, vcuadradojuan@suse.com) - primary
+  - Flavio Castelli (@flavio, fcastelli@suse.com)
+  - José Guilherme Vanz (@jvanz, jguilhermevanz@suse.com)
+  - Fabrizio Sestito (@fabriziosestito, fabrizio.sestito@suse.com)
+- Upstream Issue (URL): https://github.com/kubewarden/community/issues/37
+
+##### Elevate our .NET SDK into a first class citizen
+
+- Description: Kubewarden is a Policy Engine powered by WebAssembly policies
+  that enforces security and compliance in Kubernetes clusters. Its policies can
+  be written in CEL, Rego (OPA & Gatekeeper flavours), Rust, Go, YAML, and
+  others.
+
+  Kubewarden has a .NET SDK that allows policy authors to write policies in C#.
+  Starting with .NET 8, a big chunk of the work from
+  https://github.com/dotnet/dotnet-wasi-sdk made its way upstream. This means
+  it's a good time to revisit Kubewarden's .NET SDK for policies. This task consists
+  on bringing our .NET SDK up to standard with the rest of our SDKs such as the
+  [Go](https://github.com/kubewarden/policy-sdk-go) or
+  [Rust](https://github.com/kubewarden/policy-sdk-rust) ones.
+
+- Expected Outcome: Our .NET SDK has been ported to .NET 9, and supports the
+  same capabilities as our other SDKs. The SDK API is documented, and the policy tutorial
+  as well.
+- Recommended Skills: C#, .NET, Kubernetes.
+- Expected project size: medium
+- Mentor(s):
+  - Victor Cuadrado (@viccuad, vcuadradojuan@suse.com) - primary
+  - Flavio Castelli (@flavio, fcastelli@suse.com)
+  - José Guilherme Vanz (@jvanz, jguilhermevanz@suse.com)
+  - Fabrizio Sestito (@fabriziosestito, fabrizio.sestito@suse.com)
+- Upstream Issue (URL): https://github.com/kubewarden/policy-sdk-dotnet/issues/47


### PR DESCRIPTION
Hello, [Kubewarden](https://www.kubewarden.io/) maintainer here. We would like to include 2 proposals, one to create a Javascript SDK to work on our policies, and one to work in our .NET SDK for policies.

We favour the Javascript SDK one in case there's only 1 proposal per project.

Thanks in advance.