### PR TITLE
Add LFC102 as a standard mentee prerequisite

### DIFF
--- a/.github/ISSUE_TEMPLATE/lfx-program-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/lfx-program-proposal.yml
@@ -458,3 +458,16 @@ body:
         - label: "Yes — completion of this task requires the mentee to submit a file."
           required: false
 
+  # ── Standard mentee prerequisite: LFC102 (informational, not an input) ──
+  # LFC102 is a standing CNCF requirement injected onto every program by the
+  # export from programs/lfx-mentorship/automation/lib/prerequisites.js. Surfaced
+  # here so mentors know mentees will be expected to complete it; it is not a
+  # field they configure.
+  - type: markdown
+    attributes:
+      value: |
+        > **Every accepted mentee must complete [Inclusive Open Source Community Orientation (LFC102)](https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/).**
+        > This is a standing CNCF requirement added to every program
+        > automatically, so you do not need to configure it. Mentees
+        > upload their completion certificate on the LFX platform.
+

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -32,6 +32,7 @@ jobs:
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
             const { parseIssueForm, parseCheckboxes, parseMentors } = _lib('parse.js');
+            const { standardPrerequisites } = _lib('prerequisites.js');
             const { slugify } = _lib('slug.js');
             const { buildReadme } = _lib('readme.js');
             const { csvEscape } = _lib('csv.js');
@@ -129,6 +130,7 @@ jobs:
                     description: get('Custom Prerequisite Description') || null,
                     file_upload: !!customFileUpload,
                   } : null,
+                  standard_courses: standardPrerequisites(),
                 },
               });
             }

--- a/programs/lfx-mentorship/automation/lib/prerequisites.js
+++ b/programs/lfx-mentorship/automation/lib/prerequisites.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// Standing, org-wide mentee prerequisites injected onto every LFX program.
+//
+// Per cncf/mentoring#1866 every accepted mentee must complete LFC102 (Inclusive
+// Open Source Community Orientation). This is CNCF policy, uniform across every
+// program in a term, and is not authored by maintainers.
+//
+// An LFX prerequisite exposes exactly four fields: name (<=20 chars), a due
+// date, a description, and a "requires file upload" flag. The course URL is
+// carried inline in the description (LFX has no URL field). The due date is
+// term-wide and stamped at upload time, so it is intentionally absent here.
+// The export imports this object today; the Phase 2 upload will import it too,
+// so the LFC102 copy is defined once in code. The proposal form shows its own
+// hardcoded note describing this requirement; GitHub issue forms can't import a
+// JS constant, so that copy is maintained separately in
+// .github/ISSUE_TEMPLATE/lfx-program-proposal.yml.
+const INCLUSIVE_COMMUNITY = {
+  name: 'Inclusive Community',
+  description:
+    'Please upload the completion certificate for the Inclusive Open Source ' +
+    'Community Orientation (LFC102) course: ' +
+    'https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/\n\n' +
+    'Once completed you can find the certificate in your openprofile.dev ' +
+    'dashboard under Training & Certifications -> Certificates of Completion.',
+  file_upload: true,
+};
+
+// Returns the prerequisites added to every program automatically. Fresh copies
+// are returned so callers cannot mutate the shared constant.
+function standardPrerequisites() {
+  return [{ ...INCLUSIVE_COMMUNITY }];
+}
+
+module.exports = { INCLUSIVE_COMMUNITY, standardPrerequisites };

--- a/programs/lfx-mentorship/automation/test/prerequisites.test.js
+++ b/programs/lfx-mentorship/automation/test/prerequisites.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { INCLUSIVE_COMMUNITY, standardPrerequisites } = require('../lib/prerequisites');
+
+// The exact, admin-provided LFC102 description (cncf/mentoring#1866). Kept
+// verbatim on purpose: this test fails loudly if the copy is ever paraphrased.
+const VERBATIM_DESCRIPTION =
+  'Please upload the completion certificate for the Inclusive Open Source ' +
+  'Community Orientation (LFC102) course: ' +
+  'https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/\n\n' +
+  'Once completed you can find the certificate in your openprofile.dev ' +
+  'dashboard under Training & Certifications -> Certificates of Completion.';
+
+test('INCLUSIVE_COMMUNITY: name is the verbatim LFX prerequisite name', () => {
+  assert.equal(INCLUSIVE_COMMUNITY.name, 'Inclusive Community');
+});
+
+test('INCLUSIVE_COMMUNITY: name fits the LFX 20-character limit', () => {
+  assert.ok(INCLUSIVE_COMMUNITY.name.length <= 20);
+});
+
+test('INCLUSIVE_COMMUNITY: description is the verbatim LFC102 copy with URL inline', () => {
+  assert.equal(INCLUSIVE_COMMUNITY.description, VERBATIM_DESCRIPTION);
+});
+
+test('INCLUSIVE_COMMUNITY: requires a file upload', () => {
+  assert.equal(INCLUSIVE_COMMUNITY.file_upload, true);
+});
+
+test('INCLUSIVE_COMMUNITY: exposes only the fields LFX can store', () => {
+  // LFX prerequisites have exactly four fields: name, due date, description,
+  // and a file-upload flag. The due date is term-wide (stamped at upload), so
+  // it is intentionally absent here; the course URL lives inside description.
+  assert.deepEqual(
+    Object.keys(INCLUSIVE_COMMUNITY).sort(),
+    ['description', 'file_upload', 'name'],
+  );
+});
+
+test('standardPrerequisites: returns Inclusive Community as the only standing prereq', () => {
+  const prereqs = standardPrerequisites();
+  assert.equal(prereqs.length, 1);
+  assert.equal(prereqs[0].name, 'Inclusive Community');
+});
+
+test('standardPrerequisites: returns fresh copies, not the shared constant', () => {
+  const first = standardPrerequisites();
+  first[0].name = 'MUTATED';
+  assert.equal(INCLUSIVE_COMMUNITY.name, 'Inclusive Community');
+  assert.equal(standardPrerequisites()[0].name, 'Inclusive Community');
+});


### PR DESCRIPTION
## Add LFC102 as a standard mentee prerequisite

Per #1866, every CNCF mentee must complete the Inclusive Open Source Community
Orientation ([LFC102](https://training.linuxfoundation.org/training/inclusive-open-source-community-orientation-lfc102/)).
This wires that standing requirement into the proposal intake and export.

### Changes
- **Form:** an informational note at the end of the proposal form's Prerequisites
  section tells maintainers LFC102 is added automatically. It is not a field they
  configure (GitHub issue forms can't pre-check or lock a box).
- **Export:** each program's `prerequisites.standard_courses` in the export JSON
  always includes the LFC102 task, materialized from a single lib constant
  (`programs/lfx-mentorship/automation/lib/prerequisites.js`). README and tracking
  CSV are unchanged.
- **Tests:** 7 new unit tests lock the verbatim copy and LFX's four-field shape
  (name, description, file-upload; no due date). Full suite 107/107.

The prerequisite due date is term-wide and stamped at upload (Phase 2), not on the
form.

Validated end to end on the dev fork: the form note renders, and a Term 3 export
produced the LFC102 entry in the JSON.

Assisted-by: Copilot <223556219+Copilot@users.noreply.github.com>
