### PR TITLE
update kmesh mentor profile email

### DIFF
--- a/programs/lfx-mentorship/2026/02-Jun-Aug/README.md
+++ b/programs/lfx-mentorship/2026/02-Jun-Aug/README.md
@@ -344,7 +344,7 @@ CNCF - Kmesh: Integrating Kmesh into Headlamp UI (2026 Term 2)
   - Headlamp UI
 - Mentor(s):
   - Yash Israni (yashisrani, imailyash57@gmail.com),
-  - Jayesh Savaliya (jayesh9747, savaliyajayesh2405@gmail.com)
+  - Jayesh Savaliya (jayesh9747, 112215167@cse.iiitp.ac.in)
 - Upstream Issue: https://github.com/kmesh-net/kmesh/issues/1658
 - LFX URL: https://mentorship.lfx.linuxfoundation.org/project/c5b8d1fa-b75a-4f88-a63b-e6487dc7e39b
 


### PR DESCRIPTION
This is my existing profile email. I want to merge my account with the older one because this is my college email ID, and it will expire at the end of 2026. So, I created a new account using my personal email, but now I’m facing some issues. Could you please add the older profile?