### PR TITLE
Adding CNCF LFX 2026 Term 1 Schedule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -40,6 +40,12 @@
   - programs/lfx-mentorship/2025/*
   - programs/lfx-mentorship/2025/**/*
 
+# Add '2026' to any change to 2025 project files
+2026:
+  - programs/summerofcode/2026.md
+  - programs/lfx-mentorship/2026/*
+  - programs/lfx-mentorship/2026/**/*
+
 # Add 'Term 1: March-May' label to files for that term
 'Term 1: March-May':
   - programs/lfx-mentorship/2023/01-Mar-May/*
@@ -48,6 +54,8 @@
   - programs/lfx-mentorship/2024/01-Mar-May/**/*
   - programs/lfx-mentorship/2025/01-Mar-May/*
   - programs/lfx-mentorship/2025/01-Mar-May/**/*
+  - programs/lfx-mentorship/2026/01-Mar-May/*
+  - programs/lfx-mentorship/2026/01-Mar-May/**/*
 
 # Add 'Term 2: June-Aug' label to files for that term
 'Term 2: June-Aug':
@@ -57,6 +65,8 @@
   - programs/lfx-mentorship/2024/02-Jun-Aug/**/*
   - programs/lfx-mentorship/2025/02-Jun-Aug/*
   - programs/lfx-mentorship/2025/02-Jun-Aug/**/*
+  - programs/lfx-mentorship/2026/02-Jun-Aug/*
+  - programs/lfx-mentorship/2026/02-Jun-Aug/**/*
 
 # Add 'Term 3: Sept-Nov' label to files for that term
 'Term 3: Sept-Nov':
@@ -66,3 +76,5 @@
   - programs/lfx-mentorship/2024/03-Sep-Nov/**/*
   - programs/lfx-mentorship/2025/03-Sep-Nov/*
   - programs/lfx-mentorship/2025/03-Sep-Nov/**/*
+  - programs/lfx-mentorship/2026/03-Sep-Nov/*
+  - programs/lfx-mentorship/2026/03-Sep-Nov/**/*

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -54,6 +54,8 @@ labels:
     color: 0052CC
   - name: '2025'
     color: 0052CC
+  - name: '2026'
+    color: 0052CC
   # one "blank" line
   - name: blank
 

--- a/programs/lfx-mentorship/2026/01-Mar-May/README.md
+++ b/programs/lfx-mentorship/2026/01-Mar-May/README.md
@@ -1,0 +1,32 @@
+# Term 01 - 2026 March - May
+
+Status: Planning
+
+Mentorship duration - three months (full-time schedule)
+
+### Timeline
+
+| **Activity**                        | **Date**                                                                 |
+|-------------------------------------|--------------------------------------------------------------------------|
+| **Project Proposals Open**          | Wednesday, January 7 – Tuesday, January 20, 2026                         |
+| **Mentee Applications Open**        | Monday, January 26 – Tuesday, February 10, 2026, 11AM PST (19:00 UTC)    |
+| **Application Review Period**       | Wednesday, February 11 – Tuesday, February 24, 2026, 11AM PST (19:00 UTC)|
+| **Selection Notifications**         | Thursday, February 26, 2026                                              |
+| **Mentorship Program Begins**       | Monday, March 2, 2026                                                    |
+| **Midterm Mentee Evaluations Due**  | Tuesday, April 14, 2026, 11AM PDT (18:00 UTC)                            |
+| **First Stipend Payments**          | Wednesday, April 15, 2026                                                |
+| **Final Mentee Evaluations Due**    | Tuesday, May 26, 2026, 11AM PDT (18:00 UTC)                              |
+| **Second Stipend Payments**         | Wednesday, May 27, 2026                                                  |
+| **Last Day of Term**                | Friday, May 29, 2026                                                     |
+
+### Project instructions
+
+Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md, by February 3, 2026.
+
+### Application instructions
+
+Mentee application instructions can be found on the [Program Guidelines](https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md#program-guidelines) page.
+
+---
+
+

--- a/programs/lfx-mentorship/2026/01-Mar-May/README.md
+++ b/programs/lfx-mentorship/2026/01-Mar-May/README.md
@@ -21,7 +21,7 @@ Mentorship duration - three months (full-time schedule)
 
 ### Project instructions
 
-Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md, by February 3, 2026.
+Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md, by January 20, 2026.
 
 ### Application instructions
 

--- a/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md
+++ b/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md
@@ -1,0 +1,20 @@
+## Template
+
+```
+### CNCF Project Name
+
+#### Mentorship project Title
+
+- Description:
+- Expected Outcome:
+- Recommended Skills:
+- Mentor(s):
+  - Mentor Name (@mentor_github, mentor@email.addy) - please use the same email address as you use on the LFX Mentorship Platform at https://mentorship.lfx.linuxfoundation.org
+- Upstream Issue:
+
+```
+
+---
+
+
+## Proposed Project ideas


### PR DESCRIPTION
There is a delay between **Project Proposals Open** and **Mentee Applications Open** to give the administrators time to do the LFX Platform Loading & LFX proposal approval.

I've done my best to avoid milestones on major national holidays (not just in the US), so if you notice a conflict in rewiew, please flag it. I've also tried to avoid milestones in major events like KubeCon.

| **Activity**                        | **Date**                                                                 |
|-------------------------------------|--------------------------------------------------------------------------|
| **Project Proposals Open**          | Wednesday, January 7 – Tuesday, January 20, 2026                         |
| **Mentee Applications Open**        | Monday, January 26 – Tuesday, February 10, 2026, 11AM PST (19:00 UTC)    |
| **Application Review Period**       | Wednesday, February 11 – Tuesday, February 24, 2026, 11AM PST (19:00 UTC)|
| **Selection Notifications**         | Thursday, February 26, 2026                                              |
| **Mentorship Program Begins**       | Monday, March 2, 2026                                                    |
| **Midterm Mentee Evaluations Due**  | Tuesday, April 14, 2026, 11AM PDT (18:00 UTC)                            |
| **First Stipend Payments**          | Wednesday, April 15, 2026                                                |
| **Final Mentee Evaluations Due**    | Tuesday, May 26, 2026, 11AM PDT (18:00 UTC)                              |
| **Second Stipend Payments**         | Wednesday, May 27, 2026                                                  |
| **Last Day of Term**                | Friday, May 29, 2026                                                     |

