### PR TITLE
Fix LFX proposal automation skipping unlabeled proposals

### DIFF
--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -10,13 +10,46 @@ permissions:
 
 jobs:
   validate:
+    # Run for issues already carrying the identifying labels OR for anything
+    # filed through the proposal template (title prefix). GitHub only applies a
+    # template's `labels:` for authors with triage access, so read-only
+    # proposers' issues arrive unlabeled; the title gate lets them through and
+    # the "Bootstrap proposal labels" step below re-applies the labels.
     if: >-
-      contains(github.event.issue.labels.*.name, 'lfx mentorship')
-      && contains(github.event.issue.labels.*.name, 'Proposal')
+      (contains(github.event.issue.labels.*.name, 'lfx mentorship')
+       && contains(github.event.issue.labels.*.name, 'Proposal'))
+      || startsWith(github.event.issue.title, '[CNCF LFX Proposal]')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Bootstrap proposal labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { PROPOSAL_LABELS, isProposalTitle, missingLabels } = _lib('labels.js');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const title = context.payload.issue.title || '';
+
+            // GitHub silently drops issue-template labels for authors without
+            // triage access, so proposals from read-only project maintainers
+            // land unlabeled and every label-gated proposal workflow skips.
+            // Re-apply the identifying labels here so validation (below), the
+            // board sync step, and the approvals workflow can key off them.
+            // Re-confirm the proposal by title before labelling, so a labelled
+            // non-proposal that reaches this job never picks these up.
+            if (!isProposalTitle(title)) return;
+
+            const current = (context.payload.issue.labels || []).map((l) => l.name);
+            const toAdd = missingLabels(current, PROPOSAL_LABELS);
+            if (toAdd.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: toAdd });
+              core.info(`Bootstrapped proposal labels: ${toAdd.join(', ')}`);
+            }
 
       - name: Validate proposal
         uses: actions/github-script@v7

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -45,9 +45,10 @@ jobs:
             // land unlabeled and every label-gated proposal workflow skips.
             // Re-apply the identifying labels here so validation (below), the
             // board sync step, and the approvals workflow can key off them.
-            // Require BOTH the proposal title and the issue-form body so a
-            // magic-titled non-proposal never picks up the (token-unlocking)
-            // labels — mirrors the job gate, in a unit-tested helper.
+            // Require the exact proposal title AND the full issue-form body
+            // before applying the (token-unlocking) labels. This is stricter
+            // than the lenient job gate — the authoritative check lives here, in
+            // a unit-tested helper.
             if (!isProposalTitle(title) || !looksLikeProposalForm(body)) return;
 
             const current = (context.payload.issue.labels || []).map((l) => l.name);

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -10,15 +10,18 @@ permissions:
 
 jobs:
   validate:
-    # Run for issues already carrying the identifying labels OR for anything
-    # filed through the proposal template (title prefix). GitHub only applies a
-    # template's `labels:` for authors with triage access, so read-only
-    # proposers' issues arrive unlabeled; the title gate lets them through and
-    # the "Bootstrap proposal labels" step below re-applies the labels.
+    # Run for issues already carrying the identifying labels OR for genuine
+    # proposal-form submissions. GitHub only applies a template's `labels:` for
+    # authors with triage access, so read-only proposers' issues arrive
+    # unlabeled; the title-prefix + form-heading gate lets those through (and the
+    # "Bootstrap proposal labels" step re-applies the labels). Requiring a form
+    # heading — not just the title — keeps a magic-titled but empty issue from
+    # triggering the job (and its token-bearing board-sync step).
     if: >-
       (contains(github.event.issue.labels.*.name, 'lfx mentorship')
        && contains(github.event.issue.labels.*.name, 'Proposal'))
-      || startsWith(github.event.issue.title, '[CNCF LFX Proposal]')
+      || (startsWith(github.event.issue.title, '[CNCF LFX Proposal]')
+          && contains(github.event.issue.body, '### CNCF Project'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,19 +33,21 @@ jobs:
           script: |
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
-            const { PROPOSAL_LABELS, isProposalTitle, missingLabels } = _lib('labels.js');
+            const { PROPOSAL_LABELS, isProposalTitle, looksLikeProposalForm, missingLabels } = _lib('labels.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const title = context.payload.issue.title || '';
+            const body = context.payload.issue.body || '';
 
             // GitHub silently drops issue-template labels for authors without
             // triage access, so proposals from read-only project maintainers
             // land unlabeled and every label-gated proposal workflow skips.
             // Re-apply the identifying labels here so validation (below), the
             // board sync step, and the approvals workflow can key off them.
-            // Re-confirm the proposal by title before labelling, so a labelled
-            // non-proposal that reaches this job never picks these up.
-            if (!isProposalTitle(title)) return;
+            // Require BOTH the proposal title and the issue-form body so a
+            // magic-titled non-proposal never picks up the (token-unlocking)
+            // labels — mirrors the job gate, in a unit-tested helper.
+            if (!isProposalTitle(title) || !looksLikeProposalForm(body)) return;
 
             const current = (context.payload.issue.labels || []).map((l) => l.name);
             const toAdd = missingLabels(current, PROPOSAL_LABELS);

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -10,13 +10,14 @@ permissions:
 
 jobs:
   validate:
-    # Run for issues already carrying the identifying labels OR for genuine
-    # proposal-form submissions. GitHub only applies a template's `labels:` for
+    # Cheap pre-filter only: run when the issue already carries the identifying
+    # labels, OR its title looks like a proposal and the body carries at least
+    # the first form heading. GitHub only applies a template's `labels:` for
     # authors with triage access, so read-only proposers' issues arrive
-    # unlabeled; the title-prefix + form-heading gate lets those through (and the
-    # "Bootstrap proposal labels" step re-applies the labels). Requiring a form
-    # heading — not just the title — keeps a magic-titled but empty issue from
-    # triggering the job (and its token-bearing board-sync step).
+    # unlabeled — the title branch lets those reach the steps. This gate is
+    # deliberately loose (startsWith/contains are case-insensitive substring
+    # matches); the Bootstrap and Validate steps re-check authoritatively with
+    # looksLikeProposalForm() before mutating labels or commenting.
     if: >-
       (contains(github.event.issue.labels.*.name, 'lfx mentorship')
        && contains(github.event.issue.labels.*.name, 'Proposal'))
@@ -66,9 +67,26 @@ jobs:
             const { parseIssueForm, parseMentors } = _lib('parse.js');
             const { validateMentors, validateUpstreamUrl } = _lib('validate.js');
             const { lookupProject } = _lib('projects.js');
+            const { isProposalTitle, looksLikeProposalForm } = _lib('labels.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
+            const title = context.payload.issue.title || '';
             const body = context.payload.issue.body || '';
+
+            // ── Only validate genuine proposals ──
+            // The job gate is a lenient pre-filter (case-insensitive title +
+            // a single-heading substring), so re-check authoritatively here:
+            // proceed only if the issue already carries the identifying labels
+            // or is a real template submission (exact title + full form body).
+            // Stops a bare magic-titled issue from getting a validation comment.
+            const currentIssueLabels = (context.payload.issue.labels || []).map((l) => l.name);
+            const isProposal =
+              (currentIssueLabels.includes('lfx mentorship') && currentIssueLabels.includes('Proposal'))
+              || (isProposalTitle(title) && looksLikeProposalForm(body));
+            if (!isProposal) {
+              console.log('Not an LFX proposal (no identifying labels and body is not a proposal form); skipping validation.');
+              return;
+            }
 
             // ── Issue-form parser (lib/parse.js): splits on ### headings ──
             const fields = parseIssueForm(body);

--- a/programs/lfx-mentorship/automation/lib/labels.js
+++ b/programs/lfx-mentorship/automation/lib/labels.js
@@ -1,0 +1,40 @@
+'use strict';
+
+// Label bootstrap for LFX proposal issues.
+//
+// GitHub only applies an issue template's `labels:` when the issue author has
+// triage (or higher) access. Proposals come from external project maintainers
+// with read-only access, so the template's identifying labels are silently
+// dropped and every label-gated proposal workflow (validate, board sync,
+// approvals) skips. These helpers let the validation workflow detect a proposal
+// from its title (label-independent) and add the identifying labels itself.
+
+// Issue title prefix set by .github/ISSUE_TEMPLATE/lfx-program-proposal.yml.
+const PROPOSAL_TITLE_PREFIX = '[CNCF LFX Proposal]';
+
+// Labels every proposal must carry for the pipeline to key off. Mirrors the
+// template's `labels:` minus 'Needs Validation' — the validation step manages
+// that transient lifecycle label itself, so bootstrapping it would only add
+// and immediately remove it in the same run.
+const PROPOSAL_LABELS = ['lfx mentorship', 'Proposal'];
+
+// True when an issue title marks it as an LFX proposal. Tolerates surrounding
+// whitespace; case-sensitive to match the workflow's YAML startsWith() gate.
+function isProposalTitle(title) {
+  return typeof title === 'string' && title.trim().startsWith(PROPOSAL_TITLE_PREFIX);
+}
+
+// Given the labels already on an issue, return the required identifying labels
+// that are missing, preserving the order of `required`. Defaults to the
+// PROPOSAL_LABELS set.
+function missingLabels(current, required = PROPOSAL_LABELS) {
+  const have = new Set(current || []);
+  return required.filter((label) => !have.has(label));
+}
+
+module.exports = {
+  PROPOSAL_TITLE_PREFIX,
+  PROPOSAL_LABELS,
+  isProposalTitle,
+  missingLabels,
+};

--- a/programs/lfx-mentorship/automation/lib/labels.js
+++ b/programs/lfx-mentorship/automation/lib/labels.js
@@ -9,6 +9,8 @@
 // approvals) skips. These helpers let the validation workflow detect a proposal
 // from its title (label-independent) and add the identifying labels itself.
 
+const { parseIssueForm } = require('./parse');
+
 // Issue title prefix set by .github/ISSUE_TEMPLATE/lfx-program-proposal.yml.
 const PROPOSAL_TITLE_PREFIX = '[CNCF LFX Proposal]';
 
@@ -23,9 +25,11 @@ const PROPOSAL_LABELS = ['lfx mentorship', 'Proposal'];
 // an arbitrary issue that merely borrows the title prefix.
 const PROPOSAL_FORM_HEADINGS = ['CNCF Project', 'Term', 'Program Description', 'Mentors'];
 
-// True when an issue title marks it as an LFX proposal. Deliberately does NOT
-// trim: it must behave exactly like the workflow's YAML startsWith() gate,
-// which has no trim, so the gate and this step never disagree.
+// True when an issue title marks it as an LFX proposal. Case-sensitive and
+// untrimmed on purpose: it is the precise, authoritative check the workflow
+// steps use, matching the exact prefix the template emits. The YAML job gate's
+// startsWith() is looser (case-insensitive) but only acts as a cheap
+// pre-filter — these step-level helpers are what actually gate labelling.
 function isProposalTitle(title) {
   return typeof title === 'string' && title.startsWith(PROPOSAL_TITLE_PREFIX);
 }
@@ -33,11 +37,14 @@ function isProposalTitle(title) {
 // True when an issue body carries every required proposal-form heading. A magic
 // title alone must not let any author apply the identifying labels (which
 // unlock the token-bearing downstream workflows), so the bootstrap also
-// requires the body to look like a real template submission. Matches the
-// "### <label>" heading shape, not bare prose mentioning the field names.
+// requires the body to look like a real template submission. Detection reuses
+// parseIssueForm, so a heading only counts in the same start-of-line "### "
+// shape the rest of the pipeline relies on — not a substring mid-line or in a
+// code block.
 function looksLikeProposalForm(body, required = PROPOSAL_FORM_HEADINGS) {
   if (typeof body !== 'string' || !body) return false;
-  return required.every((heading) => body.includes(`### ${heading}`));
+  const fields = parseIssueForm(body);
+  return required.every((heading) => Object.prototype.hasOwnProperty.call(fields, heading));
 }
 
 // Given the labels already on an issue, return the required identifying labels

--- a/programs/lfx-mentorship/automation/lib/labels.js
+++ b/programs/lfx-mentorship/automation/lib/labels.js
@@ -39,8 +39,10 @@ function isProposalTitle(title) {
 // unlock the token-bearing downstream workflows), so the bootstrap also
 // requires the body to look like a real template submission. Detection reuses
 // parseIssueForm, so a heading only counts in the same start-of-line "### "
-// shape the rest of the pipeline relies on — not a substring mid-line or in a
-// code block.
+// shape the rest of the pipeline relies on, not a substring mid-line. (Like
+// parseIssueForm, it does not strip fenced code blocks, so a start-of-line
+// heading inside one still counts — harmless, since a bogus body just fails
+// validation and never advances.)
 function looksLikeProposalForm(body, required = PROPOSAL_FORM_HEADINGS) {
   if (typeof body !== 'string' || !body) return false;
   const fields = parseIssueForm(body);

--- a/programs/lfx-mentorship/automation/lib/labels.js
+++ b/programs/lfx-mentorship/automation/lib/labels.js
@@ -18,10 +18,26 @@ const PROPOSAL_TITLE_PREFIX = '[CNCF LFX Proposal]';
 // and immediately remove it in the same run.
 const PROPOSAL_LABELS = ['lfx mentorship', 'Proposal'];
 
-// True when an issue title marks it as an LFX proposal. Tolerates surrounding
-// whitespace; case-sensitive to match the workflow's YAML startsWith() gate.
+// Core headings the proposal issue form always emits (as "### <label>"; see
+// lib/parse.js parseIssueForm). Used to tell a genuine template submission from
+// an arbitrary issue that merely borrows the title prefix.
+const PROPOSAL_FORM_HEADINGS = ['CNCF Project', 'Term', 'Program Description', 'Mentors'];
+
+// True when an issue title marks it as an LFX proposal. Deliberately does NOT
+// trim: it must behave exactly like the workflow's YAML startsWith() gate,
+// which has no trim, so the gate and this step never disagree.
 function isProposalTitle(title) {
-  return typeof title === 'string' && title.trim().startsWith(PROPOSAL_TITLE_PREFIX);
+  return typeof title === 'string' && title.startsWith(PROPOSAL_TITLE_PREFIX);
+}
+
+// True when an issue body carries every required proposal-form heading. A magic
+// title alone must not let any author apply the identifying labels (which
+// unlock the token-bearing downstream workflows), so the bootstrap also
+// requires the body to look like a real template submission. Matches the
+// "### <label>" heading shape, not bare prose mentioning the field names.
+function looksLikeProposalForm(body, required = PROPOSAL_FORM_HEADINGS) {
+  if (typeof body !== 'string' || !body) return false;
+  return required.every((heading) => body.includes(`### ${heading}`));
 }
 
 // Given the labels already on an issue, return the required identifying labels
@@ -35,6 +51,8 @@ function missingLabels(current, required = PROPOSAL_LABELS) {
 module.exports = {
   PROPOSAL_TITLE_PREFIX,
   PROPOSAL_LABELS,
+  PROPOSAL_FORM_HEADINGS,
   isProposalTitle,
+  looksLikeProposalForm,
   missingLabels,
 };

--- a/programs/lfx-mentorship/automation/test/labels.test.js
+++ b/programs/lfx-mentorship/automation/test/labels.test.js
@@ -43,10 +43,11 @@ test('isProposalTitle: false for non-string input', () => {
   assert.equal(isProposalTitle(42), false);
 });
 
-// Case-sensitive, matching the workflow's YAML startsWith() gate. A lowercased
-// prefix would be filtered out by the gate before the step runs, so lib parity
-// keeps the two in agreement.
-test('isProposalTitle: case-sensitive (matches YAML gate)', () => {
+// The step-level helper is precise: case-sensitive and untrimmed, matching the
+// exact prefix the template emits. (The YAML job gate's startsWith() is looser
+// — case-insensitive — but only a pre-filter, so the helper being stricter is
+// safe and intentional.)
+test('isProposalTitle: case-sensitive (stricter than the pre-filter gate)', () => {
   assert.equal(isProposalTitle('[cncf lfx proposal] Foo'), false);
 });
 
@@ -82,6 +83,18 @@ test('looksLikeProposalForm: false for a bare heading label without the ### pref
   // Prose that merely mentions the field names must not count as a form.
   const prose = PROPOSAL_FORM_HEADINGS.join(', ');
   assert.equal(looksLikeProposalForm(prose), false);
+});
+
+test('looksLikeProposalForm: a mid-line "### CNCF Project" does not count (start-of-line only)', () => {
+  // Only headings at the start of a line count (parseIssueForm's /^### +/m), so
+  // a substring buried mid-line cannot fake a form and unlock the labels.
+  const body = [
+    'prefix ### CNCF Project',
+    '### Term\n\nx',
+    '### Program Description\n\nx',
+    '### Mentors\n\nx',
+  ].join('\n\n');
+  assert.equal(looksLikeProposalForm(body), false);
 });
 
 test('looksLikeProposalForm: false for empty / non-string bodies', () => {

--- a/programs/lfx-mentorship/automation/test/labels.test.js
+++ b/programs/lfx-mentorship/automation/test/labels.test.js
@@ -5,20 +5,28 @@ const assert = require('node:assert/strict');
 const {
   PROPOSAL_TITLE_PREFIX,
   PROPOSAL_LABELS,
+  PROPOSAL_FORM_HEADINGS,
   isProposalTitle,
+  looksLikeProposalForm,
   missingLabels,
 } = require('../lib/labels');
 
 // ── isProposalTitle ──────────────────────────────────────────────────
 // Label-independent detection of a proposal, so the workflow can run for
 // issues from read-only authors whose template labels GitHub silently drops.
+// Behaviour is kept identical to the workflow's YAML startsWith() gate — no
+// trimming, case-sensitive — so the gate and the step never disagree.
 
 test('isProposalTitle: true for the template title prefix', () => {
   assert.equal(isProposalTitle('[CNCF LFX Proposal] Apicurio: Federated Search'), true);
 });
 
-test('isProposalTitle: tolerates surrounding whitespace', () => {
-  assert.equal(isProposalTitle('  [CNCF LFX Proposal] Foo  '), true);
+test('isProposalTitle: trailing whitespace still matches (startsWith parity)', () => {
+  assert.equal(isProposalTitle('[CNCF LFX Proposal] Foo  '), true);
+});
+
+test('isProposalTitle: leading whitespace does NOT match (startsWith parity)', () => {
+  assert.equal(isProposalTitle('  [CNCF LFX Proposal] Foo'), false);
 });
 
 test('isProposalTitle: false for an unrelated title', () => {
@@ -40,6 +48,52 @@ test('isProposalTitle: false for non-string input', () => {
 // keeps the two in agreement.
 test('isProposalTitle: case-sensitive (matches YAML gate)', () => {
   assert.equal(isProposalTitle('[cncf lfx proposal] Foo'), false);
+});
+
+// ── looksLikeProposalForm ────────────────────────────────────────────
+// A magic title alone must not let any author apply the identifying labels
+// (which unlock the token-bearing downstream workflows). Require the issue body
+// to carry the proposal issue-form's headings, so the bootstrap only fires for
+// genuine template submissions.
+
+// Minimal body carrying every required heading, in the "### <label>" shape the
+// GitHub issue form emits (see lib/parse.js parseIssueForm).
+const formBody = PROPOSAL_FORM_HEADINGS.map((h) => `### ${h}\n\nvalue`).join('\n\n');
+
+test('PROPOSAL_FORM_HEADINGS: are the core required proposal fields', () => {
+  assert.deepEqual(PROPOSAL_FORM_HEADINGS, ['CNCF Project', 'Term', 'Program Description', 'Mentors']);
+});
+
+test('looksLikeProposalForm: true when all required headings are present', () => {
+  assert.equal(looksLikeProposalForm(formBody), true);
+});
+
+test('looksLikeProposalForm: true even with extra content around the headings', () => {
+  assert.equal(looksLikeProposalForm(`intro\n\n${formBody}\n\n### Technologies\n\nGo`), true);
+});
+
+test('looksLikeProposalForm: false when any required heading is missing', () => {
+  const missingMentors = ['CNCF Project', 'Term', 'Program Description']
+    .map((h) => `### ${h}\n\nvalue`).join('\n\n');
+  assert.equal(looksLikeProposalForm(missingMentors), false);
+});
+
+test('looksLikeProposalForm: false for a bare heading label without the ### prefix', () => {
+  // Prose that merely mentions the field names must not count as a form.
+  const prose = PROPOSAL_FORM_HEADINGS.join(', ');
+  assert.equal(looksLikeProposalForm(prose), false);
+});
+
+test('looksLikeProposalForm: false for empty / non-string bodies', () => {
+  assert.equal(looksLikeProposalForm(''), false);
+  assert.equal(looksLikeProposalForm(undefined), false);
+  assert.equal(looksLikeProposalForm(null), false);
+  assert.equal(looksLikeProposalForm(42), false);
+});
+
+test('looksLikeProposalForm: honours a custom required-headings list', () => {
+  assert.equal(looksLikeProposalForm('### Only\n\nx', ['Only']), true);
+  assert.equal(looksLikeProposalForm('### Only\n\nx', ['Only', 'Missing']), false);
 });
 
 // ── PROPOSAL_LABELS ──────────────────────────────────────────────────

--- a/programs/lfx-mentorship/automation/test/labels.test.js
+++ b/programs/lfx-mentorship/automation/test/labels.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  PROPOSAL_TITLE_PREFIX,
+  PROPOSAL_LABELS,
+  isProposalTitle,
+  missingLabels,
+} = require('../lib/labels');
+
+// ── isProposalTitle ──────────────────────────────────────────────────
+// Label-independent detection of a proposal, so the workflow can run for
+// issues from read-only authors whose template labels GitHub silently drops.
+
+test('isProposalTitle: true for the template title prefix', () => {
+  assert.equal(isProposalTitle('[CNCF LFX Proposal] Apicurio: Federated Search'), true);
+});
+
+test('isProposalTitle: tolerates surrounding whitespace', () => {
+  assert.equal(isProposalTitle('  [CNCF LFX Proposal] Foo  '), true);
+});
+
+test('isProposalTitle: false for an unrelated title', () => {
+  assert.equal(isProposalTitle('Bug: something is broken'), false);
+});
+
+test('isProposalTitle: false for an empty string', () => {
+  assert.equal(isProposalTitle(''), false);
+});
+
+test('isProposalTitle: false for non-string input', () => {
+  assert.equal(isProposalTitle(undefined), false);
+  assert.equal(isProposalTitle(null), false);
+  assert.equal(isProposalTitle(42), false);
+});
+
+// Case-sensitive, matching the workflow's YAML startsWith() gate. A lowercased
+// prefix would be filtered out by the gate before the step runs, so lib parity
+// keeps the two in agreement.
+test('isProposalTitle: case-sensitive (matches YAML gate)', () => {
+  assert.equal(isProposalTitle('[cncf lfx proposal] Foo'), false);
+});
+
+// ── PROPOSAL_LABELS ──────────────────────────────────────────────────
+// Frozen contract: these are the identifying labels every proposal workflow
+// (validate, board-sync, approvals) gates on. 'Needs Validation' is excluded
+// deliberately — the validation step manages that transient label itself.
+
+test('PROPOSAL_LABELS: exactly the two identifying labels, in order', () => {
+  assert.deepEqual(PROPOSAL_LABELS, ['lfx mentorship', 'Proposal']);
+});
+
+test('PROPOSAL_TITLE_PREFIX: matches the issue template title prefix', () => {
+  assert.equal(PROPOSAL_TITLE_PREFIX, '[CNCF LFX Proposal]');
+});
+
+// ── missingLabels ────────────────────────────────────────────────────
+
+test('missingLabels: all required when the issue has none', () => {
+  assert.deepEqual(missingLabels([]), ['lfx mentorship', 'Proposal']);
+});
+
+test('missingLabels: only the absent one when a label is already present', () => {
+  assert.deepEqual(missingLabels(['Proposal']), ['lfx mentorship']);
+  assert.deepEqual(missingLabels(['lfx mentorship']), ['Proposal']);
+});
+
+test('missingLabels: empty when both are already present', () => {
+  assert.deepEqual(missingLabels(['lfx mentorship', 'Proposal']), []);
+});
+
+test('missingLabels: ignores unrelated labels already on the issue', () => {
+  assert.deepEqual(missingLabels(['lfx mentorship', 'Proposal', 'Needs Validation']), []);
+});
+
+test('missingLabels: treats missing/undefined current labels as none', () => {
+  assert.deepEqual(missingLabels(undefined), ['lfx mentorship', 'Proposal']);
+});
+
+test('missingLabels: preserves the order of the required list', () => {
+  assert.deepEqual(
+    missingLabels([], ['Proposal', 'lfx mentorship']),
+    ['Proposal', 'lfx mentorship'],
+  );
+});


### PR DESCRIPTION
## What
Make the validation job run for any proposal-titled issue and bootstrap the
identifying labels (`lfx mentorship`, `Proposal`) when they're missing.

## Why
GitHub only applies an issue template's `labels:` for authors with triage
access. LFX proposers are external maintainers with read access, so the labels
were silently dropped — four proposals (#1915–#1918) opened with zero labels
and every label-gated workflow (validate, board sync, approvals) skipped.

## Changes
- Gate now also matches the `[CNCF LFX Proposal]` title prefix, not just labels
- New "Bootstrap proposal labels" step re-applies missing identifying labels
- Detection logic (`isProposalTitle`, `missingLabels`) + 14 tests in `lib/labels.js`

## Test plan
- `node --test` in `programs/lfx-mentorship/automation` — new `labels.test.js` green

