### PR TITLE
Add Microcks mentor for LFX Mentorship 2026 Term 2

### DIFF
--- a/programs/lfx-mentorship/2026/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2026/02-Jun-Aug/README.md
@@ -852,6 +852,7 @@ CNCF - Microcks: CLI v2 - VS Code Integration and Local Dev Loop Enhancement (20
   - Laurent Broudoux (@lbroudoux, laurent.broudoux@gmail.com)
   - Yacine Kheddache (@yada, yacine@microcks.io)
   - Harshvardhan Parmar (@Harsh4902, harshparmar4902@gmail.com)
+  - Vaishnav Kale (@Vaishnav88sk, vaishnavsk8804@gmail.com)
 - Upstream Issue: https://github.com/microcks/microcks-cli/issues/255
 - LFX URL: https://mentorship.lfx.linuxfoundation.org/project/7e8b57e3-0f43-4298-b079-ba9d671b68d8
 


### PR DESCRIPTION
## Description

This PR adds my entry as a mentor for the Microcks project under LFX Mentorship 2026 Term 2.

An earlier update already introduced mentors for this project. This PR extends that list by including my contribution as a co-mentor.

## Changes

- Added my details to the Microcks mentors section for LFX Mentorship 2026 Term 2
- Maintained consistency with the existing formatting and structure

## Background

I am contributing as a co-mentor for this term and have been actively involved with the Microcks project through prior contributions and community engagement.

## Impact

- Documentation-only change
- No functional or structural impact

## Checklist

- [x] Follows repository contribution guidelines
- [x] Formatting matches existing entries
- [x] No unrelated changes included

Please let me know if any modifications are required.