### PR TITLE
Add KubeCon Mentorship Session Proposal

### DIFF
--- a/cncf-toc-mentoring-subproject/KUBECON_MENTORSHIP_SESSION_PROPOSAL.md
+++ b/cncf-toc-mentoring-subproject/KUBECON_MENTORSHIP_SESSION_PROPOSAL.md
@@ -1,0 +1,32 @@
+# KubeCon Mentorship Session Proposal
+
+**Title:** Empowering the Next Generation: Success Stories and Best Practices from CNCF Mentorship Programs
+
+## Description
+This session will showcase the impact of CNCF mentorship programs (LFX, GSoC) through success stories from mentees and mentors. We will discuss best practices for fostering a supportive mentorship environment and provide insights into how these programs bridge the gap between learning and contributing to the cloud native ecosystem.
+
+## Abstract
+The CNCF Mentorship programs have been instrumental in onboarding new contributors to the cloud native ecosystem. However, the stories of growth, challenges, and success often remain within the specific project communities. This session aims to bring these stories to the forefront. We will hear from former mentees who have become maintainers, and mentors who have guided them. The panel will discuss:
+- **Success Stories:** Real-world examples of impactful contributions made by mentees.
+- **Best Practices:** Strategies for effective mentorship, communication, and project planning.
+- **Career Growth:** How mentorship programs accelerate career development in open source.
+- **Future of Mentorship:** Ideas for improving and expanding the mentorship experience.
+
+## Target Audience
+- **Aspiring Contributors:** Students and professionals looking to start their journey in cloud native.
+- **Project Maintainers:** Open source leaders interested in starting or improving mentorship programs.
+- **Community Managers:** Individuals focused on community growth and engagement.
+- **Educators:** Those looking to bridge the gap between academia and industry.
+
+## Proposed Panelists / Speakers
+*(TBD - Seeking diverse representation from various CNCF projects)*
+- **Moderator:** TBD
+- **Mentee Representative:** TBD (e.g., Someone who graduated to become a reviewer/maintainer)
+- **Mentor Representative:** TBD
+- **Program Admin:** TBD
+
+## Key Takeaways
+- Inspiration from real success stories of CNCF mentees.
+- Actionable advice for becoming a successful mentee or mentor.
+- Understanding the value of mentorship in building sustainable open source communities.
+- Networking opportunities with mentorship program participants.


### PR DESCRIPTION
Fixes #1206. Adds a proposal for a KubeCon session/track dedicated to mentorship success stories and best practices.