### PR TITLE
Warn when an LFX proposal lists fewer than two mentors

### DIFF
--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -154,8 +154,10 @@ jobs:
 
             // ── 7b. Mentor count preference (soft; decision in lib/validate.js) ──
             // Programs are encouraged to have at least two mentors; a lone
-            // experienced mentor is acceptable, so this only warns.
-            if (mentorCountWarning(mentorResult.count)) {
+            // experienced mentor is acceptable, so this only warns. Passing the
+            // whole result keeps the "skip when the field is invalid" decision
+            // in the tested lib, not here.
+            if (mentorCountWarning(mentorResult)) {
               warnings.push(
                 'Only one mentor is listed. We usually prefer at least two mentors per program — ' +
                 'if you can, consider adding a co-mentor. '

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -26,7 +26,7 @@ jobs:
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
             const { parseIssueForm, parseMentors } = _lib('parse.js');
-            const { validateMentors, validateUpstreamUrl } = _lib('validate.js');
+            const { validateMentors, validateUpstreamUrl, mentorCountWarning } = _lib('validate.js');
             const { lookupProject } = _lib('projects.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
@@ -150,6 +150,17 @@ jobs:
             if (mentorResult.ok) {
               const primaryName = parseMentors(mentorsRaw)[0].name;
               passed.push(`Mentors: ${mentorResult.count} listed (primary: ${primaryName})`);
+            }
+
+            // ── 7b. Mentor count preference (soft; decision in lib/validate.js) ──
+            // Programs are encouraged to have at least two mentors; a lone
+            // experienced mentor is acceptable, so this only warns.
+            if (mentorCountWarning(mentorResult.count)) {
+              warnings.push(
+                'Only one mentor is listed. We usually prefer at least two mentors per program — ' +
+                'if you can, consider adding a co-mentor (another community member is a great option). ' +
+                "A single experienced mentor is fine if a second isn't feasible."
+              );
             }
 
             // ── 8. Upstream Issue URL (decisions in lib/validate.js) ──

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -158,8 +158,7 @@ jobs:
             if (mentorCountWarning(mentorResult.count)) {
               warnings.push(
                 'Only one mentor is listed. We usually prefer at least two mentors per program — ' +
-                'if you can, consider adding a co-mentor (another community member is a great option). ' +
-                "A single experienced mentor is fine if a second isn't feasible."
+                'if you can, consider adding a co-mentor. '
               );
             }
 

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -160,7 +160,7 @@ jobs:
             if (mentorCountWarning(mentorResult)) {
               warnings.push(
                 'Only one mentor is listed. We usually prefer at least two mentors per program — ' +
-                'if you can, consider adding a co-mentor. '
+                'if you can, consider adding a co-mentor.'
               );
             }
 

--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -78,6 +78,22 @@ function validateUpstreamUrl(raw) {
   return null;
 }
 
+// LFX programs are encouraged — not required — to have at least two mentors, so
+// the load is shared and a co-mentor can cover absences. This is a soft
+// preference the reviewers have long applied by hand (see PRs #1321, #1323,
+// #1348): a lone experienced mentor is acceptable. Given a mentor count,
+// returns a warning descriptor { code, count } when at least one but fewer than
+// MIN_PREFERRED_MENTORS are listed, else null. Zero mentors is already a hard
+// error (validateMentors 'empty'), so it is not nudged here. Prose stays in the
+// workflow, mirroring the error-code pattern of validateMentors.
+const MIN_PREFERRED_MENTORS = 2;
+
+function mentorCountWarning(count) {
+  if (typeof count !== 'number' || !Number.isFinite(count)) return null;
+  if (count >= 1 && count < MIN_PREFERRED_MENTORS) return { code: 'few-mentors', count };
+  return null;
+}
+
 module.exports = {
   emailRe,
   urlRe,
@@ -85,4 +101,6 @@ module.exports = {
   lfidRe,
   validateMentors,
   validateUpstreamUrl,
+  mentorCountWarning,
+  MIN_PREFERRED_MENTORS,
 };

--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -81,14 +81,19 @@ function validateUpstreamUrl(raw) {
 // LFX programs are encouraged — not required — to have at least two mentors, so
 // the load is shared and a co-mentor can cover absences. This is a soft
 // preference the reviewers have long applied by hand (see PRs #1321, #1323,
-// #1348): a lone experienced mentor is acceptable. Given a mentor count,
-// returns a warning descriptor { code, count } when at least one but fewer than
-// MIN_PREFERRED_MENTORS are listed, else null. Zero mentors is already a hard
-// error (validateMentors 'empty'), so it is not nudged here. Prose stays in the
+// #1348): a lone experienced mentor is acceptable. Given a validateMentors()
+// result, returns a warning descriptor { code, count } when the field is valid
+// but lists at least one and fewer than MIN_PREFERRED_MENTORS mentors, else
+// null. Stays silent when validation failed (result.ok === false): the count is
+// unreliable then and the proposer already has hard errors to fix, so nudging
+// "only one mentor" on top would be misleading. Zero mentors is likewise a hard
+// error (validateMentors 'empty'), so it is not nudged. Prose stays in the
 // workflow, mirroring the error-code pattern of validateMentors.
 const MIN_PREFERRED_MENTORS = 2;
 
-function mentorCountWarning(count) {
+function mentorCountWarning(result) {
+  if (!result || result.ok !== true) return null;
+  const { count } = result;
   if (typeof count !== 'number' || !Number.isFinite(count)) return null;
   if (count >= 1 && count < MIN_PREFERRED_MENTORS) return { code: 'few-mentors', count };
   return null;

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -5,9 +5,39 @@ const assert = require('node:assert/strict');
 const {
   emailRe, urlRe, ghHandleRe, lfidRe,
   validateMentors, validateUpstreamUrl,
+  mentorCountWarning, MIN_PREFERRED_MENTORS,
 } = require('../lib/validate');
 
 const codes = (result) => result.errors.map(e => e.code);
+
+// ── mentorCountWarning ───────────────────────────────────────────────
+// Soft preference (not a hard rule): programs are encouraged to have at least
+// two mentors so the load is shared, but a lone experienced mentor is fine.
+
+test('MIN_PREFERRED_MENTORS: the preferred minimum is two', () => {
+  assert.equal(MIN_PREFERRED_MENTORS, 2);
+});
+
+test('mentorCountWarning: one mentor is flagged as below the preference', () => {
+  assert.deepEqual(mentorCountWarning(1), { code: 'few-mentors', count: 1 });
+});
+
+test('mentorCountWarning: two or more mentors are not flagged', () => {
+  assert.equal(mentorCountWarning(2), null);
+  assert.equal(mentorCountWarning(3), null);
+  assert.equal(mentorCountWarning(4), null);
+});
+
+test('mentorCountWarning: zero mentors is not flagged (already a hard error)', () => {
+  assert.equal(mentorCountWarning(0), null);
+});
+
+test('mentorCountWarning: non-finite / non-number input returns null', () => {
+  assert.equal(mentorCountWarning(undefined), null);
+  assert.equal(mentorCountWarning(null), null);
+  assert.equal(mentorCountWarning('1'), null);
+  assert.equal(mentorCountWarning(NaN), null);
+});
 
 test('validateMentors: a full valid 4-field line passes with no errors', () => {
   assert.deepEqual(

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -13,30 +13,46 @@ const codes = (result) => result.errors.map(e => e.code);
 // ── mentorCountWarning ───────────────────────────────────────────────
 // Soft preference (not a hard rule): programs are encouraged to have at least
 // two mentors so the load is shared, but a lone experienced mentor is fine.
+// Takes the validateMentors() result so it can stay silent when the field is
+// invalid — the count is unreliable then and the proposer already has hard
+// errors to fix, so the nudge would be misleading noise.
+
+const okResult = (count) => ({ ok: true, count, errors: [] });
+const badResult = (count) => ({ ok: false, count, errors: [{ code: 'lfid-missing' }] });
 
 test('MIN_PREFERRED_MENTORS: the preferred minimum is two', () => {
   assert.equal(MIN_PREFERRED_MENTORS, 2);
 });
 
-test('mentorCountWarning: one mentor is flagged as below the preference', () => {
-  assert.deepEqual(mentorCountWarning(1), { code: 'few-mentors', count: 1 });
+test('mentorCountWarning: one valid mentor is flagged as below the preference', () => {
+  assert.deepEqual(mentorCountWarning(okResult(1)), { code: 'few-mentors', count: 1 });
 });
 
-test('mentorCountWarning: two or more mentors are not flagged', () => {
-  assert.equal(mentorCountWarning(2), null);
-  assert.equal(mentorCountWarning(3), null);
-  assert.equal(mentorCountWarning(4), null);
+test('mentorCountWarning: two or more valid mentors are not flagged', () => {
+  assert.equal(mentorCountWarning(okResult(2)), null);
+  assert.equal(mentorCountWarning(okResult(3)), null);
+  assert.equal(mentorCountWarning(okResult(4)), null);
 });
 
 test('mentorCountWarning: zero mentors is not flagged (already a hard error)', () => {
-  assert.equal(mentorCountWarning(0), null);
+  assert.equal(mentorCountWarning(okResult(0)), null);
 });
 
-test('mentorCountWarning: non-finite / non-number input returns null', () => {
+test('mentorCountWarning: a single MALFORMED mentor is not flagged (validation failed)', () => {
+  // One line, wrong shape: count is 1 but ok is false. The proposer already has
+  // a hard error, so we must not also nudge "only one mentor listed".
+  assert.equal(mentorCountWarning(badResult(1)), null);
+});
+
+test('mentorCountWarning: null / missing result returns null', () => {
   assert.equal(mentorCountWarning(undefined), null);
   assert.equal(mentorCountWarning(null), null);
-  assert.equal(mentorCountWarning('1'), null);
-  assert.equal(mentorCountWarning(NaN), null);
+});
+
+test('mentorCountWarning: non-finite / non-number count returns null', () => {
+  assert.equal(mentorCountWarning(okResult(NaN)), null);
+  assert.equal(mentorCountWarning(okResult('1')), null);
+  assert.equal(mentorCountWarning({ ok: true }), null);
 });
 
 test('validateMentors: a full valid 4-field line passes with no errors', () => {


### PR DESCRIPTION
## What
Add a soft validation warning when a proposal lists only one mentor.

## Why
Reviewers have long asked for at least two mentors per program (PRs #1321,
#1323, #1348) but enforced it by hand. A lone experienced mentor is still
acceptable, so this warns rather than blocks.

## Changes
- `mentorCountWarning()` in `lib/validate.js` (+5 tests): flags exactly one
  mentor, silent at zero (already a hard error) and two-plus
- Validation comment renders the note

## Test plan
- `node --test` in `programs/lfx-mentorship/automation` — `validate.test.js` green
