### PR TITLE
docs: add LFX mentorship project ideas for 2026-01

### DIFF
--- a/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md
+++ b/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md
@@ -39,7 +39,7 @@
 
 - Description: This project focuses on modernizing the Jaeger-UI by upgrading its foundational routing and state management libraries. The primary goals are to migrate from legacy react-router patterns to React Router v7 and replace the deprecated history package and older Redux integration patterns with modern standards like redux-first-history. This refactoring will improve long-term maintainability, enhance performance, and simplify the code for one of the industry's most critical observability tools.
 - Expected Outcome: A fully migrated Jaeger-UI running on React Router v7, removal of deprecated history v4/v5 dependencies, refactored functional components using modern hooks (useNavigate, useParams), and a robust test suite ensuring no regressions in trace visualization or search functionality.
-- Recommended Skills: Javascript/TypeScript & React: Deep familiarity with hooks and component lifecycles. State Management: Experience with Redux. Routing Knowledge: Understanding of SPAs and browser history APIs. Testing: Experience with React Testing Library or similar.
+- Recommended Skills: JavaScript/TypeScript & React: Deep familiarity with hooks and component lifecycles. State Management: Experience with Redux. Routing Knowledge: Understanding of SPAs and browser history APIs. Testing: Experience with React Testing Library or similar.
 - Mentor(s):
   - Yuri Shkuro (@yurishkuro, github@ysh.us)
   - Jonah Kowall (@jkowall, jkowall@kowall.net)

--- a/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md
+++ b/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md
@@ -33,8 +33,6 @@
 
 ---
 
-### Jaeger
-
 #### Upgrading Core Routing and State Management in Jaeger UI
 
 - Description: This project focuses on modernizing the Jaeger-UI by upgrading its foundational routing and state management libraries. The primary goals are to migrate from legacy react-router patterns to React Router v7 and replace the deprecated history package and older Redux integration patterns with modern standards like redux-first-history. This refactoring will improve long-term maintainability, enhance performance, and simplify the code for one of the industry's most critical observability tools.

--- a/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md
+++ b/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md
@@ -18,3 +18,29 @@
 
 
 ## Proposed Project ideas
+
+### Jaeger
+
+#### AI-Powered Trace Analysis with Local LLM Support
+
+- Description: Jaeger is a widely used distributed tracing platform. This project aims to integrate Small Language Models (SLMs) and Large Language Models (LLMs) into the Jaeger ecosystem to provide intelligent trace analysis. Key features include natural language search mapping (mapping English queries to Jaeger's internal search parameters), contextual analysis, and summarization ("Explain this Span" or "Explain this trace"). The project involves backend integration using Go and LangChainGo, and frontend integration within the Jaeger React UI.
+- Expected Outcome: A working "Natural Language Search" input that populates the Jaeger search form, contextual "Explain" buttons for errors and spans, a robust backend implementation using langchaingo supporting local models (e.g., Ollama) via YAML config, and comprehensive documentation.
+- Recommended Skills: Backend: Strong Go (Golang) experience. Architecture: Understanding of OpenTelemetry Collector architecture. AI/LLM: Familiarity with LangChain and prompt engineering for SLMs. Frontend: React.js experience.
+- Mentor(s):
+  - Jonah Kowall (@jkowall, jkowall@kowall.net)
+  - Yuri Shkuro (@yurishkuro, github@ysh.us)
+- Upstream Issue: https://github.com/jaegertracing/jaeger/issues/7832
+
+---
+
+### Jaeger
+
+#### Upgrading Core Routing and State Management
+
+- Description: This project focuses on modernizing the Jaeger-UI by upgrading its foundational routing and state management libraries. The primary goals are to migrate from legacy react-router patterns to React Router v7 and replace the deprecated history package and older Redux integration patterns with modern standards like redux-first-history. This refactoring will improve long-term maintainability, enhance performance, and simplify the code for one of the industry's most critical observability tools.
+- Expected Outcome: A fully migrated Jaeger-UI running on React Router v7, removal of deprecated history v4/v5 dependencies, refactored functional components using modern hooks (useNavigate, useParams), and a robust test suite ensuring no regressions in trace visualization or search functionality.
+- Recommended Skills: Javascript/TypeScript & React: Deep familiarity with hooks and component lifecycles. State Management: Experience with Redux. Routing Knowledge: Understanding of SPAs and browser history APIs. Testing: Experience with React Testing Library or similar.
+- Mentor(s):
+  - Yuri Shkuro (@yurishkuro, github@ysh.us)
+  - Jonah Kowall (@jkowall, jkowall@kowall.net)
+- Upstream Issue: https://github.com/jaegertracing/jaeger-ui/issues/3313

--- a/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md
+++ b/programs/lfx-mentorship/2026/01-Mar-May/project_ideas.md
@@ -35,7 +35,7 @@
 
 ### Jaeger
 
-#### Upgrading Core Routing and State Management
+#### Upgrading Core Routing and State Management in Jaeger UI
 
 - Description: This project focuses on modernizing the Jaeger-UI by upgrading its foundational routing and state management libraries. The primary goals are to migrate from legacy react-router patterns to React Router v7 and replace the deprecated history package and older Redux integration patterns with modern standards like redux-first-history. This refactoring will improve long-term maintainability, enhance performance, and simplify the code for one of the industry's most critical observability tools.
 - Expected Outcome: A fully migrated Jaeger-UI running on React Router v7, removal of deprecated history v4/v5 dependencies, refactored functional components using modern hooks (useNavigate, useParams), and a robust test suite ensuring no regressions in trace visualization or search functionality.


### PR DESCRIPTION
This PR adds two new project ideas for the LFX Mentorship 2026-01 term:
1. AI-Powered Trace Analysis with Local LLM Support (Jaeger)
2. Upgrading Core Routing and State Management (Jaeger-UI)

@yurishkuro is the co-mentor for both of these per the proposals. 

Thanks!