### PR TITLE
refactor: extract LFX proposal automation into a tested lib

### DIFF
--- a/.github/workflows/lfx-automation-tests.yml
+++ b/.github/workflows/lfx-automation-tests.yml
@@ -1,0 +1,48 @@
+name: LFX Automation Tests
+
+# Unit tests for the LFX proposal automation logic (form parsing, mentor/LFID
+# validation, CSV handling, board status rules, the /confirm tally, and README
+# assembly) extracted into programs/lfx-mentorship/automation/lib. Runs on any
+# change to that logic or to the workflows that depend on it.
+
+on:
+  pull_request:
+    paths:
+      - 'programs/lfx-mentorship/automation/lib/**'
+      - 'programs/lfx-mentorship/automation/test/**'
+      - '.github/workflows/lfx-automation-tests.yml'
+      - '.github/workflows/lfx-proposal-validate.yml'
+      - '.github/workflows/lfx-proposal-approvals.yml'
+      - '.github/workflows/lfx-proposal-board-sync.yml'
+      - '.github/workflows/lfx-export.yml'
+      - '.github/workflows/lfx-export-merge-notify.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'programs/lfx-mentorship/automation/lib/**'
+      - 'programs/lfx-mentorship/automation/test/**'
+      - '.github/workflows/lfx-automation-tests.yml'
+      - '.github/workflows/lfx-proposal-validate.yml'
+      - '.github/workflows/lfx-proposal-approvals.yml'
+      - '.github/workflows/lfx-proposal-board-sync.yml'
+      - '.github/workflows/lfx-export.yml'
+      - '.github/workflows/lfx-export-merge-notify.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run automation unit tests
+        working-directory: programs/lfx-mentorship/automation
+        run: node --test

--- a/.github/workflows/lfx-export-merge-notify.yml
+++ b/.github/workflows/lfx-export-merge-notify.yml
@@ -7,26 +7,32 @@ on:
 
 permissions:
   issues: write
+  contents: write  # delete the merged export branch
 
 jobs:
   notify:
+    # Skip fork PRs: only same-repo export PRs should notify and delete branches.
     if: >-
       github.event.pull_request.merged == true
+      && github.event.pull_request.head.repo.full_name == github.repository
       && startsWith(github.event.pull_request.head.ref, 'automation/lfx-export-')
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Notify exported issues
         uses: actions/github-script@v7
         with:
           script: |
+            const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { parseExportedIssueNumbers } = _lib('notify.js');
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
             const prNumber = pr.number;
-            const prUrl = pr.html_url;
 
-            // Extract issue numbers from PR body (format: "- #123 — ...")
-            const issueNums = [...(pr.body || '').matchAll(/-\s+#(\d+)\s+—/g)]
-              .map(m => parseInt(m[1]));
+            const issueNums = parseExportedIssueNumbers(pr.body);
 
             if (issueNums.length === 0) {
               console.log('No linked issues found in PR body.');
@@ -41,4 +47,24 @@ jobs:
                   `This issue will be updated when the program is live on LFX.`,
               });
               console.log(`Notified #${issue_number} about merge of PR #${prNumber}`);
+            }
+
+      - name: Delete merged export branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { isExportBranch } = _lib('notify.js');
+            const { owner, repo } = context.repo;
+            const branch = context.payload.pull_request.head.ref;
+            if (!isExportBranch(branch)) {
+              console.log(`Not an export branch, skipping delete: ${branch}`);
+              return;
+            }
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: `heads/${branch}` });
+              console.log(`Deleted merged export branch: ${branch}`);
+            } catch (e) {
+              console.log(`Could not delete branch ${branch}: ${e.message}`);
             }

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -30,53 +30,15 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { parseIssueForm, parseCheckboxes, parseMentors } = _lib('parse.js');
+            const { slugify } = _lib('slug.js');
+            const { buildReadme } = _lib('readme.js');
+            const { csvEscape } = _lib('csv.js');
             const { owner, repo } = context.repo;
             const term = context.payload.inputs.term;
 
             console.log(`Exporting proposals for: ${term}`);
-
-            // ── Parse issue form body ──
-            function parseIssueForm(body) {
-              const fields = {};
-              for (const section of body.split(/^### +/m).slice(1)) {
-                const nl = section.indexOf('\n');
-                if (nl === -1) continue;
-                const label = section.slice(0, nl).trim();
-                let value = section.slice(nl + 1).trim();
-                if (value === '_No response_') value = '';
-                fields[label] = value;
-              }
-              return fields;
-            }
-
-            // ── Parse checkbox fields ──
-            function parseCheckboxes(raw) {
-              if (!raw) return [];
-              return raw.split('\n')
-                .filter(l => /- \[.\]/.test(l))
-                .filter(l => /- \[x\]/i.test(l))
-                .map(l => l.replace(/^- \[.\]\s*/, '').trim());
-            }
-
-            // ── Parse mentors ──
-            function parseMentors(raw) {
-              if (!raw) return [];
-              return raw.split(/\r?\n/)
-                .map(l => l.trim())
-                .filter(Boolean)
-                .map((line, i) => {
-                  const parts = line.split('|').map(p => p.trim());
-                  if (parts.length !== 3 && parts.length !== 4) return null;
-                  return {
-                    name: parts[0],
-                    github_handle: parts[1].replace(/^@/, ''),
-                    email: parts[2],
-                    lfid: parts[3] || '',
-                    role: i === 0 ? 'primary' : 'co-mentor',
-                  };
-                })
-                .filter(Boolean);
-            }
 
             // ── Fetch all approved issues for this term ──
             const issues = await github.paginate(github.rest.issues.listForRepo, {
@@ -210,15 +172,6 @@ jobs:
               (a, b) => a.toLowerCase().localeCompare(b.toLowerCase())
             );
 
-            // Slug helper for markdown anchors
-            function slugify(text) {
-              return text.toLowerCase()
-                .replace(/[^\w\s-]/g, '')
-                .replace(/\s+/g, '-')
-                .replace(/-+/g, '-')
-                .trim();
-            }
-
             // Term display: "2026 Term 3 (Sep-Nov)" → "Term 03 - 2026 September - November"
             const monthMap = {
               'Mar': 'March', 'May': 'May', 'Jun': 'June',
@@ -286,36 +239,10 @@ jobs:
             if (fs.existsSync(readmePath)) {
               existingReadme = fs.readFileSync(readmePath, 'utf8');
             }
-            const sep = existingReadme ? existingReadme.match(/^---[ \t]*$/m) : null;
-            let header;
-            if (sep) {
-              header = existingReadme.slice(0, sep.index + sep[0].length) + '\n\n';
-            } else {
-              header = [
-                `# ${readmeTitle}`,
-                '',
-                'Status: Planning',
-                '',
-                'Mentorship duration - three months (full-time schedule)',
-                '',
-                '---',
-                '',
-                '',
-              ].join('\n');
-            }
-
-            fs.writeFileSync(readmePath, header + md.join('\n') + '\n');
+            fs.writeFileSync(readmePath, buildReadme(existingReadme, md, readmeTitle));
             console.log(`Wrote README.md with ${sortedProjects.length} projects, ${programs.length} programs`);
 
             // ── Generate tracking CSV ──
-            function csvEscape(val) {
-              const s = String(val || '');
-              if (s.includes(',') || s.includes('"') || s.includes('\n')) {
-                return '"' + s.replace(/"/g, '""') + '"';
-              }
-              return s;
-            }
-
             const csvHeaders = [
               'PROJECT', 'LFX URL', 'Upstream issue', '',
               'mentor count',
@@ -453,6 +380,9 @@ jobs:
             // cncf/mentoring (prod) run identical code. The board's Status
             // column names must match the lifecycle stages used by the workflows.
             const fs = require('fs');
+            const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { shouldSkipExport, readStatusWithRetry } = _lib('board.js');
             const _board = JSON.parse(fs.readFileSync('programs/lfx-mentorship/automation/board.json', 'utf8'));
             const _envCfg = (_board.environments || {})[process.env.GITHUB_REPOSITORY];
             if (!_envCfg || !_envCfg.projectId || String(_envCfg.projectId).startsWith('REPLACE_')) {
@@ -480,13 +410,6 @@ jobs:
             }
             const issues = process.env.EXPORTED_ISSUES.split(',').filter(Boolean);
 
-            // Never pull a card back to "Exported" if the administrator has
-            // already advanced it by hand to a post-export column.
-            const ADMIN_OWNED = new Set([
-              'Posted to LFX', 'LFX Approved', 'Mentors added',
-              'Open for Applications', 'Applications Closed',
-            ]);
-
             for (const num of issues) {
               const { data: issue } = await github.rest.issues.get({
                 owner: context.repo.owner,
@@ -503,37 +426,27 @@ jobs:
               `, { projectId: PROJECT_ID, contentId: issue.node_id });
               const itemId = addResult.addProjectV2ItemById.item.id;
 
-              let currentStatus = null;
-              let readFailed = false;
-              for (let attempt = 1; attempt <= 2; attempt++) {
-                try {
-                  const _cur = await github.graphql(`
-                    query($itemId: ID!) {
-                      node(id: $itemId) { ... on ProjectV2Item {
-                        fieldValueByName(name: "Status") {
-                          ... on ProjectV2ItemFieldSingleSelectValue { name }
-                        }
-                      } }
-                    }
-                  `, { itemId });
-                  currentStatus = _cur?.node?.fieldValueByName?.name || null;
-                  readFailed = false;
-                  break;
-                } catch (e) {
-                  readFailed = true;
-                  core.warning(`Could not read current board status for #${num} (attempt ${attempt}/2): ${e.message}`);
-                  if (attempt < 2) await new Promise(r => setTimeout(r, 1000));
+              const { currentStatus, readFailed } = await readStatusWithRetry(
+                () => github.graphql(`
+                  query($itemId: ID!) {
+                    node(id: $itemId) { ... on ProjectV2Item {
+                      fieldValueByName(name: "Status") {
+                        ... on ProjectV2ItemFieldSingleSelectValue { name }
+                      }
+                    } }
+                  }
+                `, { itemId }),
+                { onError: (attempt, e) => core.warning(`Could not read current board status for #${num} (attempt ${attempt}/2): ${e.message}`) },
+              );
+              // The export loop always targets "Exported", so skip whenever the
+              // card is admin-owned (manual placement) or the status read failed
+              // (fail closed, rather than risk pulling a card back).
+              if (shouldSkipExport(currentStatus, readFailed)) {
+                if (currentStatus) {
+                  console.log(`#${num} is in admin-owned column "${currentStatus}"; leaving placement to the administrator.`);
+                } else {
+                  core.warning(`Status read failed for #${num} while about to set "Exported"; skipping to avoid clobbering a manual placement.`);
                 }
-              }
-              if (currentStatus && ADMIN_OWNED.has(currentStatus)) {
-                console.log(`#${num} is in admin-owned column "${currentStatus}"; leaving placement to the administrator.`);
-                continue;
-              }
-              // Fail closed: the export loop always targets "Exported", so if
-              // the status read failed, skip this issue rather than risk
-              // pulling a manually-placed card back.
-              if (readFailed) {
-                core.warning(`Status read failed for #${num} while about to set "Exported"; skipping to avoid clobbering a manual placement.`);
                 continue;
               }
 

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { parseIssueForm } = _lib('parse.js');
+            const { parseCsvLine } = _lib('csv.js');
+            const { computeConfirm } = _lib('confirm.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const comment = context.payload.comment;
@@ -49,19 +54,6 @@ jobs:
             });
 
             // ── Parse issue form ──
-            function parseIssueForm(text) {
-              const fields = {};
-              for (const section of text.split(/^### +/m).slice(1)) {
-                const nl = section.indexOf('\n');
-                if (nl === -1) continue;
-                const label = section.slice(0, nl).trim();
-                let value = section.slice(nl + 1).trim();
-                if (value === '_No response_') value = '';
-                fields[label] = value;
-              }
-              return fields;
-            }
-
             const fields = parseIssueForm(issueBody);
             const get = (k) => (fields[k] || '').trim();
             const project = get('CNCF Project');
@@ -226,23 +218,8 @@ jobs:
                     // Minimal CSV line parser: respects quoted fields with
                     // embedded commas and escaped double-quotes ("") so a comma
                     // inside a value like "Chainguard, Inc" cannot shift the
-                    // GitHub-handle column and trigger a false auth rejection.
-                    const parseCsvLine = (row) => {
-                      const out = [];
-                      let cur = '', inQuotes = false;
-                      for (let i = 0; i < row.length; i++) {
-                        const ch = row[i];
-                        if (inQuotes) {
-                          if (ch === '"' && row[i + 1] === '"') { cur += '"'; i++; }
-                          else if (ch === '"') { inQuotes = false; }
-                          else { cur += ch; }
-                        } else if (ch === '"') { inQuotes = true; }
-                        else if (ch === ',') { out.push(cur); cur = ''; }
-                        else { cur += ch; }
-                      }
-                      out.push(cur);
-                      return out;
-                    };
+                    // GitHub-handle column and trigger a false auth rejection
+                    // (parser in lib/csv.js).
                     for (const line of csv.split('\n').slice(1)) {
                       if (!line.trim()) continue;
                       const cols = parseCsvLine(line);
@@ -396,28 +373,21 @@ jobs:
 
               // Per-mentor confirmation: the gate flips only once EVERY listed
               // mentor has confirmed. Gather confirmations from the issue's
-              // comment history (plus this one) and compare to the roster.
-              const roster = [...new Set(mentorHandles)];
-              const confirmed = new Set([commenter.toLowerCase()]);
+              // comment history (plus this one) and compare to the roster
+              // (tally logic in lib/confirm.js).
+              let priorComments = [];
               try {
-                const priorComments = await github.paginate(github.rest.issues.listComments, {
+                priorComments = await github.paginate(github.rest.issues.listComments, {
                   owner, repo, issue_number, per_page: 100,
                 });
-                const hasConfirm = (body) => (body || '').split(/\r?\n/)
-                  .some(l => /^\/confirm\b/.test(l.trim()));
-                for (const c of priorComments) {
-                  const author = (c.user?.login || '').toLowerCase();
-                  if (roster.includes(author) && hasConfirm(c.body)) confirmed.add(author);
-                }
               } catch (e) {
                 core.warning(`Could not read prior confirmations: ${e.message}`);
               }
-
-              const remaining = roster.filter(h => !confirmed.has(h));
+              const { remaining, count, total } = computeConfirm(mentorHandles, commenter, priorComments);
               if (remaining.length) {
                 await reply('✅',
                   `Confirmation recorded from @${commenter}. ` +
-                  `${confirmed.size} of ${roster.length} mentors have confirmed.\n\n` +
+                  `${count} of ${total} mentors have confirmed.\n\n` +
                   `Still waiting on: ${remaining.map(h => `@${h}`).join(', ')}.`);
                 return;
               }
@@ -426,7 +396,7 @@ jobs:
               await addLabel('Mentors Confirmed');
               await removeLabel('Awaiting Mentor Confirmation');
               await reply('✅',
-                `All ${roster.length} listed mentor(s) have confirmed. Mentor confirmation is complete.`);
+                `All ${total} listed mentor(s) have confirmed. Mentor confirmation is complete.`);
               await checkBothGates();
               return;
             }
@@ -492,6 +462,9 @@ jobs:
             // cncf/mentoring (prod) run identical code. The board's Status
             // column names must match the lifecycle stages used below.
             const fs = require('fs');
+            const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { determineStatus, shouldSkipSync, readStatusWithRetry } = _lib('board.js');
             const _board = JSON.parse(fs.readFileSync('programs/lfx-mentorship/automation/board.json', 'utf8'));
             const _envCfg = (_board.environments || {})[process.env.GITHUB_REPOSITORY];
             if (!_envCfg || !_envCfg.projectId || String(_envCfg.projectId).startsWith('REPLACE_')) {
@@ -523,17 +496,10 @@ jobs:
 
             if (!labels.includes('lfx mentorship') || !labels.includes('Proposal')) return;
 
-            let status = 'Inbox';
             // Automation owns the lifecycle only through "Exported"; the
-            // post-export columns are manual admin moves (see board guard below).
-            if (issue.state === 'closed')                            status = 'Closed';
-            else if (labels.includes('Exported'))                    status = 'Exported';
-            else if (labels.includes('CNCF Approved'))               status = 'CNCF Approved';
-            else if (labels.includes('Maintainer/Contribex Approved')
-                     && labels.includes('Mentors Confirmed'))        status = 'Approved/confirmed';
-            else if (labels.includes('Awaiting Maintainer/Contribex Approval')
-                     || labels.includes('Awaiting Mentor Confirmation'))
-                                                                     status = 'Awaiting approvals/confirmations';
+            // post-export columns are manual admin moves (see board guard below
+            // and lib/board.js).
+            const status = determineStatus(labels, issue.state === 'closed' ? 'closed' : null);
 
             const optionId = STATUS_OPTIONS[status];
             if (!optionId) {
@@ -549,45 +515,29 @@ jobs:
             `, { projectId: PROJECT_ID, contentId: issue.node_id });
             const itemId = addResult.addProjectV2ItemById.item.id;
 
-            // ── Respect manual admin moves ──
-            // Automation owns the lifecycle only through "Exported". The
-            // post-export columns are advanced by hand, so never overwrite a
-            // card already sitting in one of them (except to reflect a close).
-            const ADMIN_OWNED = new Set([
-              'Posted to LFX', 'LFX Approved', 'Mentors added',
-              'Open for Applications', 'Applications Closed',
-            ]);
-            let currentStatus = null;
-            let readFailed = false;
-            for (let attempt = 1; attempt <= 2; attempt++) {
-              try {
-                const _cur = await github.graphql(`
-                  query($itemId: ID!) {
-                    node(id: $itemId) { ... on ProjectV2Item {
-                      fieldValueByName(name: "Status") {
-                        ... on ProjectV2ItemFieldSingleSelectValue { name }
-                      }
-                    } }
-                  }
-                `, { itemId });
-                currentStatus = _cur?.node?.fieldValueByName?.name || null;
-                readFailed = false;
-                break;
-              } catch (e) {
-                readFailed = true;
-                core.warning(`Could not read current board status (attempt ${attempt}/2): ${e.message}`);
-                if (attempt < 2) await new Promise(r => setTimeout(r, 1000));
+            // ── Respect manual admin moves (guard logic in lib/board.js) ──
+            // Automation owns the lifecycle only through "Exported"; the
+            // post-export columns are advanced by hand by the administrator, so
+            // never overwrite a card already sitting in one (except on close),
+            // and fail closed if the status read fails while setting "Exported".
+            const { currentStatus, readFailed } = await readStatusWithRetry(
+              () => github.graphql(`
+                query($itemId: ID!) {
+                  node(id: $itemId) { ... on ProjectV2Item {
+                    fieldValueByName(name: "Status") {
+                      ... on ProjectV2ItemFieldSingleSelectValue { name }
+                    }
+                  } }
+                }
+              `, { itemId }),
+              { onError: (attempt, e) => core.warning(`Could not read current board status (attempt ${attempt}/2): ${e.message}`) },
+            );
+            if (shouldSkipSync(currentStatus, status, readFailed)) {
+              if (currentStatus) {
+                console.log(`Card is in admin-owned column "${currentStatus}"; leaving placement to the administrator.`);
+              } else {
+                core.warning('Status read failed while about to set "Exported"; skipping to avoid clobbering a manual placement.');
               }
-            }
-            if (currentStatus && ADMIN_OWNED.has(currentStatus) && status !== 'Closed') {
-              console.log(`Card is in admin-owned column "${currentStatus}"; leaving placement to the administrator.`);
-              return;
-            }
-            // Fail closed: if the status read failed we cannot tell whether the
-            // card is in an admin-owned column, so never risk pulling it back
-            // to "Exported".
-            if (readFailed && status === 'Exported') {
-              core.warning('Status read failed while about to set "Exported"; skipping to avoid clobbering a manual placement.');
               return;
             }
 

--- a/.github/workflows/lfx-proposal-board-sync.yml
+++ b/.github/workflows/lfx-proposal-board-sync.yml
@@ -30,6 +30,9 @@ jobs:
             // cncf/mentoring (prod) run identical code. The board's Status
             // column names must match the lifecycle stages used below.
             const fs = require('fs');
+            const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { determineStatus, shouldSkipSync, readStatusWithRetry } = _lib('board.js');
             const _board = JSON.parse(fs.readFileSync('programs/lfx-mentorship/automation/board.json', 'utf8'));
             const _envCfg = (_board.environments || {})[process.env.GITHUB_REPOSITORY];
             if (!_envCfg || !_envCfg.projectId || String(_envCfg.projectId).startsWith('REPLACE_')) {
@@ -55,33 +58,8 @@ jobs:
             const labels = (issue.labels || []).map(l => l.name);
             const action = context.payload.action;
 
-            // ── Determine target status from labels + event ──
-            function determineStatus() {
-              if (action === 'closed')   return 'Closed';
-              if (action === 'reopened') return determineFromLabels();
-              return determineFromLabels();
-            }
-
-            function determineFromLabels() {
-              // Automation owns the lifecycle only through "Exported". The
-              // post-export columns (Posted to LFX, LFX Approved, Mentors added,
-              // Open for Applications, Applications Closed) are advanced by hand
-              // by the administrator, so they are never derived from labels here.
-              if (labels.includes('Exported'))                  return 'Exported';
-              if (labels.includes('CNCF Approved'))             return 'CNCF Approved';
-
-              const maintainerApproved = labels.includes('Maintainer/Contribex Approved');
-              const mentorsConfirmed   = labels.includes('Mentors Confirmed');
-              if (maintainerApproved && mentorsConfirmed)       return 'Approved/confirmed';
-
-              if (labels.includes('Awaiting Maintainer/Contribex Approval')
-                  || labels.includes('Awaiting Mentor Confirmation'))
-                return 'Awaiting approvals/confirmations';
-
-              return 'Inbox';
-            }
-
-            const targetStatus = determineStatus();
+            // ── Determine target status from labels + event (see lib/board.js) ──
+            const targetStatus = determineStatus(labels, action);
             console.log(`Target status: ${targetStatus}`);
 
             const optionId = STATUS_OPTIONS[targetStatus];
@@ -108,46 +86,29 @@ jobs:
             const itemId = addResult.addProjectV2ItemById.item.id;
             console.log(`Project item: ${itemId}`);
 
-            // ── Respect manual admin moves ──
-            // Automation owns the lifecycle only through "Exported". The
-            // post-export columns are advanced by hand as the administrator
-            // works with the LFX platform, so never overwrite a card that is
-            // already sitting in one of them (except to reflect a closed issue).
-            const ADMIN_OWNED = new Set([
-              'Posted to LFX', 'LFX Approved', 'Mentors added',
-              'Open for Applications', 'Applications Closed',
-            ]);
-            let currentStatus = null;
-            let readFailed = false;
-            for (let attempt = 1; attempt <= 2; attempt++) {
-              try {
-                const _cur = await github.graphql(`
-                  query($itemId: ID!) {
-                    node(id: $itemId) { ... on ProjectV2Item {
-                      fieldValueByName(name: "Status") {
-                        ... on ProjectV2ItemFieldSingleSelectValue { name }
-                      }
-                    } }
-                  }
-                `, { itemId });
-                currentStatus = _cur?.node?.fieldValueByName?.name || null;
-                readFailed = false;
-                break;
-              } catch (e) {
-                readFailed = true;
-                core.warning(`Could not read current board status (attempt ${attempt}/2): ${e.message}`);
-                if (attempt < 2) await new Promise(r => setTimeout(r, 1000));
+            // ── Respect manual admin moves (guard logic in lib/board.js) ──
+            // Automation owns the lifecycle only through "Exported"; the
+            // post-export columns are advanced by hand by the administrator, so
+            // never overwrite a card already sitting in one (except on close),
+            // and fail closed if the status read fails while setting "Exported".
+            const { currentStatus, readFailed } = await readStatusWithRetry(
+              () => github.graphql(`
+                query($itemId: ID!) {
+                  node(id: $itemId) { ... on ProjectV2Item {
+                    fieldValueByName(name: "Status") {
+                      ... on ProjectV2ItemFieldSingleSelectValue { name }
+                    }
+                  } }
+                }
+              `, { itemId }),
+              { onError: (attempt, e) => core.warning(`Could not read current board status (attempt ${attempt}/2): ${e.message}`) },
+            );
+            if (shouldSkipSync(currentStatus, targetStatus, readFailed)) {
+              if (currentStatus) {
+                console.log(`Card is in admin-owned column "${currentStatus}"; leaving placement to the administrator.`);
+              } else {
+                core.warning('Status read failed while about to set "Exported"; skipping to avoid clobbering a manual placement.');
               }
-            }
-            if (currentStatus && ADMIN_OWNED.has(currentStatus) && targetStatus !== 'Closed') {
-              console.log(`Card is in admin-owned column "${currentStatus}"; leaving placement to the administrator.`);
-              return;
-            }
-            // Fail closed: if the status read failed we cannot tell whether the
-            // card is in an admin-owned column, so never risk pulling it back
-            // to "Exported".
-            if (readFailed && targetStatus === 'Exported') {
-              core.warning('Status read failed while about to set "Exported"; skipping to avoid clobbering a manual placement.');
               return;
             }
 

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -23,39 +23,21 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { parseIssueForm } = _lib('parse.js');
+            const { validateMentors, validateUpstreamUrl } = _lib('validate.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const body = context.payload.issue.body || '';
 
-            // ── Inline issue-form parser ──
-            // Splits on ### headings, returns { label: value } map
-            function parseIssueForm(body) {
-              const fields = {};
-              const sections = body.split(/^### +/m).slice(1);
-              for (const section of sections) {
-                const nl = section.indexOf('\n');
-                if (nl === -1) continue;
-                const label = section.slice(0, nl).trim();
-                let value = section.slice(nl + 1).trim();
-                if (value === '_No response_') value = '';
-                fields[label] = value;
-              }
-              return fields;
-            }
-
+            // ── Issue-form parser (lib/parse.js): splits on ### headings ──
             const fields = parseIssueForm(body);
             const get = (k) => (fields[k] || '').trim();
 
             const errors = [];
             const warnings = [];
             const passed = [];
-
-            // ── Helper regexes ──
-            const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-            const urlRe = /^https?:\/\/\S+$/;
-            const ghHandleRe = /^@[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
-            // LF Username (LFID): a single token, no spaces, '@', or URL slashes.
-            const lfidRe = /^[^\s@/]+$/;
 
             // ── 1. CNCF Project ──
             const project = get('CNCF Project');
@@ -124,87 +106,59 @@ jobs:
               passed.push(skillsSame ? 'Skills: same as Technologies' : `Skills: ${skills}`);
             }
 
-            // ── 7. Mentors — pipe-separated, one per line ──
+            // ── 7. Mentors — pipe-separated, one per line (decisions in lib/validate.js) ──
             const mentorsRaw = get('Mentors');
-            if (!mentorsRaw) {
-              errors.push('Mentors field is empty. At least one mentor (primary) is required.');
-            } else {
-              const mentorLines = mentorsRaw.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
-              const handles = new Set();
-              const emails = new Set();
-              const lfids = new Set();
-              let mentorOk = true;
-
-              if (mentorLines.length > 4) {
-                errors.push(`Too many mentors: ${mentorLines.length} listed, but the maximum is 4 (primary plus up to 3 co-mentors). Please remove the extras.`);
-                mentorOk = false;
-              }
-
-              for (let i = 0; i < mentorLines.length; i++) {
-                const line = mentorLines[i];
-                const parts = line.split('|').map(p => p.trim());
-                const role = i === 0 ? 'Primary mentor' : `Mentor ${i + 1}`;
-
-                if (parts.length !== 3 && parts.length !== 4) {
-                  errors.push(`${role}: expected 3 or 4 pipe-separated fields (Name | @handle | email | LFID), got ${parts.length} in: \`${line}\``);
-                  mentorOk = false;
-                  continue;
-                }
-
-                const [name, handle, email, lfid] = parts;
-
-                if (!name) {
-                  errors.push(`${role}: name is empty.`);
-                  mentorOk = false;
-                }
-
-                if (!ghHandleRe.test(handle)) {
-                  errors.push(`${role}: handle \`${handle}\` doesn't match \`@username\` format.`);
-                  mentorOk = false;
-                }
-
-                if (!emailRe.test(email)) {
-                  errors.push(`${role}: email \`${email}\` doesn't look valid.`);
-                  mentorOk = false;
-                }
-
-                if (handles.has(handle.toLowerCase())) {
-                  errors.push(`${role}: duplicate handle \`${handle}\`.`);
-                  mentorOk = false;
-                }
-                handles.add(handle.toLowerCase());
-
-                if (emails.has(email.toLowerCase())) {
-                  errors.push(`${role}: duplicate email \`${email}\`.`);
-                  mentorOk = false;
-                }
-                emails.add(email.toLowerCase());
-
-                if (!lfid) {
-                  errors.push(`${role}: LFID (LF Username) is missing. You can add it later by editing this issue, but every mentor's LFID is required before the proposal can pass validation and be added to LFX.`);
-                  mentorOk = false;
-                } else if (!lfidRe.test(lfid)) {
-                  errors.push(`${role}: LFID \`${lfid}\` doesn't look like an LF Username (no spaces, @, or URL; e.g. \`janedoe\`).`);
-                  mentorOk = false;
-                } else if (lfids.has(lfid.toLowerCase())) {
-                  errors.push(`${role}: duplicate LFID \`${lfid}\`.`);
-                  mentorOk = false;
-                }
-                if (lfid) lfids.add(lfid.toLowerCase());
-              }
-
-              if (mentorOk) {
-                passed.push(`Mentors: ${mentorLines.length} listed (primary: ${mentorLines[0].split('|')[0].trim()})`);
+            const mentorResult = validateMentors(mentorsRaw);
+            for (const e of mentorResult.errors) {
+              switch (e.code) {
+                case 'empty':
+                  errors.push('Mentors field is empty. At least one mentor (primary) is required.');
+                  break;
+                case 'too-many':
+                  errors.push(`Too many mentors: ${e.count} listed, but the maximum is 4 (primary plus up to 3 co-mentors). Please remove the extras.`);
+                  break;
+                case 'count':
+                  errors.push(`${e.role}: expected 3 or 4 pipe-separated fields (Name | @handle | email | LFID), got ${e.got} in: \`${e.line}\``);
+                  break;
+                case 'name':
+                  errors.push(`${e.role}: name is empty.`);
+                  break;
+                case 'handle':
+                  errors.push(`${e.role}: handle \`${e.value}\` doesn't match \`@username\` format.`);
+                  break;
+                case 'email':
+                  errors.push(`${e.role}: email \`${e.value}\` doesn't look valid.`);
+                  break;
+                case 'dup-handle':
+                  errors.push(`${e.role}: duplicate handle \`${e.value}\`.`);
+                  break;
+                case 'dup-email':
+                  errors.push(`${e.role}: duplicate email \`${e.value}\`.`);
+                  break;
+                case 'lfid-missing':
+                  errors.push(`${e.role}: LFID (LF Username) is missing. You can add it later by editing this issue, but every mentor's LFID is required before the proposal can pass validation and be added to LFX.`);
+                  break;
+                case 'lfid-format':
+                  errors.push(`${e.role}: LFID \`${e.value}\` doesn't look like an LF Username (no spaces, @, or URL; e.g. \`janedoe\`).`);
+                  break;
+                case 'dup-lfid':
+                  errors.push(`${e.role}: duplicate LFID \`${e.value}\`.`);
+                  break;
               }
             }
+            if (mentorResult.ok) {
+              const primaryName = mentorsRaw.split(/\r?\n/).map(l => l.trim()).filter(Boolean)[0].split('|')[0].trim();
+              passed.push(`Mentors: ${mentorResult.count} listed (primary: ${primaryName})`);
+            }
 
-            // ── 8. Upstream Issue URL ──
+            // ── 8. Upstream Issue URL (decisions in lib/validate.js) ──
             const upstreamUrl = get('Upstream Issue URL');
-            if (!upstreamUrl) {
+            const upstreamErr = validateUpstreamUrl(upstreamUrl);
+            if (upstreamErr === 'empty') {
               errors.push('Upstream Issue URL is empty.');
-            } else if (!urlRe.test(upstreamUrl)) {
+            } else if (upstreamErr === 'format') {
               errors.push(`Upstream Issue URL \`${upstreamUrl}\` is not a valid URL.`);
-            } else if (upstreamUrl.includes(' ') || upstreamUrl.includes(',')) {
+            } else if (upstreamErr === 'multiple') {
               errors.push('Upstream Issue URL should be exactly one URL. If the program spans multiple issues, create an umbrella issue.');
             } else {
               passed.push(`Upstream Issue URL: ${upstreamUrl}`);
@@ -452,6 +406,9 @@ jobs:
             // cncf/mentoring (prod) run identical code. The board's Status
             // column names must match the lifecycle stages used below.
             const fs = require('fs');
+            const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { determineStatus, shouldSkipSync, readStatusWithRetry } = _lib('board.js');
             const _board = JSON.parse(fs.readFileSync('programs/lfx-mentorship/automation/board.json', 'utf8'));
             const _envCfg = (_board.environments || {})[process.env.GITHUB_REPOSITORY];
             if (!_envCfg || !_envCfg.projectId || String(_envCfg.projectId).startsWith('REPLACE_')) {
@@ -482,16 +439,10 @@ jobs:
 
             if (!labels.includes('lfx mentorship') || !labels.includes('Proposal')) return;
 
-            let status = 'Inbox';
             // Automation owns the lifecycle only through "Exported"; the
-            // post-export columns are manual admin moves (see board guard below).
-            if (labels.includes('Exported'))                         status = 'Exported';
-            else if (labels.includes('CNCF Approved'))               status = 'CNCF Approved';
-            else if (labels.includes('Maintainer/Contribex Approved')
-                     && labels.includes('Mentors Confirmed'))        status = 'Approved/confirmed';
-            else if (labels.includes('Awaiting Maintainer/Contribex Approval')
-                     || labels.includes('Awaiting Mentor Confirmation'))
-                                                                     status = 'Awaiting approvals/confirmations';
+            // post-export columns are manual admin moves (see board guard below
+            // and lib/board.js). This workflow never runs on close.
+            const status = determineStatus(labels, null);
 
             const optionId = STATUS_OPTIONS[status];
             if (!optionId) {
@@ -507,45 +458,29 @@ jobs:
             `, { projectId: PROJECT_ID, contentId: issue.node_id });
             const itemId = addResult.addProjectV2ItemById.item.id;
 
-            // ── Respect manual admin moves ──
-            // Automation owns the lifecycle only through "Exported". The
-            // post-export columns are advanced by hand, so never overwrite a
-            // card already sitting in one of them.
-            const ADMIN_OWNED = new Set([
-              'Posted to LFX', 'LFX Approved', 'Mentors added',
-              'Open for Applications', 'Applications Closed',
-            ]);
-            let currentStatus = null;
-            let readFailed = false;
-            for (let attempt = 1; attempt <= 2; attempt++) {
-              try {
-                const _cur = await github.graphql(`
-                  query($itemId: ID!) {
-                    node(id: $itemId) { ... on ProjectV2Item {
-                      fieldValueByName(name: "Status") {
-                        ... on ProjectV2ItemFieldSingleSelectValue { name }
-                      }
-                    } }
-                  }
-                `, { itemId });
-                currentStatus = _cur?.node?.fieldValueByName?.name || null;
-                readFailed = false;
-                break;
-              } catch (e) {
-                readFailed = true;
-                core.warning(`Could not read current board status (attempt ${attempt}/2): ${e.message}`);
-                if (attempt < 2) await new Promise(r => setTimeout(r, 1000));
+            // ── Respect manual admin moves (guard logic in lib/board.js) ──
+            // Automation owns the lifecycle only through "Exported"; the
+            // post-export columns are advanced by hand by the administrator, so
+            // never overwrite a card already sitting in one, and fail closed if
+            // the status read fails while setting "Exported".
+            const { currentStatus, readFailed } = await readStatusWithRetry(
+              () => github.graphql(`
+                query($itemId: ID!) {
+                  node(id: $itemId) { ... on ProjectV2Item {
+                    fieldValueByName(name: "Status") {
+                      ... on ProjectV2ItemFieldSingleSelectValue { name }
+                    }
+                  } }
+                }
+              `, { itemId }),
+              { onError: (attempt, e) => core.warning(`Could not read current board status (attempt ${attempt}/2): ${e.message}`) },
+            );
+            if (shouldSkipSync(currentStatus, status, readFailed)) {
+              if (currentStatus) {
+                console.log(`Card is in admin-owned column "${currentStatus}"; leaving placement to the administrator.`);
+              } else {
+                core.warning('Status read failed while about to set "Exported"; skipping to avoid clobbering a manual placement.');
               }
-            }
-            if (currentStatus && ADMIN_OWNED.has(currentStatus) && status !== 'Closed') {
-              console.log(`Card is in admin-owned column "${currentStatus}"; leaving placement to the administrator.`);
-              return;
-            }
-            // Fail closed: if the status read failed we cannot tell whether the
-            // card is in an admin-owned column, so never risk pulling it back
-            // to "Exported".
-            if (readFailed && status === 'Exported') {
-              core.warning('Status read failed while about to set "Exported"; skipping to avoid clobbering a manual placement.');
               return;
             }
 

--- a/programs/lfx-mentorship/automation/lib/board.js
+++ b/programs/lfx-mentorship/automation/lib/board.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// Project-board status logic shared by all four LFX proposal workflows.
+//
+// Automation owns the proposal lifecycle only through "Exported". The
+// post-export columns are advanced by hand by the administrator, so they are
+// listed in ADMIN_OWNED and never overwritten by automation (except to reflect
+// a closed issue). Extracted from lfx-proposal-board-sync.yml (status cascade +
+// sync guard + status read retry) and lfx-export.yml (export guard).
+
+const ADMIN_OWNED = new Set([
+  'Posted to LFX',
+  'LFX Approved',
+  'Mentors added',
+  'Open for Applications',
+  'Applications Closed',
+]);
+
+// Map issue labels (and the triggering action) to the target board status.
+// A closed issue always maps to "Closed"; otherwise the status is derived from
+// labels, advancing only as far as "Exported".
+function determineStatus(labels, action) {
+  if (action === 'closed') return 'Closed';
+  if (labels.includes('Exported')) return 'Exported';
+  if (labels.includes('CNCF Approved')) return 'CNCF Approved';
+  if (labels.includes('Maintainer/Contribex Approved') && labels.includes('Mentors Confirmed')) {
+    return 'Approved/confirmed';
+  }
+  if (labels.includes('Awaiting Maintainer/Contribex Approval')
+      || labels.includes('Awaiting Mentor Confirmation')) {
+    return 'Awaiting approvals/confirmations';
+  }
+  return 'Inbox';
+}
+
+// Sync guard (board-sync / validate / approvals): skip the board write when the
+// card already sits in an admin-owned column (unless the issue just closed), or
+// when the status read failed and we are about to set "Exported" (fail closed,
+// so a transient read error never pulls a manually-placed card back).
+function shouldSkipSync(currentStatus, targetStatus, readFailed) {
+  if (currentStatus && ADMIN_OWNED.has(currentStatus) && targetStatus !== 'Closed') return true;
+  if (readFailed && targetStatus === 'Exported') return true;
+  return false;
+}
+
+// Export guard: the export loop always targets "Exported", so skip whenever the
+// card is admin-owned or the status read failed.
+function shouldSkipExport(currentStatus, readFailed) {
+  if (currentStatus && ADMIN_OWNED.has(currentStatus)) return true;
+  if (readFailed) return true;
+  return false;
+}
+
+// Read the card's current Status with a small retry. readFn(attempt) is called
+// with the 1-based attempt number and must resolve to the GraphQL node shape
+// ({ node: { fieldValueByName: { name } } }); on every attempt throwing,
+// readFailed is true. onError(attempt, err), when given, is called for each
+// failed attempt (used to preserve the workflows' per-attempt warning logs).
+// The sleep is injectable so tests need not wait.
+async function readStatusWithRetry(readFn, { attempts = 2, delayMs = 1000, sleep, onError } = {}) {
+  const wait = sleep || ((ms) => new Promise(r => setTimeout(r, ms)));
+  let currentStatus = null;
+  let readFailed = false;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const _cur = await readFn(attempt);
+      currentStatus = _cur?.node?.fieldValueByName?.name || null;
+      readFailed = false;
+      break;
+    } catch (e) {
+      readFailed = true;
+      if (onError) onError(attempt, e);
+      if (attempt < attempts) await wait(delayMs);
+    }
+  }
+  return { currentStatus, readFailed };
+}
+
+module.exports = {
+  ADMIN_OWNED,
+  determineStatus,
+  shouldSkipSync,
+  shouldSkipExport,
+  readStatusWithRetry,
+};

--- a/programs/lfx-mentorship/automation/lib/confirm.js
+++ b/programs/lfx-mentorship/automation/lib/confirm.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// Per-mentor confirmation tally for the `/confirm` handler in
+// lfx-proposal-approvals.yml. The Mentor Confirmation gate flips only once
+// EVERY listed mentor has confirmed. Confirmations are gathered from the
+// issue's comment history (plus the current commenter) and compared to the
+// roster.
+//
+// mentorHandles: GitHub handles parsed from the Mentors field (with or without
+//   a leading '@'); deduplicated and lower-cased here.
+// commenter: the login of the mentor issuing this `/confirm`.
+// comments: prior issue comments, each { user: { login }, body }.
+//
+// A comment counts as a confirmation only when its author is on the roster and
+// a line in its body starts with `/confirm` (mid-sentence mentions do not
+// count).
+function computeConfirm(mentorHandles, commenter, comments) {
+  const roster = [...new Set(mentorHandles.map(h => h.replace(/^@/, '').toLowerCase()))];
+  const confirmed = new Set([commenter.toLowerCase()]);
+  const hasConfirm = (body) => (body || '').split(/\r?\n/)
+    .some(l => /^\/confirm\b/.test(l.trim()));
+  for (const c of comments) {
+    const author = (c.user?.login || '').toLowerCase();
+    if (roster.includes(author) && hasConfirm(c.body)) confirmed.add(author);
+  }
+  const remaining = roster.filter(h => !confirmed.has(h));
+  return { flip: remaining.length === 0, remaining, count: confirmed.size, total: roster.length };
+}
+
+module.exports = { computeConfirm };

--- a/programs/lfx-mentorship/automation/lib/csv.js
+++ b/programs/lfx-mentorship/automation/lib/csv.js
@@ -1,0 +1,44 @@
+'use strict';
+
+// CSV helpers used by the LFX proposal workflows.
+//
+//   - parseCsvLine: quote-aware row parser, lifted verbatim from
+//     lfx-proposal-approvals.yml. A quoted comma (e.g. "Chainguard, Inc")
+//     must not shift later columns, or the maintainer-auth lookup would read
+//     the wrong GitHub-handle column and reject a real maintainer.
+//   - csvEscape: field quoter for the export tracking CSV, adapted from
+//     lfx-export.yml. One deliberate change from the original `|| ''`: it
+//     uses `?? ''`, so a falsy-but-valid 0 serializes as "0" rather than "".
+//     Unreachable today (validation requires a primary mentor); hardened for
+//     safety and covered by csv.test.js.
+
+// Parse one CSV row into an array of fields, honouring double-quoted fields
+// and "" escaping inside them.
+function parseCsvLine(row) {
+  const out = [];
+  let cur = '', inQuotes = false;
+  for (let i = 0; i < row.length; i++) {
+    const ch = row[i];
+    if (inQuotes) {
+      if (ch === '"' && row[i + 1] === '"') { cur += '"'; i++; }
+      else if (ch === '"') { inQuotes = false; }
+      else { cur += ch; }
+    } else if (ch === '"') { inQuotes = true; }
+    else if (ch === ',') { out.push(cur); cur = ''; }
+    else { cur += ch; }
+  }
+  out.push(cur);
+  return out;
+}
+
+// Quote a CSV field when it contains a comma, quote, or newline; escapes
+// embedded quotes by doubling them.
+function csvEscape(val) {
+  const s = String(val ?? '');
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+module.exports = { parseCsvLine, csvEscape };

--- a/programs/lfx-mentorship/automation/lib/notify.js
+++ b/programs/lfx-mentorship/automation/lib/notify.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// Logic for the LFX Export Merge Notify workflow, extracted as pure functions
+// so it can be unit-tested while the workflow's side effects stay thin.
+
+// Extract the issue numbers the export workflow records in the PR body as
+// "- #<n> — <name>" (emitted by lfx-export.yml). The em-dash (U+2014) is a
+// functional delimiter: this regex must match the line format lfx-export.yml
+// emits, so changing that output means changing this too. Returns an array of
+// numbers (order preserved, no de-dup).
+function parseExportedIssueNumbers(body) {
+  return [...String(body || '').matchAll(/-\s+#(\d+)\s+—/g)].map(m => parseInt(m[1], 10));
+}
+
+// True when ref is a branch the export workflow created. Guards the
+// destructive branch delete so only automation/lfx-export-* branches are
+// removed, mirroring the workflow's job-level scope.
+function isExportBranch(ref) {
+  return typeof ref === 'string' && ref.startsWith('automation/lfx-export-');
+}
+
+module.exports = { parseExportedIssueNumbers, isExportBranch };

--- a/programs/lfx-mentorship/automation/lib/parse.js
+++ b/programs/lfx-mentorship/automation/lib/parse.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// Issue-form parsing shared by the LFX proposal workflows.
+//
+// Extracted verbatim from the inline `github-script` blocks so the workflows
+// can `require()` a single source of truth instead of copy-pasting it:
+//   - parseIssueForm:  lfx-proposal-validate.yml, lfx-export.yml,
+//                      lfx-proposal-approvals.yml (three identical copies)
+//   - parseCheckboxes: lfx-export.yml
+//   - parseMentors:    lfx-export.yml
+
+// Split a GitHub issue-form body into a { label: value } map. Sections are
+// delimited by "### <label>" headings; "_No response_" is normalised to ''.
+function parseIssueForm(body) {
+  const fields = {};
+  for (const section of body.split(/^### +/m).slice(1)) {
+    const nl = section.indexOf('\n');
+    if (nl === -1) continue;
+    const label = section.slice(0, nl).trim();
+    let value = section.slice(nl + 1).trim();
+    if (value === '_No response_') value = '';
+    fields[label] = value;
+  }
+  return fields;
+}
+
+// Return the labels of the checked items from a checkbox field's raw value.
+function parseCheckboxes(raw) {
+  if (!raw) return [];
+  return raw.split('\n')
+    .filter(l => /- \[.\]/.test(l))
+    .filter(l => /- \[x\]/i.test(l))
+    .map(l => l.replace(/^- \[.\]\s*/, '').trim());
+}
+
+// Parse the pipe-separated Mentors field into structured mentor objects. Lines
+// with 3 or 4 fields are kept (LFID is the optional 4th); any other field count
+// drops the line. Role is by position: the first non-empty line is primary, the
+// rest co-mentors (a malformed first line is a blocking validation error upstream).
+function parseMentors(raw) {
+  if (!raw) return [];
+  return raw.split(/\r?\n/)
+    .map(l => l.trim())
+    .filter(Boolean)
+    .map((line, i) => {
+      const parts = line.split('|').map(p => p.trim());
+      if (parts.length !== 3 && parts.length !== 4) return null;
+      return {
+        name: parts[0],
+        github_handle: parts[1].replace(/^@/, ''),
+        email: parts[2],
+        lfid: parts[3] || '',
+        role: i === 0 ? 'primary' : 'co-mentor',
+      };
+    })
+    .filter(Boolean);
+}
+
+module.exports = { parseIssueForm, parseCheckboxes, parseMentors };

--- a/programs/lfx-mentorship/automation/lib/readme.js
+++ b/programs/lfx-mentorship/automation/lib/readme.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// Term README assembly for the LFX export, extracted from lfx-export.yml.
+//
+// The export preserves the term frontmatter (title, timeline, project and
+// application instructions) up to and including the first horizontal rule,
+// then regenerates only the body (Table of Contents + Accepted Projects)
+// below it. This keeps a re-export idempotent and never wipes the hand-written
+// term timeline. When the term README has no frontmatter yet, a minimal header
+// is synthesised. The fs read/write stays in the workflow; this is the pure
+// string assembly.
+function buildReadme(existingReadme, bodyLines, readmeTitle) {
+  const sep = existingReadme ? existingReadme.match(/^---[ \t]*$/m) : null;
+  let header;
+  if (sep) {
+    header = existingReadme.slice(0, sep.index + sep[0].length) + '\n\n';
+  } else {
+    header = [
+      `# ${readmeTitle}`,
+      '',
+      'Status: Planning',
+      '',
+      'Mentorship duration - three months (full-time schedule)',
+      '',
+      '---',
+      '',
+      '',
+    ].join('\n');
+  }
+  return header + bodyLines.join('\n') + '\n';
+}
+
+module.exports = { buildReadme };

--- a/programs/lfx-mentorship/automation/lib/slug.js
+++ b/programs/lfx-mentorship/automation/lib/slug.js
@@ -1,0 +1,18 @@
+'use strict';
+
+// Markdown anchor slug helper, lifted verbatim from lfx-export.yml. Used to
+// build the README Table of Contents links from project and program names.
+//
+// Note: this captures the current behaviour exactly, including the quirk that
+// leading/trailing spaces become hyphens (whitespace is converted to '-'
+// before the final trim, which only removes whitespace). The known duplicate-
+// anchor issue is a separate, deliberate behaviour change, not done here.
+function slugify(text) {
+  return text.toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+}
+
+module.exports = { slugify };

--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// Field validation shared by the LFX proposal workflows.
+//
+// The regexes are lifted verbatim from lfx-proposal-validate.yml. validateMentors
+// and validateUpstreamUrl capture the decision logic of that workflow's mentor
+// loop (validate.yml mentor block) and Upstream Issue URL check as pure
+// functions that return structured error codes (presentation stays in the
+// workflow). Error codes, not prose, are the stable contract.
+
+const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const urlRe = /^https?:\/\/\S+$/;
+const ghHandleRe = /^@[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+// LF Username (LFID): a single token, no spaces, '@', or URL slashes.
+const lfidRe = /^[^\s@/]+$/;
+
+// Validate the Mentors field (pipe-separated, one mentor per line).
+// Returns { ok, count, errors }, where each error is { role, code, ... }.
+// Codes: 'empty', 'too-many', 'count', 'name', 'handle', 'email',
+//        'dup-handle', 'dup-email', 'lfid-missing', 'lfid-format', 'dup-lfid'.
+function validateMentors(raw) {
+  const errors = [];
+  if (!raw || !raw.trim()) {
+    errors.push({ role: null, code: 'empty' });
+    return { ok: false, count: 0, errors };
+  }
+
+  const lines = raw.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  if (lines.length > 4) {
+    errors.push({ role: null, code: 'too-many', count: lines.length });
+  }
+
+  const handles = new Set();
+  const emails = new Set();
+  const lfids = new Set();
+
+  lines.forEach((line, i) => {
+    const role = i === 0 ? 'Primary mentor' : `Mentor ${i + 1}`;
+    const parts = line.split('|').map(p => p.trim());
+
+    if (parts.length !== 3 && parts.length !== 4) {
+      errors.push({ role, code: 'count', got: parts.length, line });
+      return;
+    }
+
+    const [name, handle, email, lfid] = parts;
+
+    if (!name) errors.push({ role, code: 'name' });
+    if (!ghHandleRe.test(handle)) errors.push({ role, code: 'handle', value: handle });
+    if (!emailRe.test(email)) errors.push({ role, code: 'email', value: email });
+
+    if (handles.has(handle.toLowerCase())) errors.push({ role, code: 'dup-handle', value: handle });
+    handles.add(handle.toLowerCase());
+
+    if (emails.has(email.toLowerCase())) errors.push({ role, code: 'dup-email', value: email });
+    emails.add(email.toLowerCase());
+
+    if (!lfid) {
+      errors.push({ role, code: 'lfid-missing' });
+    } else if (!lfidRe.test(lfid)) {
+      errors.push({ role, code: 'lfid-format', value: lfid });
+    } else if (lfids.has(lfid.toLowerCase())) {
+      errors.push({ role, code: 'dup-lfid', value: lfid });
+    }
+    if (lfid) lfids.add(lfid.toLowerCase());
+  });
+
+  return { ok: errors.length === 0, count: lines.length, errors };
+}
+
+// Validate the Upstream Issue URL field. Returns a single error code or null.
+// Codes: 'empty', 'format', 'multiple'.
+function validateUpstreamUrl(raw) {
+  const url = (raw || '').trim();
+  if (!url) return 'empty';
+  if (!urlRe.test(url)) return 'format';
+  if (url.includes(',')) return 'multiple';
+  return null;
+}
+
+module.exports = {
+  emailRe,
+  urlRe,
+  ghHandleRe,
+  lfidRe,
+  validateMentors,
+  validateUpstreamUrl,
+};

--- a/programs/lfx-mentorship/automation/test/board.test.js
+++ b/programs/lfx-mentorship/automation/test/board.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  determineStatus, shouldSkipSync, shouldSkipExport, readStatusWithRetry,
+} = require('../lib/board');
+
+test('determineStatus: empty labels map to Inbox', () => {
+  assert.equal(determineStatus([]), 'Inbox');
+});
+
+test('determineStatus: a closed issue always maps to Closed', () => {
+  assert.equal(determineStatus(['Exported'], 'closed'), 'Closed');
+  assert.equal(determineStatus([], 'closed'), 'Closed');
+});
+
+test('determineStatus: the label cascade stops at Exported', () => {
+  assert.equal(determineStatus(['Exported', 'CNCF Approved']), 'Exported');
+  assert.equal(determineStatus(['CNCF Approved']), 'CNCF Approved');
+  assert.equal(
+    determineStatus(['Maintainer/Contribex Approved', 'Mentors Confirmed']),
+    'Approved/confirmed',
+  );
+  assert.equal(determineStatus(['Awaiting Mentor Confirmation']), 'Awaiting approvals/confirmations');
+  assert.equal(determineStatus(['Awaiting Maintainer/Contribex Approval']), 'Awaiting approvals/confirmations');
+});
+
+test('determineStatus: admin-only and flag labels do not drive the cascade', () => {
+  assert.equal(determineStatus(['Posted to LFX', 'Exported', 'CNCF Approved']), 'Exported');
+  assert.equal(determineStatus(['Mentors Registered', 'Exported']), 'Exported');
+});
+
+test('shouldSkipSync: protects admin-owned columns except on close', () => {
+  assert.equal(shouldSkipSync('Posted to LFX', 'Exported', false), true);
+  assert.equal(shouldSkipSync('Mentors added', 'CNCF Approved', false), true);
+  assert.equal(shouldSkipSync('Posted to LFX', 'Closed', false), false);
+});
+
+test('shouldSkipSync: non-admin statuses proceed when the read succeeded', () => {
+  assert.equal(shouldSkipSync('CNCF Approved', 'Exported', false), false);
+  assert.equal(shouldSkipSync(null, 'Awaiting approvals/confirmations', false), false);
+  assert.equal(shouldSkipSync(null, 'Exported', false), false);
+});
+
+test('shouldSkipSync: fails closed only when about to set Exported after a read failure', () => {
+  assert.equal(shouldSkipSync(null, 'Exported', true), true);
+  assert.equal(shouldSkipSync(null, 'Awaiting approvals/confirmations', true), false);
+  assert.equal(shouldSkipSync(null, 'CNCF Approved', true), false);
+  assert.equal(shouldSkipSync(null, 'Closed', true), false);
+  assert.equal(shouldSkipSync('Posted to LFX', 'Exported', true), true);
+});
+
+test('shouldSkipExport: skips admin-owned cards or any read failure', () => {
+  assert.equal(shouldSkipExport('Posted to LFX', false), true);
+  assert.equal(shouldSkipExport('Exported', false), false);
+  assert.equal(shouldSkipExport(null, false), false);
+  assert.equal(shouldSkipExport(null, true), true);
+  assert.equal(shouldSkipExport('Exported', true), true);
+});
+
+const node = (name) => ({ node: { fieldValueByName: name === null ? null : { name } } });
+const noSleep = { sleep: async () => {} };
+
+test('readStatusWithRetry: returns the status on a first-attempt success', async () => {
+  const r = await readStatusWithRetry(() => node('Posted to LFX'), noSleep);
+  assert.deepEqual(r, { currentStatus: 'Posted to LFX', readFailed: false });
+});
+
+test('readStatusWithRetry: recovers on the second attempt', async () => {
+  const r = await readStatusWithRetry((attempt) => {
+    if (attempt === 1) throw new Error('transient');
+    return node('Exported');
+  }, noSleep);
+  assert.deepEqual(r, { currentStatus: 'Exported', readFailed: false });
+});
+
+test('readStatusWithRetry: both attempts failing sets readFailed', async () => {
+  const r = await readStatusWithRetry(() => { throw new Error('boom'); }, noSleep);
+  assert.deepEqual(r, { currentStatus: null, readFailed: true });
+});
+
+test('readStatusWithRetry: a fresh card with no status reads as null, not failed', async () => {
+  const r = await readStatusWithRetry(() => node(null), noSleep);
+  assert.deepEqual(r, { currentStatus: null, readFailed: false });
+});
+
+test('readStatusWithRetry: onError is called once per failed attempt', async () => {
+  const seen = [];
+  const r = await readStatusWithRetry(() => { throw new Error('boom'); }, {
+    ...noSleep,
+    onError: (attempt, err) => seen.push([attempt, err.message]),
+  });
+  assert.deepEqual(r, { currentStatus: null, readFailed: true });
+  assert.deepEqual(seen, [[1, 'boom'], [2, 'boom']]);
+});

--- a/programs/lfx-mentorship/automation/test/confirm.test.js
+++ b/programs/lfx-mentorship/automation/test/confirm.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { computeConfirm } = require('../lib/confirm');
+
+test('the first of three mentors confirming does not flip the gate', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b', 'c'], 'a', []),
+    { flip: false, remaining: ['b', 'c'], count: 1, total: 3 },
+  );
+});
+
+test('the last mentor completing the roster flips the gate', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b', 'c'], 'c', [
+      { user: { login: 'a' }, body: '/confirm' },
+      { user: { login: 'b' }, body: 'sure thing\n/confirm' },
+    ]),
+    { flip: true, remaining: [], count: 3, total: 3 },
+  );
+});
+
+test('a single mentor confirming flips immediately', () => {
+  assert.deepEqual(
+    computeConfirm(['solo'], 'solo', []),
+    { flip: true, remaining: [], count: 1, total: 1 },
+  );
+});
+
+test('a non-mentor /confirm is ignored', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'a', [{ user: { login: 'randouser' }, body: '/confirm' }]),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('duplicate roster handles are deduped', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'A', 'b'], 'a', []),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('a bot comment quoting /confirm does not count (author not on roster)', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'a', [
+      { user: { login: 'github-actions[bot]' }, body: 'Use `/confirm` to confirm participation.' },
+    ]),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('author matching is case-insensitive', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'b', [{ user: { login: 'A' }, body: '/confirm' }]),
+    { flip: true, remaining: [], count: 2, total: 2 },
+  );
+});
+
+test('a mid-sentence /confirm does not count as a prior confirmation', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'a', [{ user: { login: 'b' }, body: 'I will /confirm later' }]),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('@-prefixed roster handles are normalized', () => {
+  assert.deepEqual(
+    computeConfirm(['@a', '@b'], 'a', []),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});

--- a/programs/lfx-mentorship/automation/test/csv.test.js
+++ b/programs/lfx-mentorship/automation/test/csv.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseCsvLine, csvEscape } = require('../lib/csv');
+
+// Columns: Maturity, Project, Name, Company, GitHub, OWNERS (handle = cols[4]).
+
+test('parseCsvLine: a plain row splits on commas', () => {
+  assert.deepEqual(
+    parseCsvLine(',Kubernetes steering,Antonio Ojea,Google,aojea,https://git.k8s.io/steering#members'),
+    ['', 'Kubernetes steering', 'Antonio Ojea', 'Google', 'aojea', 'https://git.k8s.io/steering#members'],
+  );
+});
+
+test('parseCsvLine: a quoted comma does not shift the handle column', () => {
+  const row = ',Kubernetes maintainers,Adolfo García Veytia,"Carabiner Systems, Inc",puerco,';
+  assert.equal(parseCsvLine(row)[4], 'puerco');
+  assert.equal(parseCsvLine(row)[1], 'Kubernetes maintainers');
+  assert.equal(parseCsvLine(',,Carlos Tadeu Panato Jr.,"Chainguard, Inc",cpanato,')[4], 'cpanato');
+});
+
+test('parseCsvLine: escaped double-quotes inside a quoted field', () => {
+  const moris = parseCsvLine(',,"Satoshi ""Moris"" Tagomori",,tagomoris,');
+  assert.equal(moris[2], 'Satoshi "Moris" Tagomori');
+  assert.equal(moris[4], 'tagomoris');
+});
+
+test('parseCsvLine: a naive split would have mislabeled the handle (regression contrast)', () => {
+  const bugRow = ',Kubernetes maintainers,Adolfo García Veytia,"Carabiner Systems, Inc",puerco,';
+  assert.notEqual(bugRow.split(',')[4], 'puerco');
+  assert.equal(parseCsvLine(bugRow)[4], 'puerco');
+});
+
+test('csvEscape: leaves a plain value untouched', () => {
+  assert.equal(csvEscape('plain'), 'plain');
+});
+
+test('csvEscape: quotes values containing comma, quote, or newline', () => {
+  assert.equal(csvEscape('has,comma'), '"has,comma"');
+  assert.equal(csvEscape('has "quote"'), '"has ""quote"""');
+  assert.equal(csvEscape('line\nbreak'), '"line\nbreak"');
+});
+
+test('csvEscape: coerces null/undefined to empty and numbers to strings', () => {
+  assert.equal(csvEscape(null), '');
+  assert.equal(csvEscape(undefined), '');
+  assert.equal(csvEscape(5), '5');
+  assert.equal(csvEscape(0), '0');
+});

--- a/programs/lfx-mentorship/automation/test/notify.test.js
+++ b/programs/lfx-mentorship/automation/test/notify.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseExportedIssueNumbers, isExportBranch } = require('../lib/notify');
+
+// parseExportedIssueNumbers extracts the issue numbers the export workflow
+// writes into the PR body as "- #<n> — <name>". The em-dash (U+2014) is a
+// functional delimiter shared with lfx-export.yml: it must match exactly.
+test('parseExportedIssueNumbers: single issue', () => {
+  assert.deepEqual(
+    parseExportedIssueNumbers('- #29 — CNCF - OpenTelemetry: Testing (2026 Term 3)'),
+    [29]
+  );
+});
+
+test('parseExportedIssueNumbers: multiple issues across lines', () => {
+  const body = '**Exported proposals:**\n- #12 — Foo\n- #34 — Bar\n';
+  assert.deepEqual(parseExportedIssueNumbers(body), [12, 34]);
+});
+
+test('parseExportedIssueNumbers: empty string yields none', () => {
+  assert.deepEqual(parseExportedIssueNumbers(''), []);
+});
+
+test('parseExportedIssueNumbers: null/undefined yields none', () => {
+  assert.deepEqual(parseExportedIssueNumbers(null), []);
+  assert.deepEqual(parseExportedIssueNumbers(undefined), []);
+});
+
+test('parseExportedIssueNumbers: only the em-dash delimiter matches', () => {
+  // hyphen-minus and en-dash must not be treated as the delimiter
+  assert.deepEqual(parseExportedIssueNumbers('- #5 - Foo'), []);
+  assert.deepEqual(parseExportedIssueNumbers('- #5 \u2013 Foo'), []);
+});
+
+test('parseExportedIssueNumbers: requires the leading list dash', () => {
+  assert.deepEqual(parseExportedIssueNumbers('#7 — no leading dash'), []);
+});
+
+test('parseExportedIssueNumbers: does not de-duplicate (captures current behaviour)', () => {
+  assert.deepEqual(parseExportedIssueNumbers('- #5 — A\n- #5 — A again'), [5, 5]);
+});
+
+// isExportBranch guards the destructive branch delete: only branches the
+// export workflow creates (automation/lfx-export-*) may be removed.
+test('isExportBranch: true for an export branch', () => {
+  assert.equal(isExportBranch('automation/lfx-export-2026-03-Sep-Nov'), true);
+});
+
+test('isExportBranch: true for the bare prefix', () => {
+  assert.equal(isExportBranch('automation/lfx-export-'), true);
+});
+
+test('isExportBranch: false for other automation branches', () => {
+  assert.equal(isExportBranch('automation/landscape-sync'), false);
+});
+
+test('isExportBranch: false for main and unrelated branches', () => {
+  assert.equal(isExportBranch('main'), false);
+  assert.equal(isExportBranch('feature/x'), false);
+});
+
+test('isExportBranch: false for empty or non-string input', () => {
+  assert.equal(isExportBranch(''), false);
+  assert.equal(isExportBranch(undefined), false);
+  assert.equal(isExportBranch(null), false);
+  assert.equal(isExportBranch(42), false);
+});

--- a/programs/lfx-mentorship/automation/test/parse.test.js
+++ b/programs/lfx-mentorship/automation/test/parse.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseIssueForm, parseCheckboxes, parseMentors } = require('../lib/parse');
+
+test('parseIssueForm: splits ### sections into a label->value map', () => {
+  const body = [
+    '### CNCF Project', '', 'Kubernetes', '',
+    '### Program Description', '', 'Do cool things.', '',
+  ].join('\n');
+  assert.deepEqual(parseIssueForm(body), {
+    'CNCF Project': 'Kubernetes',
+    'Program Description': 'Do cool things.',
+  });
+});
+
+test('parseIssueForm: _No response_ becomes empty string', () => {
+  const body = '### Skills same as Technologies?\n\n_No response_';
+  assert.equal(parseIssueForm(body)['Skills same as Technologies?'], '');
+});
+
+test('parseIssueForm: a heading with no following newline is skipped', () => {
+  assert.deepEqual(parseIssueForm('### Solo'), {});
+});
+
+test('parseIssueForm: values are trimmed', () => {
+  assert.equal(parseIssueForm('### A\n\n   spaced   ')['A'], 'spaced');
+});
+
+test('parseCheckboxes: keeps only checked items, stripping the box', () => {
+  const raw = '- [x] Resume\n- [ ] Cover letter\n- [X] Sample PR\nnot a checkbox';
+  assert.deepEqual(parseCheckboxes(raw), ['Resume', 'Sample PR']);
+});
+
+test('parseCheckboxes: empty input yields empty array', () => {
+  assert.deepEqual(parseCheckboxes(''), []);
+});
+
+test('parseMentors: a 4-field line yields lfid and strips @', () => {
+  assert.deepEqual(
+    parseMentors('Jane Doe | @janedoe | jane@example.com | janedoe'),
+    [{ name: 'Jane Doe', github_handle: 'janedoe', email: 'jane@example.com', lfid: 'janedoe', role: 'primary' }],
+  );
+});
+
+test('parseMentors: roles are assigned primary then co-mentor', () => {
+  const roles = parseMentors(
+    'Jane Doe | @janedoe | jane@example.com | janedoe\n' +
+    'Sam Lee | @samlee | sam@example.com | samlee',
+  ).map(m => m.role);
+  assert.deepEqual(roles, ['primary', 'co-mentor']);
+});
+
+test('parseMentors: a 3-field line is kept with empty lfid (LFID optional)', () => {
+  assert.deepEqual(
+    parseMentors('Jane Doe | @janedoe | jane@example.com'),
+    [{ name: 'Jane Doe', github_handle: 'janedoe', email: 'jane@example.com', lfid: '', role: 'primary' }],
+  );
+});
+
+test('parseMentors: lines with 2 or 5 fields are dropped', () => {
+  assert.deepEqual(parseMentors('Jane Doe | @janedoe'), []);
+  assert.deepEqual(parseMentors('Jane | @j | j@x.com | jlfid | extra'), []);
+});
+
+test('parseMentors: lfid is captured distinct from the github handle', () => {
+  assert.equal(parseMentors('A B | @abhandle | a@b.com | a-b-lfid')[0].lfid, 'a-b-lfid');
+});
+
+test('parseMentors: empty input yields empty array', () => {
+  assert.deepEqual(parseMentors(''), []);
+});

--- a/programs/lfx-mentorship/automation/test/readme.test.js
+++ b/programs/lfx-mentorship/automation/test/readme.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { buildReadme } = require('../lib/readme');
+
+const TITLE = 'Term 03 - 2026 September - November';
+
+const stub = `# Term 03 - 2026 September - November
+
+Status: Planning
+
+Mentorship duration - three months (full-time schedule)
+
+### Timeline
+
+| Activity | Dates (2026) |
+|----------|--------------|
+| Project Proposals Open | Wed, Jul 1 - Tue, Jul 28 |
+| Last Day of Term | Fri, Nov 27 |
+
+### Project instructions
+
+Project maintainers ... submitting a PR ... project_ideas.md, by July 28, 2026.
+
+### Application instructions
+
+Mentee application instructions can be found on the Program Guidelines page.
+
+---
+
+
+`;
+
+const body = [
+  '## Table of Contents', '',
+  '- [OpenTelemetry](#opentelemetry)', '',
+  '## Accepted Projects', '',
+  '### OpenTelemetry', '', '#### Some program', '',
+];
+
+test('buildReadme: preserves term frontmatter and appends the generated body', () => {
+  const out = buildReadme(stub, body, TITLE);
+  assert.match(out, /### Timeline/);
+  assert.match(out, /\| Last Day of Term \| Fri, Nov 27 \|/);
+  assert.match(out, /### Project instructions/);
+  assert.match(out, /### Application instructions/);
+  assert.match(out, /## Table of Contents/);
+  assert.match(out, /## Accepted Projects/);
+  assert.ok(out.indexOf('---') < out.indexOf('## Table of Contents'));
+  assert.equal((out.match(/^# Term 03/m) || []).length, 1);
+});
+
+test('buildReadme: re-export is idempotent (no duplicated frontmatter or TOC)', () => {
+  const first = buildReadme(stub, body, TITLE);
+  const second = buildReadme(first, body, TITLE);
+  assert.equal((second.match(/### Timeline/g) || []).length, 1);
+  assert.equal((second.match(/## Table of Contents/g) || []).length, 1);
+  assert.equal((second.match(/### Project instructions/g) || []).length, 1);
+  assert.equal(second, first);
+});
+
+test('buildReadme: a README with no --- rule falls back to a minimal header', () => {
+  const out = buildReadme('# Old\n\nsome stuff no rule\n', body, TITLE);
+  assert.ok(out.startsWith(`# ${TITLE}`));
+  assert.match(out, /Status: Planning/);
+  assert.match(out, /---/);
+  assert.match(out, /## Table of Contents/);
+});
+
+test('buildReadme: no existing README falls back to a minimal header', () => {
+  const out = buildReadme(null, body, TITLE);
+  assert.ok(out.startsWith(`# ${TITLE}`));
+  assert.match(out, /## Accepted Projects/);
+});

--- a/programs/lfx-mentorship/automation/test/slug.test.js
+++ b/programs/lfx-mentorship/automation/test/slug.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { slugify } = require('../lib/slug');
+
+test('slugify: lowercases a single word', () => {
+  assert.equal(slugify('OpenTelemetry'), 'opentelemetry');
+});
+
+test('slugify: spaces become single hyphens', () => {
+  assert.equal(slugify('Hello World'), 'hello-world');
+});
+
+test('slugify: punctuation is dropped', () => {
+  assert.equal(slugify('Foo: Bar!'), 'foo-bar');
+});
+
+test('slugify: runs of hyphens collapse to one', () => {
+  assert.equal(slugify('a---b'), 'a-b');
+});
+
+test('slugify: underscores are preserved (word characters)', () => {
+  assert.equal(slugify('Underscore_keep'), 'underscore_keep');
+});
+
+// Characterization of two known quirks of the current implementation (not
+// fixed here): surrounding whitespace becomes leading/trailing hyphens, and
+// non-ASCII letters are stripped. Documented so a future deliberate change is
+// an obvious diff.
+test('slugify: surrounding whitespace becomes hyphens (current quirk)', () => {
+  assert.equal(slugify('  pad  '), '-pad-');
+});
+
+test('slugify: non-ASCII letters are stripped (current quirk)', () => {
+  assert.equal(slugify('Café'), 'caf');
+});

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  emailRe, urlRe, ghHandleRe, lfidRe,
+  validateMentors, validateUpstreamUrl,
+} = require('../lib/validate');
+
+const codes = (result) => result.errors.map(e => e.code);
+
+test('validateMentors: a full valid 4-field line passes with no errors', () => {
+  assert.deepEqual(
+    validateMentors('Jane Doe | @janedoe | jane@example.com | janedoe'),
+    { ok: true, count: 1, errors: [] },
+  );
+});
+
+test('validateMentors: empty field flags "empty"', () => {
+  assert.deepEqual(validateMentors(''), { ok: false, count: 0, errors: [{ role: null, code: 'empty' }] });
+  assert.deepEqual(validateMentors('   '), { ok: false, count: 0, errors: [{ role: null, code: 'empty' }] });
+});
+
+test('validateMentors: a 3-field line flags missing LFID (optional at submit, required to pass)', () => {
+  assert.deepEqual(
+    validateMentors('Jane Doe | @janedoe | jane@example.com').errors,
+    [{ role: 'Primary mentor', code: 'lfid-missing' }],
+  );
+});
+
+test('validateMentors: a 4-field line with empty trailing LFID also flags missing', () => {
+  assert.deepEqual(codes(validateMentors('Jane Doe | @janedoe | jane@example.com | ')), ['lfid-missing']);
+});
+
+test('validateMentors: wrong field counts flag "count" and skip the line', () => {
+  assert.deepEqual(codes(validateMentors('Jane Doe | @janedoe')), ['count']);
+  assert.deepEqual(codes(validateMentors('Jane | @j | j@x.com | jlfid | extra')), ['count']);
+});
+
+test('validateMentors: the "count" error carries the offending line for the message', () => {
+  const e = validateMentors('Jane Doe | @janedoe').errors[0];
+  assert.equal(e.code, 'count');
+  assert.equal(e.got, 2);
+  assert.equal(e.line, 'Jane Doe | @janedoe');
+});
+
+test('validateMentors: a malformed LFID (URL) flags "lfid-format"', () => {
+  assert.deepEqual(
+    codes(validateMentors('Jane Doe | @janedoe | jane@example.com | https://openprofile.dev/profile/janedoe')),
+    ['lfid-format'],
+  );
+});
+
+test('validateMentors: bad handle and email are both flagged on one line', () => {
+  const result = validateMentors('Jane Doe | janedoe | not-an-email | janedoe');
+  assert.deepEqual(codes(result), ['handle', 'email']);
+  assert.deepEqual(result.errors.map(e => e.role), ['Primary mentor', 'Primary mentor']);
+});
+
+test('validateMentors: more than four mentors flags "too-many" but still checks lines', () => {
+  const five = Array.from({ length: 5 }, (_, i) => `M${i} | @m${i} | m${i}@x.com | lf${i}`).join('\n');
+  const result = validateMentors(five);
+  assert.equal(result.count, 5);
+  assert.ok(result.errors.some(e => e.code === 'too-many' && e.count === 5));
+});
+
+test('validateMentors: duplicate handle, email, and LFID are each flagged on the later line', () => {
+  const dupHandle = validateMentors('A | @dup | a@x.com | la\nB | @dup | b@x.com | lb');
+  assert.ok(dupHandle.errors.some(e => e.code === 'dup-handle' && e.role === 'Mentor 2'));
+
+  const dupEmail = validateMentors('A | @a | same@x.com | la\nB | @b | same@x.com | lb');
+  assert.ok(dupEmail.errors.some(e => e.code === 'dup-email' && e.role === 'Mentor 2'));
+
+  const dupLfid = validateMentors('A | @a | a@x.com | shared\nB | @b | b@x.com | shared');
+  assert.ok(dupLfid.errors.some(e => e.code === 'dup-lfid' && e.role === 'Mentor 2'));
+});
+
+test('validateUpstreamUrl: classifies empty, malformed, multiple, and valid', () => {
+  assert.equal(validateUpstreamUrl(''), 'empty');
+  assert.equal(validateUpstreamUrl('not a url'), 'format');
+  // A comma with no whitespace passes the URL regex, then trips the single-URL check.
+  assert.equal(validateUpstreamUrl('https://example.com/a,https://example.com/b'), 'multiple');
+  assert.equal(validateUpstreamUrl('https://github.com/cncf/mentoring/issues/1'), null);
+});
+
+test('validateUpstreamUrl: whitespace fails the URL regex first (format, not multiple)', () => {
+  // urlRe requires \S+$, so any space yields "format" before the single-URL check.
+  assert.equal(validateUpstreamUrl('https://example.com/a, https://example.com/b'), 'format');
+});
+
+test('lfidRe: accepts plain usernames and dot/dash/underscore', () => {
+  assert.equal(lfidRe.test('janedoe'), true);
+  assert.equal(lfidRe.test('jane.doe-1_x'), true);
+});
+
+test('lfidRe: rejects empty, spaces, emails, and URLs', () => {
+  assert.equal(lfidRe.test(''), false);
+  assert.equal(lfidRe.test('jane doe'), false);
+  assert.equal(lfidRe.test('jane@example.com'), false);
+  assert.equal(lfidRe.test('https://openprofile.dev/profile/janedoe'), false);
+});
+
+test('emailRe / ghHandleRe / urlRe: basic accept and reject', () => {
+  assert.equal(emailRe.test('jane@example.com'), true);
+  assert.equal(emailRe.test('jane@example'), false);
+  assert.equal(ghHandleRe.test('@jane-doe'), true);
+  assert.equal(ghHandleRe.test('jane'), false);
+  assert.equal(urlRe.test('https://example.com/x'), true);
+  assert.equal(urlRe.test('ftp://example.com'), false);
+});


### PR DESCRIPTION
## Background

The LFX proposal intake system (#1884) shipped with all logic inline in the
workflow YAML. This promotes the dev-fork rewire that extracts that logic into a
tested Node library, plus one shipped feature.

## What changed

- **Logic extracted to `programs/lfx-mentorship/automation/lib/*.js`.** The five
  proposal workflows (validate, approvals, export, board-sync, merge-notify) now
  `require()` small, single-purpose modules instead of carrying inline scripts.
  Net: +1215 / -422.
- **79 unit tests** (`node --test`) cover form parsing, mentor/LFID validation,
  CSV assembly, board-status rules, the `/confirm` tally, README assembly, and
  the merge-notify PR parser. A new `lfx-automation-tests.yml` runs them on any
  change to the lib or the workflows that depend on it.
- **Feature: merged `chore: LFX export` PRs auto-delete their
  `automation/lfx-export-*` branch.** merge-notify gains `contents: write` and a
  guarded `deleteRef` step.

The extraction is behavior-preserving; the only behavior change is the branch
auto-delete.

## Verification

Exercised end-to-end in the dev fork (`nate-double-u/mentoring`) against live
issues:

| Path | Result |
| --- | --- |
| Happy path: validate, approvals, export, merge-notify | pass |
| Missing-LFID validation gate (fails, then passes on edit) | pass |
| Export, merge-notify stamp, branch auto-delete | pass |

All 79 tests green locally.

## Notes for reviewers

- No changes to `settings.yml` labels, the issue template, or `board.json`; those
  are already current on `main`.
- Consolidates fork PRs https://github.com/nate-double-u/mentoring/issues/28 (refactor) and https://github.com/nate-double-u/mentoring/issues/28 (auto-delete) into one
  promotion commit.
- `lfx-automation-tests.yml` is new, so it will not run on this PR (Actions uses
  the base branch's workflow set). It starts running on the push to `main` at
  merge and on every PR after.
