### PR TITLE
Fix LFX /approve rejecting non-first project maintainers

### DIFF
--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -27,7 +27,7 @@ jobs:
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
             const { parseIssueForm } = _lib('parse.js');
-            const { parseCsvLine } = _lib('csv.js');
+            const { findMaintainerInCsv } = _lib('maintainers.js');
             const { computeConfirm } = _lib('confirm.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
@@ -203,7 +203,11 @@ jobs:
                 }
               }
 
-              // 2. Check cncf/foundation project-maintainers.csv
+              // 2. Check cncf/foundation project-maintainers.csv.
+              // The CSV is grouped: the Project column is set only on each
+              // group's first row, so the lookup forward-fills it before
+              // matching the handle. Extracted to lib/maintainers.js so the
+              // authorization decision is unit-tested (cncf/mentoring#1908).
               if (!authorized && project) {
                 try {
                   const resp = await fetch(
@@ -211,26 +215,10 @@ jobs:
                   );
                   if (resp.ok) {
                     const csv = await resp.text();
-                    // CSV columns: Maturity, Project, Name, Company, GitHub, OWNERS
-                    // Project column may include subgroup: "OpenTelemetry (Governance Committee)"
-                    // Maturity is only on the first row of each group; subsequent rows are empty.
-                    const normalProject = project.toLowerCase();
-                    // Minimal CSV line parser: respects quoted fields with
-                    // embedded commas and escaped double-quotes ("") so a comma
-                    // inside a value like "Chainguard, Inc" cannot shift the
-                    // GitHub-handle column and trigger a false auth rejection
-                    // (parser in lib/csv.js).
-                    for (const line of csv.split('\n').slice(1)) {
-                      if (!line.trim()) continue;
-                      const cols = parseCsvLine(line);
-                      const csvProject = (cols[1] || '').trim().toLowerCase();
-                      const csvGh = (cols[4] || '').trim().toLowerCase();
-                      if (csvGh === commenter.toLowerCase()
-                          && (csvProject.startsWith(normalProject) || csvProject.includes(normalProject))) {
-                        authorized = true;
-                        authSource = `project-maintainers.csv (${cols[1].trim()})`;
-                        break;
-                      }
+                    const hit = findMaintainerInCsv(csv, project, commenter);
+                    if (hit.authorized) {
+                      authorized = true;
+                      authSource = `project-maintainers.csv (${hit.project})`;
                     }
                   }
                 } catch (e) {

--- a/programs/lfx-mentorship/automation/lib/maintainers.js
+++ b/programs/lfx-mentorship/automation/lib/maintainers.js
@@ -1,0 +1,38 @@
+'use strict';
+
+// Maintainer authorization lookup against cncf/foundation's
+// project-maintainers.csv, used by the LFX proposal `/approve` check.
+//
+// Columns: 0 Maturity, 1 Project, 2 Name, 3 Company, 4 GitHub, 5 OWNERS.
+//
+// The CSV is grouped: the Maturity and Project columns are set only on the
+// FIRST maintainer row of each project (or subgroup); every following row in
+// the group leaves them blank. The Project cell may also carry a subgroup
+// label such as "OpenTelemetry (Governance Committee)", so a project matches
+// by prefix/substring rather than equality.
+const { parseCsvLine } = require('./csv.js');
+
+// Return { authorized, project } for whether `handle` is listed as a
+// maintainer of `project` in the CSV text. Matching is case-insensitive.
+function findMaintainerInCsv(csvText, project, handle) {
+  const wanted = String(project || '').trim().toLowerCase();
+  const who = String(handle || '').trim().toLowerCase();
+  if (!wanted || !who) return { authorized: false, project: '' };
+
+  let group = '';  // Project column, forward-filled from each group's first row
+  for (const line of String(csvText).split('\n').slice(1)) {
+    if (!line.trim()) continue;
+    const cols = parseCsvLine(line);
+    const rowProject = (cols[1] || '').trim();
+    if (rowProject) group = rowProject;  // new group header; blank rows inherit it
+    const rowHandle = (cols[4] || '').trim().toLowerCase();
+    if (!rowHandle) continue;
+    const p = group.toLowerCase();
+    if (rowHandle === who && (p.startsWith(wanted) || p.includes(wanted))) {
+      return { authorized: true, project: group };
+    }
+  }
+  return { authorized: false, project: '' };
+}
+
+module.exports = { findMaintainerInCsv };

--- a/programs/lfx-mentorship/automation/test/maintainers.test.js
+++ b/programs/lfx-mentorship/automation/test/maintainers.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { findMaintainerInCsv } = require('../lib/maintainers');
+
+// Mirrors the grouped shape of cncf/foundation/project-maintainers.csv:
+// Maturity and Project are set only on each group's first row; continuation
+// rows leave them blank. Columns: Maturity,Project,Name,Company,GitHub,OWNERS.
+const CSV = [
+  'Maturity,Project,Name,Company,GitHub,OWNERS',
+  'Graduated,Knative,Ali Ok,Red Hat,aliok,https://github.com/knative/community/blob/main/MAINTAINERS.md',
+  ',,Calum Murray,Red Hat,Cali0707,',
+  ',,Chris Suszynski,Red Hat,cardil,',
+  'Graduated,Kubernetes,Someone Steering,Google,steersperson,https://git.k8s.io/steering#members',
+  ',Kubernetes maintainers,Adolfo García Veytia,"Carabiner Systems, Inc",puerco,',
+  ',,Carlos Tadeu Panato Jr.,"Chainguard, Inc",cpanato,',
+].join('\n');
+
+test('authorizes a project group-header maintainer', () => {
+  const hit = findMaintainerInCsv(CSV, 'Knative', 'aliok');
+  assert.equal(hit.authorized, true);
+  assert.equal(hit.project, 'Knative');
+});
+
+test('authorizes a continuation-row maintainer (regression, #1908)', () => {
+  // These rows leave the Project column blank; they must inherit "Knative".
+  assert.equal(findMaintainerInCsv(CSV, 'Knative', 'Cali0707').authorized, true);
+  assert.equal(findMaintainerInCsv(CSV, 'Knative', 'cardil').authorized, true);
+});
+
+test('authorizes a subgroup-header maintainer with a quoted-comma company', () => {
+  // "Kubernetes maintainers" contains "kubernetes"; the quoted company must
+  // not shift the handle out of column 4.
+  assert.equal(findMaintainerInCsv(CSV, 'Kubernetes', 'puerco').authorized, true);
+});
+
+test('authorizes a continuation row under a subgroup (regression, #1908)', () => {
+  const hit = findMaintainerInCsv(CSV, 'Kubernetes', 'cpanato');
+  assert.equal(hit.authorized, true);
+  assert.equal(hit.project, 'Kubernetes maintainers');
+});
+
+test('matching is case-insensitive on handle and project', () => {
+  assert.equal(findMaintainerInCsv(CSV, 'Knative', 'ALIOK').authorized, true);
+  assert.equal(findMaintainerInCsv(CSV, 'knative', 'Cali0707').authorized, true);
+});
+
+test('rejects a handle absent from the CSV', () => {
+  assert.equal(findMaintainerInCsv(CSV, 'Knative', 'nobody').authorized, false);
+});
+
+test('does not leak a maintainer across group boundaries', () => {
+  // Forward-fill must reset at each new group header.
+  assert.equal(findMaintainerInCsv(CSV, 'Kubernetes', 'Cali0707').authorized, false);
+  assert.equal(findMaintainerInCsv(CSV, 'Knative', 'cpanato').authorized, false);
+});
+
+test('rejects on blank project or handle', () => {
+  assert.equal(findMaintainerInCsv(CSV, '', 'aliok').authorized, false);
+  assert.equal(findMaintainerInCsv(CSV, 'Knative', '').authorized, false);
+});


### PR DESCRIPTION
## What

`/approve` only authorized the *first-listed* maintainer of each project in
`cncf/foundation/project-maintainers.csv`. Every other maintainer of that
project was rejected.

## Why

The CSV is grouped — the Project column is set only on each group's first row;
continuation rows leave it blank. The tier-2 lookup matched per row, so a
maintainer whose row had a blank Project never matched. Repro: @Cali0707, a
Knative maintainer, was rejected on #1907.

## Change

- Forward-fill each group's Project down to its continuation rows.
- Extract the lookup from the workflow YAML into `lib/maintainers.js`, so the
  authorization decision is unit-tested — it had no coverage before.

## Validation

- 8 new unit tests (`test/maintainers.test.js`); full suite 115 pass.
- Live-CSV check: `Knative/Cali0707 → authorized`.
- Dev e2e (nate-double-u/mentoring): @Cali0707 `/approve` now authorized.

Fixes #1908.
