### PR TITLE
kgateway: google summer of code proposals

### DIFF
--- a/programs/summerofcode/2026.md
+++ b/programs/summerofcode/2026.md
@@ -38,3 +38,42 @@ You can find the project ideas from previous year [here](./2025.md).
 ## Ideas
 
 
+### kgateway
+
+##### Benchmarking and Performance Evaluation of Inference Routing Extensions in kgateway
+
+- Description:
+kgateway provides inference routing capabilities based on the Kubernetes Gateway API Inference Extension project. This integration enables advanced behaviors such as model-aware routing, serving priority, and customizable load-balancing of self-hosted Generative AI models.
+
+However, there is currently no standardized or reproducible way to evaluate the performance impact of these inference routing extensions.
+
+This project aims to design and implement a comprehensive benchmarking framework to measure the latency, throughput, and resource overhead introduced by inference routing extensions in kgateway. The benchmarks will help maintainers and users understand performance tradeoffs, validate optimizations, and guide future architectural decisions.
+
+- Expected Outcome:
+  - A reproducible benchmarking framework for inference routing extensions in kgateway
+  - Benchmark scenarios covering:
+    - Baseline gateway routing vs inference-enabled routing
+    - Different inference extensions and EPP configurations
+    - Request/response and streaming inference workloads
+  - Collected metrics including:
+    - End-to-end latency (p50 / p95 / p99)
+    - Throughput
+    - CPU and memory overhead
+  - Automated benchmark execution (e.g., via CI or documented scripts)
+  - Documentation describing benchmark methodology, results interpretation, and best practices
+
+- Recommended Skills:
+  - Go
+  - Kubernetes
+  - Familiarity with gateways or networking concepts
+  - Basic understanding of AI inference workloads is a plus
+
+- Expected project size:
+  Medium (~175 hour projects)
+
+- Mentor(s):
+  - Primary Mentor: Nina Polshakova (@npolshakova, nina.polshakova@solo.io)
+  - Secondary Mentor: Daneyon Hansen (@danehans, daneyon.hansen@solo.io)
+
+- Upstream Issue (URL):
+  https://github.com/kgateway-dev/kgateway/issues/12289


### PR DESCRIPTION
Adds [kgateway](https://github.com/kgateway-dev/kgateway) project proposals for the Google Summer of Code 2026 term. 