### PR TITLE
fix: keep projects.yml date stable when project list is unchanged

### DIFF
--- a/.github/workflows/landscape-projects-sync.yml
+++ b/.github/workflows/landscape-projects-sync.yml
@@ -116,7 +116,12 @@ jobs:
           except FileNotFoundError:
               existing = None
           with open(projects_path, "w", encoding="utf-8") as f:
-              f.write(render(body, len(projects), date.today().isoformat(), existing))
+              f.write(render(
+                  body,
+                  total=len(projects),
+                  today=date.today().isoformat(),
+                  existing=existing,
+              ))
 
           # ── Update issue form dropdown ──
           form_path = ".github/ISSUE_TEMPLATE/lfx-program-proposal.yml"

--- a/.github/workflows/landscape-projects-sync.yml
+++ b/.github/workflows/landscape-projects-sync.yml
@@ -102,14 +102,20 @@ jobs:
           print(f"Checked {len(checked_orgs)} orgs, {dot_count} have .project repos")
 
           # ── Write projects.yml ──
-          header = (
-              f"# Auto-generated from cncf/landscape — DO NOT EDIT MANUALLY.\n"
-              f"# Last updated: {date.today().isoformat()}\n"
-              f"# Total projects: {len(projects)}\n\n"
-          )
-          with open("programs/lfx-mentorship/automation/projects.yml", "w") as f:
-              f.write(header)
-              yaml.dump(projects, f, default_flow_style=False, sort_keys=False)
+          # Render via the tested helper so the "Last updated" date only moves
+          # when the project list actually changes. Otherwise the weekly run
+          # would diff on the date line alone and open a spurious PR.
+          sys.path.insert(0, "programs/lfx-mentorship/automation/lib")
+          from projects_yml import render
+
+          projects_path = "programs/lfx-mentorship/automation/projects.yml"
+          body = yaml.dump(projects, default_flow_style=False, sort_keys=False)
+          try:
+              existing = open(projects_path, encoding="utf-8").read()
+          except FileNotFoundError:
+              existing = None
+          with open(projects_path, "w", encoding="utf-8") as f:
+              f.write(render(body, len(projects), date.today().isoformat(), existing))
 
           # ── Update issue form dropdown ──
           form_path = ".github/ISSUE_TEMPLATE/lfx-program-proposal.yml"

--- a/.github/workflows/landscape-projects-sync.yml
+++ b/.github/workflows/landscape-projects-sync.yml
@@ -111,7 +111,8 @@ jobs:
           projects_path = "programs/lfx-mentorship/automation/projects.yml"
           body = yaml.dump(projects, default_flow_style=False, sort_keys=False)
           try:
-              existing = open(projects_path, encoding="utf-8").read()
+              with open(projects_path, encoding="utf-8") as f:
+                  existing = f.read()
           except FileNotFoundError:
               existing = None
           with open(projects_path, "w", encoding="utf-8") as f:

--- a/.github/workflows/lfx-automation-tests.yml
+++ b/.github/workflows/lfx-automation-tests.yml
@@ -1,9 +1,10 @@
 name: LFX Automation Tests
 
 # Unit tests for the LFX proposal automation logic (form parsing, mentor/LFID
-# validation, CSV handling, board status rules, the /confirm tally, and README
-# assembly) extracted into programs/lfx-mentorship/automation/lib. Runs on any
-# change to that logic or to the workflows that depend on it.
+# validation, CSV handling, board status rules, the /confirm tally, README
+# assembly, and the projects.yml sync render) in
+# programs/lfx-mentorship/automation/lib. Runs on any change to that logic or
+# to the workflows that depend on it.
 
 on:
   pull_request:
@@ -16,6 +17,7 @@ on:
       - '.github/workflows/lfx-proposal-board-sync.yml'
       - '.github/workflows/lfx-export.yml'
       - '.github/workflows/lfx-export-merge-notify.yml'
+      - '.github/workflows/landscape-projects-sync.yml'
   push:
     branches: [main]
     paths:
@@ -27,6 +29,7 @@ on:
       - '.github/workflows/lfx-proposal-board-sync.yml'
       - '.github/workflows/lfx-export.yml'
       - '.github/workflows/lfx-export-merge-notify.yml'
+      - '.github/workflows/landscape-projects-sync.yml'
 
 permissions:
   contents: read
@@ -46,3 +49,12 @@ jobs:
       - name: Run automation unit tests
         working-directory: programs/lfx-mentorship/automation
         run: node --test
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run Python unit tests
+        working-directory: programs/lfx-mentorship/automation
+        run: python -m unittest discover -s test -p 'test_*.py'

--- a/programs/lfx-mentorship/automation/.gitignore
+++ b/programs/lfx-mentorship/automation/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/programs/lfx-mentorship/automation/lib/projects_yml.py
+++ b/programs/lfx-mentorship/automation/lib/projects_yml.py
@@ -1,0 +1,43 @@
+"""Render the auto-generated projects.yml for the landscape sync workflow.
+
+Pure, dependency-free helper so the date-handling logic is unit-testable
+outside the inline-Python workflow that calls it.
+
+The header carries a "Last updated" date. Because the landscape sync runs on a
+schedule, writing today's date on every run produces a one-line diff (and a
+spurious PR) even when the project list is unchanged. `render` preserves the
+prior date when only that line would change, so the date moves only when the
+project list (or its count) actually changes.
+"""
+
+import re
+
+_DATE_LINE = re.compile(r"^# Last updated: .*$", re.MULTILINE)
+
+
+def _header(total, date_str):
+    return (
+        "# Auto-generated from cncf/landscape — DO NOT EDIT MANUALLY.\n"
+        f"# Last updated: {date_str}\n"
+        f"# Total projects: {total}\n\n"
+    )
+
+
+def _ignore_date(text):
+    return _DATE_LINE.sub("# Last updated:", text)
+
+
+def render(body, total, today, existing=None):
+    """Return the projects.yml content to write.
+
+    body:     the YAML-dumped project list (no header).
+    total:    project count for the header.
+    today:    ISO date string to use when the content actually changed.
+    existing: current file content on disk, or None if the file is absent.
+    """
+    new_content = _header(total, today) + body
+    if existing is not None and _ignore_date(existing) == _ignore_date(new_content):
+        # Only the date would change, so keep the file byte-identical: the
+        # sync then produces no diff and no spurious PR.
+        return existing
+    return new_content

--- a/programs/lfx-mentorship/automation/test/test_projects_yml.py
+++ b/programs/lfx-mentorship/automation/test/test_projects_yml.py
@@ -1,0 +1,62 @@
+"""Unit tests for the projects.yml render helper used by the
+landscape-projects-sync workflow.
+
+Run from programs/lfx-mentorship/automation:
+    python3 -m unittest discover -s test -p 'test_*.py'
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "lib")
+)
+
+from projects_yml import render  # noqa: E402
+
+BODY = (
+    "- name: Aeraki Mesh\n"
+    "  slug: aerakimesh\n"
+    "  maturity: sandbox\n"
+)
+
+
+class RenderProjectsYmlTest(unittest.TestCase):
+    def test_first_write_uses_today(self):
+        out = render(BODY, total=1, today="2026-06-29", existing=None)
+        self.assertIn("# Last updated: 2026-06-29\n", out)
+        self.assertIn("# Total projects: 1\n", out)
+        self.assertTrue(out.endswith(BODY))
+
+    def test_body_unchanged_preserves_old_date(self):
+        existing = render(BODY, total=1, today="2026-06-25", existing=None)
+        out = render(BODY, total=1, today="2026-06-29", existing=existing)
+        # Nothing but the date would change, so keep the file byte-identical
+        # (old date, no diff, no spurious PR).
+        self.assertEqual(out, existing)
+        self.assertIn("# Last updated: 2026-06-25\n", out)
+
+    def test_body_changed_bumps_date(self):
+        existing = render(BODY, total=1, today="2026-06-25", existing=None)
+        new_body = BODY + (
+            "- name: Argo\n"
+            "  slug: argo\n"
+            "  maturity: graduated\n"
+        )
+        out = render(new_body, total=2, today="2026-06-29", existing=existing)
+        self.assertIn("# Last updated: 2026-06-29\n", out)
+        self.assertIn("# Total projects: 2\n", out)
+        self.assertTrue(out.endswith(new_body))
+
+    def test_count_change_alone_bumps_date(self):
+        # The total-projects line is meaningful content, not ignored like the
+        # date line: a count change must bump the date.
+        existing = render(BODY, total=1, today="2026-06-25", existing=None)
+        out = render(BODY, total=99, today="2026-06-29", existing=existing)
+        self.assertIn("# Last updated: 2026-06-29\n", out)
+        self.assertIn("# Total projects: 99\n", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The weekly landscape sync rewrote the "Last updated" date every run, diffing on that line alone and opening spurious PRs (e.g. #1900). Render via a tested helper that preserves the date unless the list changes.

Assisted-by: Copilot <223556219+Copilot@users.noreply.github.com>