### PR TITLE
Add 2026 Term 3 (Sep-Nov) schedule and project ideas template

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -40,7 +40,7 @@
   - programs/lfx-mentorship/2025/*
   - programs/lfx-mentorship/2025/**/*
 
-# Add '2026' to any change to 2025 project files
+# Add '2026' to any change to 2026 project files
 2026:
   - programs/summerofcode/2026.md
   - programs/lfx-mentorship/2026/*

--- a/programs/lfx-mentorship/2026/03-Sep-Nov/README.md
+++ b/programs/lfx-mentorship/2026/03-Sep-Nov/README.md
@@ -1,0 +1,35 @@
+# Term 03 - 2026 September - November
+
+Status: Planning
+
+Mentorship duration - three months (full-time schedule)
+
+### Timeline
+
+| Activity | Dates (2026) |
+|--------------|------------------|
+| Project Proposals Open | Wed, Jul 1 – Tue, Jul 28, 18:00 UTC |
+| Mentee Candidate Info Sessions | Tue, Jul 21, Times TBD (will be multiple timezone options) |
+| Mentee Applications Open | Mon, Aug 3 – Tue, Aug 18, 18:00 UTC |
+| Application Review Period (2 weeks) | Wed, Aug 19 – Tue, Sep 1, 18:00 UTC |
+| Selection Notifications | Wed, Sep 2 – Fri, Sep 4 *(notifications may take a few days to reach all mentees)* |
+| Mentorship Program Begins | Mon, Sep 7 |
+| Mentorship Kick Off Call | Tue, Sep 8, Times TBD (will be multiple timezone options) |
+| Midterm Mentee Evaluations | Tue, Oct 20, 18:00 UTC |
+| First Stipend Payments | Wed, Oct 21 |
+| Final Mentee Evaluations | Tue, Nov 24, 18:00 UTC |
+| Second Stipend Payments | Wed, Nov 25 |
+| Last Day of Term | Fri, Nov 27 |
+
+
+### Project instructions
+
+Project maintainers and potential mentors are welcome to propose their mentoring project ideas via submitting a PR to GitHub here https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/2026/03-Sep-Nov/project_ideas.md, by July 28, 2026. Please limit proposals to 4-5 projects per CNCF project.
+
+### Application instructions
+
+Mentee application instructions can be found on the [Program Guidelines](https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md#program-guidelines) page.
+
+---
+
+

--- a/programs/lfx-mentorship/2026/03-Sep-Nov/project_ideas.md
+++ b/programs/lfx-mentorship/2026/03-Sep-Nov/project_ideas.md
@@ -1,0 +1,20 @@
+## Template
+
+```
+### CNCF Project Name
+
+#### Mentorship project Title
+
+- Description:
+- Expected Outcome:
+- Recommended Skills:
+- Mentor(s):
+  - Mentor Name (@mentor_github, mentor@email.addy) - please use the same email address as you use on the LFX Mentorship Platform at https://mentorship.lfx.linuxfoundation.org
+- Upstream Issue:
+
+```
+
+---
+
+
+## Proposed Project ideas


### PR DESCRIPTION
Initialize the `03-Sep-Nov` directory for the 2026 Term 3 LFX Mentorship program.

### Changes
- **`programs/lfx-mentorship/2026/03-Sep-Nov/README.md`** — Full program timeline and instructions
- **`programs/lfx-mentorship/2026/03-Sep-Nov/project_ideas.md`** — Proposal template for mentors
- **`.github/labeler.yml`** — Fix comment typo (2025 → 2026)

### Timeline

| Activity | Dates (2026) |
|--------------|------------------|
| Project Proposals Open | Wed, Jul 1 – Tue, Jul 28, 18:00 UTC |
| Mentee Candidate Info Sessions | Tue, Jul 21, Times TBD |
| Mentee Applications Open | Mon, Aug 3 – Tue, Aug 18, 18:00 UTC |
| Application Review Period (2 weeks) | Wed, Aug 19 – Tue, Sep 1, 18:00 UTC |
| Selection Notifications | Wed, Sep 2 – Fri, Sep 4 |
| Mentorship Program Begins | Mon, Sep 7 |
| Mentorship Kick Off Call | Tue, Sep 8, Times TBD |
| Midterm Mentee Evaluations | Tue, Oct 20, 18:00 UTC |
| First Stipend Payments | Wed, Oct 21 |
| Final Mentee Evaluations | Tue, Nov 24, 18:00 UTC |
| Second Stipend Payments | Wed, Nov 25 |
| Last Day of Term | Fri, Nov 27 |

Closes #1756