### PR TITLE
Refactor the LFX proposal workflows: extract inline logic into tested libs

### DIFF
--- a/.github/workflows/lfx-automation-tests.yml
+++ b/.github/workflows/lfx-automation-tests.yml
@@ -46,6 +46,12 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install test dependencies
+        # lib/maintainers.js parses maintainers.yaml with js-yaml.
+        # --ignore-scripts blocks dependency lifecycle scripts (js-yaml needs none).
+        working-directory: programs/lfx-mentorship/automation
+        run: npm install --no-save --ignore-scripts js-yaml@4.3.0
+
       - name: Run automation unit tests
         working-directory: programs/lfx-mentorship/automation
         run: node --test

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -36,6 +36,7 @@ jobs:
             const { slugify } = _lib('slug.js');
             const { buildReadme } = _lib('readme.js');
             const { csvEscape } = _lib('csv.js');
+            const { lookupProject } = _lib('projects.js');
             const { owner, repo } = context.repo;
             const term = context.payload.inputs.term;
 
@@ -63,20 +64,6 @@ jobs:
             // ── Load projects.yml for metadata ──
             const projYaml = fs.readFileSync('programs/lfx-mentorship/automation/projects.yml', 'utf8');
 
-            function getProjectMeta(projectName) {
-              const re = new RegExp(
-                `- name: ${projectName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\n` +
-                `[\\s\\S]*?(?=\\n- name:|$)`
-              );
-              const m = projYaml.match(re);
-              if (!m) return {};
-              const block = m[0];
-              const slug = (block.match(/slug:\s*(\S+)/) || [])[1] || '';
-              const maturity = (block.match(/maturity:\s*(\S+)/) || [])[1] || '';
-              const repoUrl = (block.match(/repo_url:\s*(\S+)/) || [])[1] || '';
-              return { slug, maturity, repo_url: repoUrl };
-            }
-
             // ── Build export records ──
             const programs = [];
             for (const iss of termIssues) {
@@ -100,7 +87,7 @@ jobs:
               const customFileUpload = (get('Custom Prerequisite — File Upload') || '')
                 .match(/\[x\]/i);
 
-              const meta = getProjectMeta(project);
+              const meta = lookupProject(projYaml, project) || {};
 
               programs.push({
                 issue_number: iss.number,

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -36,6 +36,7 @@ jobs:
             const { findMaintainerInCsv, isProjectMaintainer } = _lib('maintainers.js');
             const { computeConfirm } = _lib('confirm.js');
             const { lookupProject } = _lib('projects.js');
+            const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const comment = context.payload.comment;
@@ -214,48 +215,32 @@ jobs:
                       ghOrg.toLowerCase(),
                       projectSlug,
                     ].filter((v, i, a) => v && a.indexOf(v) === i);
-                    let section = '';
-                    for (const key of projectKeys) {
-                      const re = new RegExp(`^${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:`, 'im');
-                      const parts = raw.split(re);
-                      if (parts.length > 1) {
-                        section = parts[1].split(/^\S/m)[0];
-                        break;
-                      }
-                    }
+                    const section = getProjectSection(raw, projectKeys);
                     if (section) {
                       // Check fallback_handles
-                      const handleBlock = section.match(/fallback_handles:\s*\n((?:\s+-\s+\S+.*\n?)*)/);
-                      if (handleBlock) {
-                        const handles = [...handleBlock[1].matchAll(/-\s+(\S+)/g)].map(m => m[1].toLowerCase());
-                        if (handles.includes(commenter.toLowerCase())) {
-                          authorized = true;
-                          authSource = 'approvers.yml (fallback handle)';
-                        }
+                      if (getFallbackHandles(section).includes(commenter.toLowerCase())) {
+                        authorized = true;
+                        authSource = 'approvers.yml (fallback handle)';
                       }
                       // Check fallback_teams
                       if (!authorized) {
-                        const teamBlock = section.match(/fallback_teams:\s*\n((?:\s+-\s+\S+.*\n?)*)/);
-                        if (teamBlock) {
-                          const teams = [...teamBlock[1].matchAll(/-\s+(\S+)/g)].map(m => m[1]);
-                          for (const team of teams) {
-                            const [org, slug] = team.split('/');
-                            if (!org || !slug) continue;
-                            try {
-                              const { data } = await github.rest.teams.getMembershipForUserInOrg({
-                                org, team_slug: slug, username: commenter,
-                              });
-                              if (data.state === 'active') {
-                                authorized = true;
-                                authSource = `approvers.yml (team ${team})`;
-                                break;
-                              }
-                            } catch (e) {
-                              // Likely a cross-org team: the repo token can't read
-                              // membership outside this org, so the team authorizes
-                              // no one. Use fallback_handles for cross-org approvers.
-                              console.log(`Could not verify team ${team} for ${commenter}: ${e.message}`);
+                        for (const team of getFallbackTeams(section)) {
+                          const [org, slug] = team.split('/');
+                          if (!org || !slug) continue;
+                          try {
+                            const { data } = await github.rest.teams.getMembershipForUserInOrg({
+                              org, team_slug: slug, username: commenter,
+                            });
+                            if (data.state === 'active') {
+                              authorized = true;
+                              authSource = `approvers.yml (team ${team})`;
+                              break;
                             }
+                          } catch (e) {
+                            // Likely a cross-org team: the repo token can't read
+                            // membership outside this org, so the team authorizes
+                            // no one. Use fallback_handles for cross-org approvers.
+                            console.log(`Could not verify team ${team} for ${commenter}: ${e.message}`);
                           }
                         }
                       }
@@ -264,13 +249,9 @@ jobs:
 
                   // 3b. Global approvers: can /approve for any project
                   if (!authorized) {
-                    const globalBlock = raw.match(/global_approvers:\s*\n((?:\s+-\s+\S+.*\n?)*)/);
-                    if (globalBlock) {
-                      const globals = [...globalBlock[1].matchAll(/-\s+(\S+)/g)].map(m => m[1].toLowerCase());
-                      if (globals.includes(commenter.toLowerCase())) {
-                        authorized = true;
-                        authSource = 'approvers.yml (global approver)';
-                      }
+                    if (getGlobalApprovers(raw).includes(commenter.toLowerCase())) {
+                      authorized = true;
+                      authSource = 'approvers.yml (global approver)';
                     }
                   }
                 } catch (e) {
@@ -372,10 +353,7 @@ jobs:
               let admins = [];
               try {
                 const raw = fs.readFileSync('programs/lfx-mentorship/automation/approvers.yml', 'utf8');
-                const globalBlock = raw.match(/global_approvers:\s*\n((?:\s+-\s+\S+.*\n?)*)/);
-                if (globalBlock) {
-                  admins = [...globalBlock[1].matchAll(/-\s+(\S+)/g)].map(m => m[1].toLowerCase());
-                }
+                admins = getGlobalApprovers(raw);
               } catch (e) {
                 console.log(`Failed to read approvers.yml: ${e.message}`);
               }

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -32,7 +32,7 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
-            const { parseIssueForm } = _lib('parse.js');
+            const { parseIssueForm, parseMentors } = _lib('parse.js');
             const { findMaintainerInCsv, isProjectMaintainer } = _lib('maintainers.js');
             const { computeConfirm } = _lib('confirm.js');
             const { lookupProject } = _lib('projects.js');
@@ -298,19 +298,13 @@ jobs:
 
               // Authorization: commenter must be a listed mentor
               const mentorsRaw = get('Mentors');
-              const mentorLines = mentorsRaw.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
-              const mentorHandles = mentorLines
-                .map(line => {
-                  const parts = line.split('|').map(p => p.trim());
-                  return parts.length >= 2 ? parts[1].replace(/^@/, '').toLowerCase() : '';
-                })
-                .filter(Boolean);
+              const confirmHandles = parseMentors(mentorsRaw).map(m => m.github_handle.toLowerCase());
 
-              if (!mentorHandles.includes(commenter.toLowerCase())) {
+              if (!confirmHandles.includes(commenter.toLowerCase())) {
                 await reply('❌',
                   `@${commenter} is not listed as a mentor on this proposal.\n\n` +
                   `Only listed mentors can \`/confirm\`. ` +
-                  `Current mentors: ${mentorHandles.map(h => `@${h}`).join(', ') || '(none parsed)'}`);
+                  `Current mentors: ${confirmHandles.map(h => `@${h}`).join(', ') || '(none parsed)'}`);
                 return;
               }
 
@@ -326,7 +320,7 @@ jobs:
               } catch (e) {
                 core.warning(`Could not read prior confirmations: ${e.message}`);
               }
-              const { remaining, count, total } = computeConfirm(mentorHandles, commenter, priorComments);
+              const { remaining, count, total } = computeConfirm(confirmHandles, commenter, priorComments);
               if (remaining.length) {
                 await reply('✅',
                   `Confirmation recorded from @${commenter}. ` +

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -35,6 +35,7 @@ jobs:
             const { parseIssueForm } = _lib('parse.js');
             const { findMaintainerInCsv, isProjectMaintainer } = _lib('maintainers.js');
             const { computeConfirm } = _lib('confirm.js');
+            const { lookupProject } = _lib('projects.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const comment = context.payload.comment;
@@ -138,22 +139,11 @@ jobs:
               if (project) {
                 try {
                   const projYaml = fs.readFileSync('programs/lfx-mentorship/automation/projects.yml', 'utf8');
-                  // Find the entry for this project and extract repo_url + has_dot_project
-                  const projRe = new RegExp(
-                    `- name: ${project.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\n` +
-                    `[\\s\\S]*?(?=\\n- name:|$)`
-                  );
-                  const projMatch = projYaml.match(projRe);
-                  if (projMatch) {
-                    const block = projMatch[0];
-                    const slugMatch = block.match(/^\s*slug:\s*(\S+)/m);
-                    if (slugMatch) projectSlug = slugMatch[1].trim().toLowerCase();
-                    const urlMatch = block.match(/repo_url:\s*(\S+)/);
-                    if (urlMatch) {
-                      const urlParts = urlMatch[1].match(/github\.com\/([^/]+)\//);
-                      if (urlParts) ghOrg = urlParts[1];
-                    }
-                    hasDotProject = /has_dot_project:\s*true/i.test(block);
+                  const info = lookupProject(projYaml, project);
+                  if (info) {
+                    ghOrg = info.org;
+                    projectSlug = info.slug;
+                    hasDotProject = info.hasDotProject;
                   }
                 } catch (e) {
                   console.log(`projects.yml org lookup failed: ${e.message}`);

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -27,7 +27,7 @@ jobs:
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
             const { parseIssueForm } = _lib('parse.js');
-            const { findMaintainerInCsv } = _lib('maintainers.js');
+            const { findMaintainerInCsv, isProjectMaintainer } = _lib('maintainers.js');
             const { computeConfirm } = _lib('confirm.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
@@ -162,37 +162,15 @@ jobs:
                   );
                   if (resp.ok) {
                     const yaml = await resp.text();
-                    // Parse maintainers.yaml: look for project-maintainers team members
-                    // Structure: maintainers[].teams[] where name=project-maintainers has members[]
-                    // Simple line-by-line parse: find "- name: project-maintainers" then collect members
-                    let inMaintainersTeam = false;
-                    let inMembers = false;
-                    for (const line of yaml.split('\n')) {
-                      if (/name:\s*["']?project-maintainers/.test(line)) {
-                        inMaintainersTeam = true;
-                        continue;
-                      }
-                      if (inMaintainersTeam && /members:/.test(line)) {
-                        inMembers = true;
-                        continue;
-                      }
-                      if (inMembers) {
-                        const memberMatch = line.match(/^\s+-\s+(\S+)/);
-                        if (memberMatch) {
-                          const handle = memberMatch[1].replace(/^@/, '').toLowerCase();
-                          if (handle === commenter.toLowerCase()) {
-                            authorized = true;
-                            authSource = `${ghOrg}/.project/maintainers.yaml`;
-                            break;
-                          }
-                        } else if (/^\s+-\s*name:/.test(line) || /^\s*\S.*:/.test(line)) {
-                          // Moved past the members list to a new team or section
-                          inMaintainersTeam = false;
-                          inMembers = false;
-                        }
-                      }
-                    }
-                    if (!authorized) {
+                    // Tier-1 lookup extracted to lib/maintainers.js so the
+                    // authorization decision is unit-tested (cncf/mentoring#1908
+                    // follow-up). Behavior is unchanged from the previous inline
+                    // scanner; its known limitations are documented by the
+                    // characterization tests in test/maintainers.test.js.
+                    if (isProjectMaintainer(yaml, commenter)) {
+                      authorized = true;
+                      authSource = `${ghOrg}/.project/maintainers.yaml`;
+                    } else {
                       console.log(`.project/maintainers.yaml found for ${ghOrg} but ${commenter} not in project-maintainers team`);
                     }
                   } else {

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -159,11 +159,10 @@ jobs:
                   );
                   if (resp.ok) {
                     const yaml = await resp.text();
-                    // Tier-1 lookup extracted to lib/maintainers.js so the
-                    // authorization decision is unit-tested (cncf/mentoring#1908
-                    // follow-up). Behavior is unchanged from the previous inline
-                    // scanner; its known limitations are documented by the
-                    // characterization tests in test/maintainers.test.js.
+                    // Tier-1 lookup lives in lib/maintainers.js: a js-yaml parse
+                    // of the .project schema that authorizes only members of the
+                    // exactly-named project-maintainers team. Unit-tested in
+                    // test/maintainers.test.js (cncf/mentoring#1908 follow-up).
                     if (isProjectMaintainer(yaml, commenter)) {
                       authorized = true;
                       authSource = `${ghOrg}/.project/maintainers.yaml`;

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        # lib/maintainers.js parses .project/maintainers.yaml with js-yaml.
+        # --ignore-scripts blocks dependency lifecycle scripts (js-yaml needs none).
+        working-directory: programs/lfx-mentorship/automation
+        run: npm install --no-save --ignore-scripts js-yaml@4.3.0
+
       - name: Process slash command
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -25,7 +25,7 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
-            const { parseIssueForm } = _lib('parse.js');
+            const { parseIssueForm, parseMentors } = _lib('parse.js');
             const { validateMentors, validateUpstreamUrl } = _lib('validate.js');
             const { lookupProject } = _lib('projects.js');
             const { owner, repo } = context.repo;
@@ -148,7 +148,7 @@ jobs:
               }
             }
             if (mentorResult.ok) {
-              const primaryName = mentorsRaw.split(/\r?\n/).map(l => l.trim()).filter(Boolean)[0].split('|')[0].trim();
+              const primaryName = parseMentors(mentorsRaw)[0].name;
               passed.push(`Mentors: ${mentorResult.count} listed (primary: ${primaryName})`);
             }
 

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -27,6 +27,7 @@ jobs:
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
             const { parseIssueForm } = _lib('parse.js');
             const { validateMentors, validateUpstreamUrl } = _lib('validate.js');
+            const { lookupProject } = _lib('projects.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const body = context.payload.issue.body || '';
@@ -183,22 +184,12 @@ jobs:
                 const projectKeys = [project.toLowerCase().replace(/\s+/g, '-')];
                 try {
                   const projYaml = fs.readFileSync('programs/lfx-mentorship/automation/projects.yml', 'utf8');
-                  const projRe = new RegExp(
-                    `- name: ${project.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\n` +
-                    `[\\s\\S]*?(?=\\n- name:|$)`
-                  );
-                  const projMatch = projYaml.match(projRe);
-                  if (projMatch) {
-                    const block = projMatch[0];
-                    // GitHub org before projects.yml slug, to match the candidate
-                    // ordering in lfx-proposal-approvals.yml (org preferred over slug).
-                    const urlMatch = block.match(/repo_url:\s*(\S+)/);
-                    if (urlMatch) {
-                      const orgMatch = urlMatch[1].match(/github\.com\/([^/]+)/);
-                      if (orgMatch) projectKeys.push(orgMatch[1].toLowerCase());
-                    }
-                    const slugMatch = block.match(/^\s*slug:\s*(\S+)/m);
-                    if (slugMatch) projectKeys.push(slugMatch[1].trim().toLowerCase());
+                  // GitHub org before projects.yml slug, to match the candidate
+                  // ordering in lfx-proposal-approvals.yml (org preferred over slug).
+                  const info = lookupProject(projYaml, project);
+                  if (info) {
+                    if (info.org) projectKeys.push(info.org.toLowerCase());
+                    if (info.slug) projectKeys.push(info.slug);
                   }
                 } catch (e) {
                   console.log(`projects.yml key lookup failed: ${e.message}`);

--- a/programs/lfx-mentorship/automation/lib/approvers.js
+++ b/programs/lfx-mentorship/automation/lib/approvers.js
@@ -1,0 +1,54 @@
+'use strict';
+
+// Parsing helpers for approvers.yml (the LFX proposal fallback-approver file),
+// used by the /approve and /cncf-approve authorization checks in
+// lfx-proposal-approvals.yml. Extracted verbatim from that workflow so the
+// parsing is defined once, de-duplicated (global_approvers was parsed in two
+// places), and unit-tested (cncf/mentoring#1908 follow-up). Behavior is
+// unchanged; a later change may switch to a real YAML parser (js-yaml is
+// already available in that workflow).
+
+// global_approvers: lowercased handles that may /approve any project, and the
+// /cncf-approve admin allowlist.
+function getGlobalApprovers(raw) {
+  const block = String(raw).match(/global_approvers:\s*\n((?:\s+-\s+\S+.*\n?)*)/);
+  if (!block) return [];
+  return [...block[1].matchAll(/-\s+(\S+)/g)].map((m) => m[1].toLowerCase());
+}
+
+// The indented block for the first matching project key, or '' if none match.
+// Keys are tried in order; key matching is case-insensitive.
+function getProjectSection(raw, keys) {
+  const text = String(raw);
+  for (const key of keys || []) {
+    if (!key) continue;
+    const re = new RegExp(`^${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:`, 'im');
+    const parts = text.split(re);
+    if (parts.length > 1) {
+      return parts[1].split(/^\S/m)[0];
+    }
+  }
+  return '';
+}
+
+// fallback_handles within a project section: lowercased handles.
+function getFallbackHandles(section) {
+  const block = String(section).match(/fallback_handles:\s*\n((?:\s+-\s+\S+.*\n?)*)/);
+  if (!block) return [];
+  return [...block[1].matchAll(/-\s+(\S+)/g)].map((m) => m[1].toLowerCase());
+}
+
+// fallback_teams within a project section: raw "org/team" strings (case kept,
+// since GitHub team slugs are matched by the API downstream).
+function getFallbackTeams(section) {
+  const block = String(section).match(/fallback_teams:\s*\n((?:\s+-\s+\S+.*\n?)*)/);
+  if (!block) return [];
+  return [...block[1].matchAll(/-\s+(\S+)/g)].map((m) => m[1]);
+}
+
+module.exports = {
+  getGlobalApprovers,
+  getProjectSection,
+  getFallbackHandles,
+  getFallbackTeams,
+};

--- a/programs/lfx-mentorship/automation/lib/maintainers.js
+++ b/programs/lfx-mentorship/automation/lib/maintainers.js
@@ -35,4 +35,44 @@ function findMaintainerInCsv(csvText, project, handle) {
   return { authorized: false, project: '' };
 }
 
-module.exports = { findMaintainerInCsv };
+// Whether `handle` is a member of the `project-maintainers` team in an
+// {org}/.project/maintainers.yaml document (tier-1 of the /approve check).
+//
+// This is the hand-rolled line-scanner that shipped inline in
+// lfx-proposal-approvals.yml, extracted verbatim so the extraction itself
+// changes no behavior (locked by characterization tests). Its known
+// limitations are intentionally preserved here and documented by those tests;
+// hardening them (e.g. via a real YAML parser) is a separate, deliberate step:
+//   - members written as mappings (`- name: foo`) are NOT matched;
+//   - the team-name test is a prefix match, so `project-maintainers-emeritus`
+//     is treated as `project-maintainers`.
+function isProjectMaintainer(yamlText, handle) {
+  const who = String(handle || '').replace(/^@/, '').toLowerCase();
+  if (!who) return false;
+
+  let inMaintainersTeam = false;
+  let inMembers = false;
+  for (const line of String(yamlText).split('\n')) {
+    if (/name:\s*["']?project-maintainers/.test(line)) {
+      inMaintainersTeam = true;
+      continue;
+    }
+    if (inMaintainersTeam && /members:/.test(line)) {
+      inMembers = true;
+      continue;
+    }
+    if (inMembers) {
+      const memberMatch = line.match(/^\s+-\s+(\S+)/);
+      if (memberMatch) {
+        const h = memberMatch[1].replace(/^@/, '').toLowerCase();
+        if (h === who) return true;
+      } else if (/^\s+-\s*name:/.test(line) || /^\s*\S.*:/.test(line)) {
+        inMaintainersTeam = false;
+        inMembers = false;
+      }
+    }
+  }
+  return false;
+}
+
+module.exports = { findMaintainerInCsv, isProjectMaintainer };

--- a/programs/lfx-mentorship/automation/lib/maintainers.js
+++ b/programs/lfx-mentorship/automation/lib/maintainers.js
@@ -11,6 +11,7 @@
 // label such as "OpenTelemetry (Governance Committee)", so a project matches
 // by prefix/substring rather than equality.
 const { parseCsvLine } = require('./csv.js');
+const yaml = require('js-yaml');
 
 // Return { authorized, project } for whether `handle` is listed as a
 // maintainer of `project` in the CSV text. Matching is case-insensitive.
@@ -38,37 +39,36 @@ function findMaintainerInCsv(csvText, project, handle) {
 // Whether `handle` is a member of the `project-maintainers` team in an
 // {org}/.project/maintainers.yaml document (tier-1 of the /approve check).
 //
-// This is the hand-rolled line-scanner that shipped inline in
-// lfx-proposal-approvals.yml, extracted verbatim so the extraction itself
-// changes no behavior (locked by characterization tests). Its known
-// limitations are intentionally preserved here and documented by those tests;
-// hardening them (e.g. via a real YAML parser) is a separate, deliberate step:
-//   - members written as mappings (`- name: foo`) are NOT matched;
-//   - the team-name test is a prefix match, so `project-maintainers-emeritus`
-//     is treated as `project-maintainers`.
+// Parses the document with js-yaml and navigates the canonical dot-project
+// schema (cncf/automation utilities/dot-project): maintainers[].teams[] where
+// team.name === "project-maintainers" has members[] of bare GitHub handles.
+// Only members of an exactly-named project-maintainers team authorize; other
+// teams (reviewers, sig-*-leads, *-emeritus) do not. Non-string members and
+// malformed YAML are ignored (returns false, never throws). Handle matching is
+// case-insensitive and tolerates a leading '@'.
 function isProjectMaintainer(yamlText, handle) {
-  const who = String(handle || '').replace(/^@/, '').toLowerCase();
+  const who = String(handle || '').replace(/^@/, '').trim().toLowerCase();
   if (!who) return false;
 
-  let inMaintainersTeam = false;
-  let inMembers = false;
-  for (const line of String(yamlText).split('\n')) {
-    if (/name:\s*["']?project-maintainers/.test(line)) {
-      inMaintainersTeam = true;
-      continue;
-    }
-    if (inMaintainersTeam && /members:/.test(line)) {
-      inMembers = true;
-      continue;
-    }
-    if (inMembers) {
-      const memberMatch = line.match(/^\s+-\s+(\S+)/);
-      if (memberMatch) {
-        const h = memberMatch[1].replace(/^@/, '').toLowerCase();
-        if (h === who) return true;
-      } else if (/^\s+-\s*name:/.test(line) || /^\s*\S.*:/.test(line)) {
-        inMaintainersTeam = false;
-        inMembers = false;
+  let doc;
+  try {
+    doc = yaml.load(String(yamlText));
+  } catch {
+    return false;
+  }
+
+  const groups = doc && Array.isArray(doc.maintainers) ? doc.maintainers : [];
+  for (const group of groups) {
+    const teams = group && Array.isArray(group.teams) ? group.teams : [];
+    for (const team of teams) {
+      if (!team || String(team.name || '').trim().toLowerCase() !== 'project-maintainers') {
+        continue;
+      }
+      const members = Array.isArray(team.members) ? team.members : [];
+      for (const m of members) {
+        if (typeof m === 'string' && m.replace(/^@/, '').trim().toLowerCase() === who) {
+          return true;
+        }
       }
     }
   }

--- a/programs/lfx-mentorship/automation/lib/projects.js
+++ b/programs/lfx-mentorship/automation/lib/projects.js
@@ -12,7 +12,10 @@
 //     mixed-case, e.g. "WasmEdge") org to build the .project URL; validate
 //     lowercases it at its call site for quota keys, and still does. Org
 //     extraction requires a path segment after the org (as approvals did), so
-//     an org-only repo_url like https://github.com/CoHDI yields '';
+//     an org-only repo_url like https://github.com/CoHDI yields ''. NOTE:
+//     validate's old inline regex extracted an org here even without a path
+//     segment, so for such entries its raw candidate-key list differs — but the
+//     deduplicated quota keys are unchanged, since the slug supplies the same key;
 //   - hasDotProject reflects `has_dot_project: true`.
 // A later change may replace this regex scan with a real YAML parser.
 

--- a/programs/lfx-mentorship/automation/lib/projects.js
+++ b/programs/lfx-mentorship/automation/lib/projects.js
@@ -2,8 +2,9 @@
 
 // Look up a project entry in projects.yml by display name, returning the
 // fields the LFX proposal workflows need. Extracted from the duplicated inline
-// parsers in lfx-proposal-approvals.yml and lfx-proposal-validate.yml so the
-// lookup is defined once and unit-tested (cncf/mentoring#1908 follow-up).
+// parsers in lfx-proposal-approvals.yml, lfx-proposal-validate.yml, and
+// lfx-export.yml (getProjectMeta) so the lookup is defined once and
+// unit-tested (cncf/mentoring#1908 follow-up).
 //
 // Behavior is preserved from those inline copies:
 //   - slug is lowercased (both call sites did this);
@@ -15,8 +16,9 @@
 //   - hasDotProject reflects `has_dot_project: true`.
 // A later change may replace this regex scan with a real YAML parser.
 
-// Return { slug, org, hasDotProject } for the named project, or null if the
-// project is not present. slug is lowercased, org is raw, hasDotProject is bool.
+// Return { slug, org, maturity, hasDotProject } for the named project, or null
+// if the project is not present. slug is lowercased, org is raw, maturity is
+// raw, hasDotProject is bool.
 function lookupProject(yamlText, name) {
   if (!name) return null;
   const escaped = String(name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -29,6 +31,10 @@ function lookupProject(yamlText, name) {
   const slugMatch = block.match(/^\s*slug:\s*(\S+)/m);
   if (slugMatch) slug = slugMatch[1].trim().toLowerCase();
 
+  let maturity = '';
+  const maturityMatch = block.match(/^\s*maturity:\s*(\S+)/m);
+  if (maturityMatch) maturity = maturityMatch[1].trim();
+
   let org = '';
   const urlMatch = block.match(/repo_url:\s*(\S+)/);
   if (urlMatch) {
@@ -37,7 +43,7 @@ function lookupProject(yamlText, name) {
   }
 
   const hasDotProject = /has_dot_project:\s*true/i.test(block);
-  return { slug, org, hasDotProject };
+  return { slug, org, maturity, hasDotProject };
 }
 
 module.exports = { lookupProject };

--- a/programs/lfx-mentorship/automation/lib/projects.js
+++ b/programs/lfx-mentorship/automation/lib/projects.js
@@ -1,0 +1,43 @@
+'use strict';
+
+// Look up a project entry in projects.yml by display name, returning the
+// fields the LFX proposal workflows need. Extracted from the duplicated inline
+// parsers in lfx-proposal-approvals.yml and lfx-proposal-validate.yml so the
+// lookup is defined once and unit-tested (cncf/mentoring#1908 follow-up).
+//
+// Behavior is preserved from those inline copies:
+//   - slug is lowercased (both call sites did this);
+//   - org is returned RAW from repo_url. approvals used the raw (possibly
+//     mixed-case, e.g. "WasmEdge") org to build the .project URL; validate
+//     lowercases it at its call site for quota keys, and still does. Org
+//     extraction requires a path segment after the org (as approvals did), so
+//     an org-only repo_url like https://github.com/CoHDI yields '';
+//   - hasDotProject reflects `has_dot_project: true`.
+// A later change may replace this regex scan with a real YAML parser.
+
+// Return { slug, org, hasDotProject } for the named project, or null if the
+// project is not present. slug is lowercased, org is raw, hasDotProject is bool.
+function lookupProject(yamlText, name) {
+  if (!name) return null;
+  const escaped = String(name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const projRe = new RegExp(`- name: ${escaped}\\n[\\s\\S]*?(?=\\n- name:|$)`);
+  const m = String(yamlText).match(projRe);
+  if (!m) return null;
+  const block = m[0];
+
+  let slug = '';
+  const slugMatch = block.match(/^\s*slug:\s*(\S+)/m);
+  if (slugMatch) slug = slugMatch[1].trim().toLowerCase();
+
+  let org = '';
+  const urlMatch = block.match(/repo_url:\s*(\S+)/);
+  if (urlMatch) {
+    const orgMatch = urlMatch[1].match(/github\.com\/([^/]+)\//);
+    if (orgMatch) org = orgMatch[1];
+  }
+
+  const hasDotProject = /has_dot_project:\s*true/i.test(block);
+  return { slug, org, hasDotProject };
+}
+
+module.exports = { lookupProject };

--- a/programs/lfx-mentorship/automation/test/approvers.test.js
+++ b/programs/lfx-mentorship/automation/test/approvers.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  getGlobalApprovers,
+  getProjectSection,
+  getFallbackHandles,
+  getFallbackTeams,
+} = require('../lib/approvers');
+
+// Fixture mirrors the real approvers.yml shape: a global_approvers list plus
+// per-project sections keyed by GitHub org, with fallback_teams and an optional
+// commented fallback_handles entry.
+const YAML = `# comment header
+global_approvers:
+  - nate-double-u
+  - dkrook
+  - Swil78
+
+kubernetes:
+  fallback_teams:
+    - kubernetes/sig-contribex
+
+open-telemetry:
+  fallback_teams:
+    - open-telemetry/governance-committee
+  fallback_handles:
+    - maryliag    # GC liaison for mentorship
+`;
+
+test('getGlobalApprovers: returns all handles, lowercased', () => {
+  assert.deepEqual(getGlobalApprovers(YAML), ['nate-double-u', 'dkrook', 'swil78']);
+});
+
+test('getGlobalApprovers: returns [] when the key is absent', () => {
+  assert.deepEqual(getGlobalApprovers('kubernetes:\n  fallback_handles:\n    - x\n'), []);
+});
+
+test('getProjectSection: returns the block for the first matching key', () => {
+  const section = getProjectSection(YAML, ['nope', 'kubernetes']);
+  assert.match(section, /fallback_teams:/);
+  assert.match(section, /kubernetes\/sig-contribex/);
+  // Must stop before the next top-level key.
+  assert.doesNotMatch(section, /open-telemetry/);
+});
+
+test('getProjectSection: key matching is case-insensitive', () => {
+  assert.match(getProjectSection(YAML, ['KUBERNETES']), /sig-contribex/);
+});
+
+test('getProjectSection: a key that is only a prefix does not match', () => {
+  // "open" must not match "open-telemetry:".
+  assert.equal(getProjectSection(YAML, ['open']), '');
+});
+
+test('getProjectSection: returns empty string when no key matches', () => {
+  assert.equal(getProjectSection(YAML, ['does-not-exist']), '');
+  assert.equal(getProjectSection(YAML, []), '');
+});
+
+test('getFallbackHandles: lowercased, ignoring trailing comments', () => {
+  const section = getProjectSection(YAML, ['open-telemetry']);
+  assert.deepEqual(getFallbackHandles(section), ['maryliag']);
+});
+
+test('getFallbackHandles: returns [] for a section without fallback_handles', () => {
+  const section = getProjectSection(YAML, ['kubernetes']);
+  assert.deepEqual(getFallbackHandles(section), []);
+});
+
+test('getFallbackTeams: returns raw org/team strings with case preserved', () => {
+  assert.deepEqual(
+    getFallbackTeams(getProjectSection(YAML, ['kubernetes'])),
+    ['kubernetes/sig-contribex'],
+  );
+  assert.deepEqual(
+    getFallbackTeams(getProjectSection(YAML, ['open-telemetry'])),
+    ['open-telemetry/governance-committee'],
+  );
+});
+
+test('getFallbackTeams: returns [] for a section without fallback_teams', () => {
+  assert.deepEqual(getFallbackTeams('fallback_handles:\n    - someone\n'), []);
+});

--- a/programs/lfx-mentorship/automation/test/maintainers.test.js
+++ b/programs/lfx-mentorship/automation/test/maintainers.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { findMaintainerInCsv } = require('../lib/maintainers');
+const { findMaintainerInCsv, isProjectMaintainer } = require('../lib/maintainers');
 
 // Mirrors the grouped shape of cncf/foundation/project-maintainers.csv:
 // Maturity and Project are set only on each group's first row; continuation
@@ -59,4 +59,108 @@ test('does not leak a maintainer across group boundaries', () => {
 test('rejects on blank project or handle', () => {
   assert.equal(findMaintainerInCsv(CSV, '', 'aliok').authorized, false);
   assert.equal(findMaintainerInCsv(CSV, 'Knative', '').authorized, false);
+});
+
+// ── isProjectMaintainer: tier-1 {org}/.project/maintainers.yaml ──────────
+// CHARACTERIZATION tests. These lock in the behavior of the hand-rolled
+// scanner exactly as it shipped inline, so the extraction is proven
+// behavior-preserving. Where a test documents a known limitation it says so;
+// those are deliberately NOT "fixed" here (that's a separate behavior change).
+
+// Canonical schema (cncf/automation dot-project util): bare-scalar members.
+const CANONICAL = `maintainers:
+  - project_id: "cert-manager"
+    org: "cert-manager"
+    teams:
+      - name: "project-maintainers"
+        members:
+          - munnerz
+          - joshvanl
+          - SgtCoDFish
+`;
+
+test('isProjectMaintainer: authorizes a listed member (canonical schema)', () => {
+  assert.equal(isProjectMaintainer(CANONICAL, 'joshvanl'), true);
+});
+
+test('isProjectMaintainer: rejects a non-member', () => {
+  assert.equal(isProjectMaintainer(CANONICAL, 'stranger'), false);
+});
+
+test('isProjectMaintainer: strips a leading @ and is case-insensitive', () => {
+  assert.equal(isProjectMaintainer(CANONICAL, '@Munnerz'), true);
+  assert.equal(isProjectMaintainer(CANONICAL, 'MUNNERZ'), true);
+});
+
+test('isProjectMaintainer: handles a quoted/unquoted team name alike', () => {
+  const unquoted = CANONICAL.replace('"project-maintainers"', 'project-maintainers');
+  assert.equal(isProjectMaintainer(unquoted, 'munnerz'), true);
+});
+
+test('isProjectMaintainer: a team listed BEFORE project-maintainers is excluded', () => {
+  const before = `maintainers:
+  - org: "acme"
+    teams:
+      - name: "reviewers"
+        members:
+          - bob
+      - name: "project-maintainers"
+        members:
+          - alice
+`;
+  assert.equal(isProjectMaintainer(before, 'alice'), true);
+  assert.equal(isProjectMaintainer(before, 'bob'), false);
+});
+
+test('isProjectMaintainer: LIMITATION — a team listed AFTER project-maintainers is over-authorized', () => {
+  // Once armed at project-maintainers, the reset never fires: a following
+  // `- name: "reviewers"` line is swallowed as a bogus member (`name:`), so
+  // inMaintainersTeam is never cleared and the next `members:` re-arms the
+  // scanner. Every following team's members are wrongly authorized. This is
+  // the scanner's actual behavior today, surfaced by characterization, not
+  // desired behavior.
+  const after = `maintainers:
+  - org: "acme"
+    teams:
+      - name: "project-maintainers"
+        members:
+          - alice
+      - name: "reviewers"
+        members:
+          - bob
+`;
+  assert.equal(isProjectMaintainer(after, 'alice'), true);
+  assert.equal(isProjectMaintainer(after, 'bob'), true); // over-auth (bug)
+});
+
+test('isProjectMaintainer: LIMITATION — mapping-style members are NOT matched', () => {
+  // Members written as `- name: foo` (rather than bare `- foo`) are missed by
+  // the scanner. Documented current behavior, not desired behavior.
+  const mappingStyle = `maintainers:
+  - org: "acme"
+    teams:
+      - name: "project-maintainers"
+        members:
+          - name: alice
+          - name: bob
+`;
+  assert.equal(isProjectMaintainer(mappingStyle, 'alice'), false);
+});
+
+test('isProjectMaintainer: LIMITATION — prefix over-match treats *-emeritus as project-maintainers', () => {
+  // The team-name test is a prefix match, so an emeritus team is wrongly
+  // treated as the maintainers team. Documented current behavior.
+  const emeritus = `maintainers:
+  - org: "acme"
+    teams:
+      - name: "project-maintainers-emeritus"
+        members:
+          - retiree
+`;
+  assert.equal(isProjectMaintainer(emeritus, 'retiree'), true);
+});
+
+test('isProjectMaintainer: rejects empty/whitespace handle', () => {
+  assert.equal(isProjectMaintainer(CANONICAL, ''), false);
+  assert.equal(isProjectMaintainer(CANONICAL, '   '), false);
 });

--- a/programs/lfx-mentorship/automation/test/maintainers.test.js
+++ b/programs/lfx-mentorship/automation/test/maintainers.test.js
@@ -112,13 +112,9 @@ test('isProjectMaintainer: a team listed BEFORE project-maintainers is excluded'
   assert.equal(isProjectMaintainer(before, 'bob'), false);
 });
 
-test('isProjectMaintainer: LIMITATION — a team listed AFTER project-maintainers is over-authorized', () => {
-  // Once armed at project-maintainers, the reset never fires: a following
-  // `- name: "reviewers"` line is swallowed as a bogus member (`name:`), so
-  // inMaintainersTeam is never cleared and the next `members:` re-arms the
-  // scanner. Every following team's members are wrongly authorized. This is
-  // the scanner's actual behavior today, surfaced by characterization, not
-  // desired behavior.
+test('isProjectMaintainer: a team listed AFTER project-maintainers is excluded', () => {
+  // Only members of the exactly-named project-maintainers team are authorized;
+  // a following reviewers team must not leak authorization.
   const after = `maintainers:
   - org: "acme"
     teams:
@@ -130,26 +126,63 @@ test('isProjectMaintainer: LIMITATION — a team listed AFTER project-maintainer
           - bob
 `;
   assert.equal(isProjectMaintainer(after, 'alice'), true);
-  assert.equal(isProjectMaintainer(after, 'bob'), true); // over-auth (bug)
+  assert.equal(isProjectMaintainer(after, 'bob'), false);
 });
 
-test('isProjectMaintainer: LIMITATION — mapping-style members are NOT matched', () => {
-  // Members written as `- name: foo` (rather than bare `- foo`) are missed by
-  // the scanner. Documented current behavior, not desired behavior.
+test('isProjectMaintainer: matches the canonical multi-team example (thockin yes, cpanato no)', () => {
+  // Verbatim shape from cncf/automation dot-project example/maintainers.yaml:
+  // cpanato is a sig-release-lead, NOT a project-maintainer.
+  const kubernetes = `maintainers:
+  - project_id: "kubernetes"
+    org: "kubernetes"
+    teams:
+      - name: "project-maintainers"
+        members:
+          - thockin
+          - liggitt
+          - derekwaynecarr
+          - dims
+      - name: "sig-release-leads"
+        members:
+          - justaugustus
+          - cpanato
+          - saschagrunert
+`;
+  assert.equal(isProjectMaintainer(kubernetes, 'thockin'), true);
+  assert.equal(isProjectMaintainer(kubernetes, 'cpanato'), false);
+});
+
+test('isProjectMaintainer: authorizes a member in a second maintainers[] entry (multi-project org)', () => {
+  const multi = `maintainers:
+  - project_id: "proj-a"
+    teams:
+      - name: "project-maintainers"
+        members:
+          - alice
+  - project_id: "proj-b"
+    teams:
+      - name: "project-maintainers"
+        members:
+          - bob
+`;
+  assert.equal(isProjectMaintainer(multi, 'alice'), true);
+  assert.equal(isProjectMaintainer(multi, 'bob'), true);
+});
+
+test('isProjectMaintainer: non-string members are safely ignored', () => {
+  // The schema uses bare-scalar handles; a mapping is invalid and must not
+  // match or throw.
   const mappingStyle = `maintainers:
   - org: "acme"
     teams:
       - name: "project-maintainers"
         members:
           - name: alice
-          - name: bob
 `;
   assert.equal(isProjectMaintainer(mappingStyle, 'alice'), false);
 });
 
-test('isProjectMaintainer: LIMITATION — prefix over-match treats *-emeritus as project-maintainers', () => {
-  // The team-name test is a prefix match, so an emeritus team is wrongly
-  // treated as the maintainers team. Documented current behavior.
+test('isProjectMaintainer: *-emeritus is not treated as project-maintainers', () => {
   const emeritus = `maintainers:
   - org: "acme"
     teams:
@@ -157,7 +190,13 @@ test('isProjectMaintainer: LIMITATION — prefix over-match treats *-emeritus as
         members:
           - retiree
 `;
-  assert.equal(isProjectMaintainer(emeritus, 'retiree'), true);
+  assert.equal(isProjectMaintainer(emeritus, 'retiree'), false);
+});
+
+test('isProjectMaintainer: malformed YAML returns false without throwing', () => {
+  assert.equal(isProjectMaintainer('this: is: not: valid: yaml:\n  - [', 'alice'), false);
+  assert.equal(isProjectMaintainer('', 'alice'), false);
+  assert.equal(isProjectMaintainer('just a string', 'alice'), false);
 });
 
 test('isProjectMaintainer: rejects empty/whitespace handle', () => {

--- a/programs/lfx-mentorship/automation/test/maintainers.test.js
+++ b/programs/lfx-mentorship/automation/test/maintainers.test.js
@@ -62,10 +62,10 @@ test('rejects on blank project or handle', () => {
 });
 
 // ── isProjectMaintainer: tier-1 {org}/.project/maintainers.yaml ──────────
-// CHARACTERIZATION tests. These lock in the behavior of the hand-rolled
-// scanner exactly as it shipped inline, so the extraction is proven
-// behavior-preserving. Where a test documents a known limitation it says so;
-// those are deliberately NOT "fixed" here (that's a separate behavior change).
+// Verifies the js-yaml-based tier-1 authorization: only members of the
+// exactly-named project-maintainers team authorize. Teams listed after it,
+// *-emeritus teams, and non-string members are excluded; malformed YAML is
+// rejected without throwing.
 
 // Canonical schema (cncf/automation dot-project util): bare-scalar members.
 const CANONICAL = `maintainers:

--- a/programs/lfx-mentorship/automation/test/projects.test.js
+++ b/programs/lfx-mentorship/automation/test/projects.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { lookupProject } = require('../lib/projects');
+
+// Fixture modeled on real programs/lfx-mentorship/automation/projects.yml
+// entries: a .project adopter, a non-adopter, a paren-in-name project directly
+// followed by a name it must not bleed into, and a mixed-case org.
+const YAML = `# Auto-generated from cncf/landscape — DO NOT EDIT MANUALLY.
+- name: Aeraki Mesh
+  slug: aerakimesh
+  maturity: sandbox
+  repo_url: https://github.com/aeraki-mesh/aeraki
+  has_dot_project: true
+- name: Agones
+  slug: agones
+  maturity: sandbox
+  repo_url: https://github.com/agones-dev/agones
+- name: Open Policy Agent (OPA)
+  slug: openpolicyagent
+  maturity: graduated
+  repo_url: https://github.com/open-policy-agent/opa
+- name: Open Policy Containers
+  slug: openpolicycontainers
+  maturity: sandbox
+  repo_url: https://github.com/open-policy-containers/opcr
+- name: WasmEdge Runtime
+  slug: wasmedge-runtime
+  maturity: sandbox
+  repo_url: https://github.com/WasmEdge/WasmEdge
+`;
+
+test('lookupProject: returns slug, org, hasDotProject for a .project adopter', () => {
+  assert.deepEqual(lookupProject(YAML, 'Aeraki Mesh'), {
+    slug: 'aerakimesh', org: 'aeraki-mesh', hasDotProject: true,
+  });
+});
+
+test('lookupProject: hasDotProject is false when the field is absent', () => {
+  const info = lookupProject(YAML, 'Agones');
+  assert.equal(info.hasDotProject, false);
+  assert.equal(info.org, 'agones-dev');
+  assert.equal(info.slug, 'agones');
+});
+
+test('lookupProject: preserves a mixed-case org verbatim (no lowercasing)', () => {
+  // approvals uses org raw for the .project URL; it must not be lowercased here.
+  assert.equal(lookupProject(YAML, 'WasmEdge Runtime').org, 'WasmEdge');
+});
+
+test('lookupProject: escapes regex-special characters in the name', () => {
+  const info = lookupProject(YAML, 'Open Policy Agent (OPA)');
+  assert.equal(info.slug, 'openpolicyagent');
+  assert.equal(info.org, 'open-policy-agent');
+});
+
+test('lookupProject: a name does not bleed into the following entry', () => {
+  // "Open Policy Agent (OPA)" is immediately followed by "Open Policy
+  // Containers"; the block must stop at the next entry.
+  assert.equal(lookupProject(YAML, 'Open Policy Agent (OPA)').slug, 'openpolicyagent');
+});
+
+test('lookupProject: a name that is only a prefix of an entry does not match', () => {
+  assert.equal(lookupProject(YAML, 'Open Policy'), null);
+});
+
+test('lookupProject: an org-only repo_url (no repo path) yields an empty org', () => {
+  // Preserves the prior approvals behavior; real example: CoHDI.
+  const orgOnly = `- name: CoHDI
+  slug: cohdi
+  repo_url: https://github.com/CoHDI
+`;
+  const info = lookupProject(orgOnly, 'CoHDI');
+  assert.equal(info.slug, 'cohdi');
+  assert.equal(info.org, '');
+});
+
+test('lookupProject: returns null for an unknown project', () => {
+  assert.equal(lookupProject(YAML, 'Nonexistent Project'), null);
+});
+
+test('lookupProject: returns null for an empty or missing name', () => {
+  assert.equal(lookupProject(YAML, ''), null);
+  assert.equal(lookupProject(YAML, undefined), null);
+});

--- a/programs/lfx-mentorship/automation/test/projects.test.js
+++ b/programs/lfx-mentorship/automation/test/projects.test.js
@@ -31,10 +31,15 @@ const YAML = `# Auto-generated from cncf/landscape — DO NOT EDIT MANUALLY.
   repo_url: https://github.com/WasmEdge/WasmEdge
 `;
 
-test('lookupProject: returns slug, org, hasDotProject for a .project adopter', () => {
+test('lookupProject: returns slug, org, maturity, hasDotProject for a .project adopter', () => {
   assert.deepEqual(lookupProject(YAML, 'Aeraki Mesh'), {
-    slug: 'aerakimesh', org: 'aeraki-mesh', hasDotProject: true,
+    slug: 'aerakimesh', org: 'aeraki-mesh', maturity: 'sandbox', hasDotProject: true,
   });
+});
+
+test('lookupProject: extracts maturity (raw) for the named project', () => {
+  assert.equal(lookupProject(YAML, 'Open Policy Agent (OPA)').maturity, 'graduated');
+  assert.equal(lookupProject(YAML, 'Agones').maturity, 'sandbox');
 });
 
 test('lookupProject: hasDotProject is false when the field is absent', () => {


### PR DESCRIPTION
## Refactor the LFX proposal workflows: extract inline logic into tested libs

Follow-up to the #1908 post mortem, which found that the `/approve` bug shipped
because parsing/decision logic lived inline in workflow YAML where `node --test`
can't reach it. This closes all five audit suspects: every hand-rolled parser of
external data is now a unit-tested `lib/` function, with behaviour verified
against real data.

**Includes a security fix** (see commit 2): tier-1 `.project/maintainers.yaml`
authorization was over-permissive.

### What changed

Six commits, each a single behaviour-preserving step (or a clearly-separated
behaviour change), following the two-hats refactoring discipline:

1. **Extract tier-1 maintainers.yaml lookup** — move the inline scanner into
   `lib/maintainers.js`, verbatim, with characterization tests.
2. **Fix tier-1 over-authorization** *(behaviour change)* — replace the
   hand-rolled scanner with a real `js-yaml` parse. Previously, members of any
   team listed **after** `project-maintainers` (e.g. `sig-release-leads`) and a
   `project-maintainers-emeritus` team were wrongly authorized to `/approve`.
   Now only the exactly-named `project-maintainers` team authorizes.
3. **De-duplicate the projects.yml parser** — three-way-drifted copies collapse
   into `lib/projects.js` `lookupProject`.
4. **Extract + de-duplicate approvers.yml parsing** into `lib/approvers.js`
   (`global_approvers` was parsed in two places).
5. **Reuse `parse.js parseMentors`** for `/confirm` and the primary-name display
   instead of re-parsing inline.
6. **Reuse `lookupProject` in the export** — removes the third copy of the
   projects.yml block parser (`getProjectMeta`).

### Verification

- Full unit suite green (`node --test`), 147 tests.
- Each extraction proven behaviour-preserving with an equivalence harness against
  real data: all 225 projects in `projects.yml`, the live `approvers.yml`, and
  real `.project/maintainers.yaml` files. The approvals output is byte-identical
  except the intended tier-1 fix.
- `js-yaml` is pinned and installed in the workflows that need it, including the
  test workflow.

### Test plan (e2e on dev)

- [ ] A **non-first-listed** project maintainer `/approve`s a proposal and is
      authorized (regression from #1908, still passing).
- [ ] A real `.project` project: a `project-maintainers` member `/approve`s and
      is authorized; a member of a **different** team in the same file is
      **not** (the tier-1 fix).
- [ ] `/confirm` by a listed mentor still records confirmation.
- [ ] A global approver in `approvers.yml` can still `/approve`.

### Follow-ups (not in this PR)

- Optional: switch `projects.yml` / `approvers.yml` parsing to `js-yaml` too
  (kept regex-based here to stay behaviour-preserving and dependency-light).
- Optional: DRY `validateMentors` onto `parseMentors`.
- Surface `/approve` rejections to admins so detection doesn't depend on luck
  (post-mortem action item).

Assisted-by: Copilot <223556219+Copilot@users.noreply.github.com>
