### PR TITLE
Auto-satisfy LFX proposal gates when the proposer is a maintainer/mentor

### DIFF
--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -37,6 +37,7 @@ jobs:
             const { buildReadme } = _lib('readme.js');
             const { csvEscape } = _lib('csv.js');
             const { lookupProject } = _lib('projects.js');
+            const { lfxTitle } = _lib('title.js');
             const { owner, repo } = context.repo;
             const term = context.payload.inputs.term;
 
@@ -72,8 +73,7 @@ jobs:
 
               const project = get('CNCF Project');
               const programName = get('Program Name');
-              const termToken = term.replace(/\s*\(.*$/, '');
-              const fullName = `CNCF - ${project}: ${programName} (${termToken})`;
+              const fullName = lfxTitle({ project, programName, term });
 
               const skillsSame = (get('Skills same as Technologies?') || '')
                 .match(/\[x\]/i);

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -277,8 +277,9 @@ jobs:
 
               // Per-mentor confirmation: the gate flips only once EVERY listed
               // mentor has confirmed. Gather confirmations from the issue's
-              // comment history (plus this one) and compare to the roster
-              // (tally logic in lib/confirm.js).
+              // comment history (plus this one) and the issue author (a
+              // proposer who lists themselves as a mentor counts as confirmed),
+              // compared to the roster (tally logic in lib/confirm.js).
               let priorComments = [];
               try {
                 priorComments = await github.paginate(github.rest.issues.listComments, {
@@ -287,7 +288,8 @@ jobs:
               } catch (e) {
                 core.warning(`Could not read prior confirmations: ${e.message}`);
               }
-              const { remaining, count, total } = computeConfirm(confirmHandles, commenter, priorComments);
+              const proposer = context.payload.issue.user?.login;
+              const { remaining, count, total } = computeConfirm(confirmHandles, commenter, priorComments, proposer);
               if (remaining.length) {
                 await reply('✅',
                   `Confirmation recorded from @${commenter}. ` +

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -33,7 +33,7 @@ jobs:
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
             const { parseIssueForm, parseMentors } = _lib('parse.js');
-            const { findMaintainerInCsv, isProjectMaintainer } = _lib('maintainers.js');
+            const { resolveProjectMaintainer } = _lib('authorize.js');
             const { computeConfirm } = _lib('confirm.js');
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
@@ -151,52 +151,20 @@ jobs:
                 }
               }
 
-              // 1. Check {org}/.project/maintainers.yaml (only if has_dot_project)
-              if (!authorized && ghOrg && hasDotProject) {
-                try {
-                  const resp = await fetch(
-                    `https://raw.githubusercontent.com/${ghOrg}/.project/main/maintainers.yaml`
-                  );
-                  if (resp.ok) {
-                    const yaml = await resp.text();
-                    // Tier-1 lookup lives in lib/maintainers.js: a js-yaml parse
-                    // of the .project schema that authorizes only members of the
-                    // exactly-named project-maintainers team. Unit-tested in
-                    // test/maintainers.test.js (cncf/mentoring#1908 follow-up).
-                    if (isProjectMaintainer(yaml, commenter)) {
-                      authorized = true;
-                      authSource = `${ghOrg}/.project/maintainers.yaml`;
-                    } else {
-                      console.log(`.project/maintainers.yaml found for ${ghOrg} but ${commenter} not in project-maintainers team`);
-                    }
-                  } else {
-                    console.log(`${ghOrg}/.project not found (HTTP ${resp.status}); falling back to CSV`);
-                  }
-                } catch (e) {
-                  console.log(`.project check failed: ${e.message}`);
-                }
-              }
-
-              // 2. Check cncf/foundation project-maintainers.csv.
-              // The CSV is grouped: the Project column is set only on each
-              // group's first row, so the lookup forward-fills it before
-              // matching the handle. Extracted to lib/maintainers.js so the
-              // authorization decision is unit-tested (cncf/mentoring#1908).
-              if (!authorized && project) {
-                try {
-                  const resp = await fetch(
-                    'https://raw.githubusercontent.com/cncf/foundation/main/project-maintainers.csv'
-                  );
-                  if (resp.ok) {
-                    const csv = await resp.text();
-                    const hit = findMaintainerInCsv(csv, project, commenter);
-                    if (hit.authorized) {
-                      authorized = true;
-                      authSource = `project-maintainers.csv (${hit.project})`;
-                    }
-                  }
-                } catch (e) {
-                  console.log(`project-maintainers.csv check failed: ${e.message}`);
+              // 1-2. Project-maintainer rosters: {org}/.project/maintainers.yaml
+              // (when adopted), then cncf/foundation project-maintainers.csv.
+              // Extracted to lib/authorize.js so the same "is @handle a project
+              // maintainer?" decision also drives proposer-implied approval in
+              // the validation workflow. Tier-3 (approvers.yml) stays inline
+              // below — delegates/global approvers are not project maintainers.
+              if (!authorized) {
+                const r = await resolveProjectMaintainer({
+                  handle: commenter, project, org: ghOrg, hasDotProject,
+                  fetchFn: fetch, log: (m) => console.log(m),
+                });
+                if (r.authorized) {
+                  authorized = true;
+                  authSource = r.source;
                 }
               }
 

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -351,9 +351,12 @@ jobs:
             let mentorsConfirmed = currentLabels.includes('Mentors Confirmed');
             let maintainerAutoApproved = false;
             if (errors.length === 0) {
-              // Maintainer gate: is the proposer a project maintainer? (If a
-              // maintainer edited, they are the OP, so the proposer check covers
-              // "the editor is a maintainer".)
+              // Maintainer gate: is the proposer a project maintainer?
+              // Deliberately keyed off the PROPOSER, not the editor: a project
+              // maintainer can only edit an issue when they are the OP, and the
+              // only others with edit rights on this repo are trusted CNCF/TOC
+              // collaborators — so keeping the proposer's approval across a
+              // non-OP edit is acceptable and not an approval bypass.
               if (!maintainerApproved && proposer) {
                 try {
                   const projYaml = fs.readFileSync('programs/lfx-mentorship/automation/projects.yml', 'utf8');

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -473,11 +473,12 @@ jobs:
             }
 
             // ── Notify approvers when a material edit cleared their approval ──
-            // Tag whoever recorded the maintainer / CNCF approval we just cleared
-            // so they can re-review the changed proposal.
+            // Only on a material edit (the "edited after approval" message would
+            // be misleading if CNCF was cleared by a gate regression instead).
+            // Tag whoever recorded the maintainer / CNCF approval we cleared.
             const clearedMaintainer = gate.remove.includes('Maintainer/Contribex Approved');
             const clearedCncf = gate.remove.includes('CNCF Approved');
-            if (clearedMaintainer || clearedCncf) {
+            if (materialChange && (clearedMaintainer || clearedCncf)) {
               const { maintainers, cncfAdmins } = findRecordedApprovers(issueComments);
               const toTag = [];
               if (clearedMaintainer) for (const h of maintainers) toTag.push(h);

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -354,14 +354,13 @@ jobs:
                   console.log(`proposer maintainer check failed: ${e.message}`);
                 }
               }
-              // Mentor gate: does the proposer's own slot complete the roster?
-              // (computeConfirm also counts any mentors who already /confirmed.)
-              if (!mentorsConfirmed) {
-                const roster = parseMentors(mentorsRaw).map(m => m.github_handle);
-                if (computeConfirm(roster, null, issueComments, proposer).flip) {
-                  mentorsConfirmed = true;
-                }
-              }
+              // Mentor gate: recompute from the CURRENT roster so adding an
+              // unconfirmed mentor re-opens confirmation (and a removed mentor
+              // resolves it). computeConfirm counts the proposer's own slot plus
+              // any mentors who already /confirmed. Unlike the maintainer gate,
+              // this is NOT monotonic — it reflects the present roster.
+              const roster = parseMentors(mentorsRaw).map(m => m.github_handle);
+              mentorsConfirmed = computeConfirm(roster, null, issueComments, proposer).flip;
             }
 
             // ── Build validation comment ──

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -72,13 +72,14 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
-            const { parseIssueForm, parseMentors } = _lib('parse.js');
+            const { parseIssueForm, parseMentors, formFieldsChanged } = _lib('parse.js');
             const { validateMentors, validateUpstreamUrl, mentorCountWarning } = _lib('validate.js');
             const { lookupProject } = _lib('projects.js');
             const { isProposalTitle, looksLikeProposalForm } = _lib('labels.js');
             const { resolveProjectMaintainer } = _lib('authorize.js');
             const { computeConfirm } = _lib('confirm.js');
             const { gateLabelChanges } = _lib('gates.js');
+            const { findRecordedApprovers } = _lib('approvals.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const title = context.payload.issue.title || '';
@@ -315,15 +316,25 @@ jobs:
               'https://mentorship.lfx.linuxfoundation.org.'
             );
 
-            // ── Proposer-implied approval & confirmation ──
+            // ── Proposer-implied approval / confirmation & edit invalidation ──
             // A proposal filed by a project maintainer implies their approval;
-            // one filed by a listed mentor implies that mentor's confirmation
-            // (both actions the proposer could take by hand). Resolve them here
-            // so the comment wording and the gate labels reflect them. Only
-            // meaningful when validation passes. Existing recorded approvals /
-            // confirmations are honored and never downgraded.
+            // one filed by a listed mentor implies that mentor's confirmation.
+            // Conversely, a MATERIAL edit (a parsed form field changed) after a
+            // maintainer or CNCF approval invalidates it — the approved content
+            // changed — so we clear it and tag whoever approved. Mentor
+            // confirmation is a participation commitment and is NOT cleared by
+            // content edits; only roster changes move the mentor gate.
             const currentLabels = (context.payload.issue.labels || []).map(l => l.name);
             const proposer = context.payload.issue.user?.login || '';
+
+            // Material change: on an edit, did any parsed form field (or the
+            // title) change? Cosmetic edits (whitespace, a prepended comment)
+            // are not material, so re-triggering validation won't reset anything.
+            const changes = context.payload.changes || {};
+            const materialChange = context.payload.action === 'edited'
+              && (!!changes.title
+                  || (!!changes.body && formFieldsChanged(changes.body.from || '', body)));
+
             let issueComments = [];
             try {
               issueComments = await github.paginate(github.rest.issues.listComments, {
@@ -333,11 +344,16 @@ jobs:
               core.warning(`Could not read issue comments: ${e.message}`);
             }
 
-            let maintainerApproved = currentLabels.includes('Maintainer/Contribex Approved');
+            // Honor an existing maintainer approval only on a non-material edit;
+            // a material edit forces it to be re-earned (proposer-implied below,
+            // or a fresh /approve).
+            let maintainerApproved = currentLabels.includes('Maintainer/Contribex Approved') && !materialChange;
             let mentorsConfirmed = currentLabels.includes('Mentors Confirmed');
-            let approvalNote = '';
+            let maintainerAutoApproved = false;
             if (errors.length === 0) {
-              // Maintainer gate: is the proposer a project maintainer?
+              // Maintainer gate: is the proposer a project maintainer? (If a
+              // maintainer edited, they are the OP, so the proposer check covers
+              // "the editor is a maintainer".)
               if (!maintainerApproved && proposer) {
                 try {
                   const projYaml = fs.readFileSync('programs/lfx-mentorship/automation/projects.yml', 'utf8');
@@ -348,17 +364,16 @@ jobs:
                   });
                   if (r.authorized) {
                     maintainerApproved = true;
-                    approvalNote = r.source;
+                    maintainerAutoApproved = true;
                   }
                 } catch (e) {
                   console.log(`proposer maintainer check failed: ${e.message}`);
                 }
               }
               // Mentor gate: recompute from the CURRENT roster so adding an
-              // unconfirmed mentor re-opens confirmation (and a removed mentor
-              // resolves it). computeConfirm counts the proposer's own slot plus
-              // any mentors who already /confirmed. Unlike the maintainer gate,
-              // this is NOT monotonic — it reflects the present roster.
+              // unconfirmed mentor re-opens confirmation (and a removed/swapped
+              // mentor resolves from persisted /confirm comments). Counts the
+              // proposer's own slot. NOT monotonic — reflects the present roster.
               const roster = parseMentors(mentorsRaw).map(m => m.github_handle);
               mentorsConfirmed = computeConfirm(roster, null, issueComments, proposer).flip;
             }
@@ -397,7 +412,7 @@ jobs:
                 '',
               );
               lines.push(maintainerApproved
-                ? `1. **Maintainer approval:** ✅ recorded${approvalNote ? ` — proposer @${proposer} is a project maintainer` : ''}.`
+                ? `1. **Maintainer approval:** ✅ recorded${maintainerAutoApproved ? ` — proposer @${proposer} is a project maintainer` : ''}.`
                 : '1. **Maintainer approval:** a maintainer of the CNCF project (or an authorized delegate) comments `/approve`.');
               lines.push(mentorsConfirmed
                 ? '2. **Mentor confirmation:** ✅ recorded.'
@@ -445,16 +460,37 @@ jobs:
 
             // ── Approval / confirmation gates (decision in lib/gates.js) ──
             // Auto-satisfy the maintainer gate when the proposer is a project
-            // maintainer, and the mentor gate when the proposer's slot completes
-            // the roster; otherwise fall back to the awaiting labels. When both
-            // gates end up satisfied, signal the CNCF admin. Regressed
-            // validation just clears the awaiting labels.
-            const gate = gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, currentLabels });
+            // maintainer, and the mentor gate when the current roster is fully
+            // confirmed; otherwise set the awaiting labels. A material edit
+            // clears the maintainer and CNCF approvals (content changed); when
+            // both gates hold, signal the CNCF admin.
+            const gate = gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, materialChange, currentLabels });
             for (const name of gate.remove) {
               try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name }); } catch {}
             }
             if (gate.add.length) {
               await github.rest.issues.addLabels({ owner, repo, issue_number, labels: gate.add });
+            }
+
+            // ── Notify approvers when a material edit cleared their approval ──
+            // Tag whoever recorded the maintainer / CNCF approval we just cleared
+            // so they can re-review the changed proposal.
+            const clearedMaintainer = gate.remove.includes('Maintainer/Contribex Approved');
+            const clearedCncf = gate.remove.includes('CNCF Approved');
+            if (clearedMaintainer || clearedCncf) {
+              const { maintainers, cncfAdmins } = findRecordedApprovers(issueComments);
+              const toTag = [];
+              if (clearedMaintainer) for (const h of maintainers) toTag.push(h);
+              if (clearedCncf) for (const h of cncfAdmins) toTag.push(h);
+              const mentions = [...new Set(toTag)].map(h => `@${h}`).join(' ');
+              const what = [clearedMaintainer && 'maintainer approval', clearedCncf && 'CNCF admin approval']
+                .filter(Boolean).join(' and ');
+              await github.rest.issues.createComment({
+                owner, repo, issue_number,
+                body: `♻️ This proposal was edited after approval, so its ${what} ` +
+                  `${clearedMaintainer && clearedCncf ? 'have' : 'has'} been cleared and must be granted again.` +
+                  (mentions ? `\n\n${mentions} — please re-review the updated proposal.` : ''),
+              });
             }
 
             // ── Term labels ──

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -327,13 +327,16 @@ jobs:
             const currentLabels = (context.payload.issue.labels || []).map(l => l.name);
             const proposer = context.payload.issue.user?.login || '';
 
-            // Material change: on an edit, did any parsed form field (or the
-            // title) change? Cosmetic edits (whitespace, a prepended comment)
-            // are not material, so re-triggering validation won't reset anything.
+            // Material change: on an edit, did any parsed form field change
+            // (whitespace-normalized)? Cosmetic edits (whitespace, a prepended
+            // comment, text reflow) are not material, so re-triggering
+            // validation won't reset anything. The issue TITLE is ignored — it
+            // is auto-derived from body fields (`[CNCF LFX Proposal] <project>
+            // <program>`), which are the source of truth, so a title-only edit
+            // isn't a content change.
             const changes = context.payload.changes || {};
             const materialChange = context.payload.action === 'edited'
-              && (!!changes.title
-                  || (!!changes.body && formFieldsChanged(changes.body.from || '', body)));
+              && !!changes.body && formFieldsChanged(changes.body.from || '', body);
 
             let issueComments = [];
             try {

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -428,7 +428,7 @@ jobs:
               lines.push('', '### What happens next', '');
               lines.push(
                 (maintainerApproved && mentorsConfirmed)
-                  ? 'Maintainer approval and mentor confirmation are already in place (the proposer is a project maintainer and/or listed mentor), so this proposal goes straight to final CNCF admin review.'
+                  ? 'Maintainer approval and mentor confirmation are already in place, so this proposal goes straight to final CNCF admin review.'
                   : 'This proposal is now waiting on the people below. No further action is needed from the proposer unless validation flags a change.',
                 '',
               );
@@ -504,7 +504,12 @@ jobs:
               const toTag = [];
               if (clearedMaintainer) for (const h of maintainers) toTag.push(h);
               if (clearedCncf) for (const h of cncfAdmins) toTag.push(h);
-              const mentions = [...new Set(toTag)].map(h => `@${h}`).join(' ');
+              // De-dupe case-insensitively (a global approver can appear in both
+              // lists), preserving first-seen casing.
+              const seenTag = new Set();
+              const mentions = toTag
+                .filter(h => { const k = h.toLowerCase(); if (seenTag.has(k)) return false; seenTag.add(k); return true; })
+                .map(h => `@${h}`).join(' ');
               const what = [clearedMaintainer && 'maintainer approval', clearedCncf && 'CNCF admin approval']
                 .filter(Boolean).join(' and ');
               await github.rest.issues.createComment({

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -80,6 +80,7 @@ jobs:
             const { computeConfirm } = _lib('confirm.js');
             const { gateLabelChanges } = _lib('gates.js');
             const { findRecordedApprovers } = _lib('approvals.js');
+            const { lfxTitle, programNameBudget, LFX_TITLE_MAX } = _lib('title.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const title = context.payload.issue.title || '';
@@ -129,15 +130,13 @@ jobs:
             if (!programName) {
               errors.push('Program Name is empty.');
             } else {
-              // Budget: 100 - len("CNCF - ") - len(project) - len(": ") - len(" (") - len(term_token) - len(")")
-              // term_token is e.g. "2026 Term 2" extracted from "2026 Term 2 (Jun-Aug)"
-              const termToken = term.replace(/\s*\(.*$/, '');
-              const overhead = 'CNCF - '.length + (project?.length || 0) + ': '.length + ' ('.length + termToken.length + ')'.length;
-              const budget = 100 - overhead;
+              // The full title is "CNCF - <project>: <name> (<term>)" capped at
+              // LFX_TITLE_MAX; budget/format live in lib/title.js.
+              const budget = programNameBudget({ project, term });
               if (programName.length > budget) {
                 errors.push(
                   `Program Name is ${programName.length} chars but only ${budget} are available ` +
-                  `(full name would be ${overhead + programName.length}/100 chars). Please shorten it.`
+                  `(full name would be ${LFX_TITLE_MAX - budget + programName.length}/${LFX_TITLE_MAX} chars). Please shorten it.`
                 );
               } else {
                 passed.push(`Program Name length: ${programName.length}/${budget} chars available`);
@@ -386,6 +385,22 @@ jobs:
 
             // ── Build validation comment ──
             const lines = ['## 🤖 LFX Proposal Validation', ''];
+
+            // Show the full LFX title up top (what the program will be called on
+            // the platform), with its length against the 100-char cap, whenever
+            // the parts are present.
+            if (project && programName && term) {
+              const fullTitle = lfxTitle({ project, programName, term });
+              const over = fullTitle.length > LFX_TITLE_MAX ? ' ⚠️ over limit' : '';
+              lines.push(
+                `**LFX program title** (${fullTitle.length}/${LFX_TITLE_MAX} chars${over}):`,
+                '',
+                '```',
+                fullTitle,
+                '```',
+                '',
+              );
+            }
 
             if (errors.length === 0) {
               lines.push('✅ **All checks passed.**', '');

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        # lib/authorize.js -> lib/maintainers.js parses .project/maintainers.yaml
+        # with js-yaml (proposer-implied maintainer approval). --ignore-scripts
+        # blocks dependency lifecycle scripts (js-yaml needs none).
+        working-directory: programs/lfx-mentorship/automation
+        run: npm install --no-save --ignore-scripts js-yaml@4.3.0
+
       - name: Bootstrap proposal labels
         uses: actions/github-script@v7
         with:
@@ -69,6 +76,9 @@ jobs:
             const { validateMentors, validateUpstreamUrl, mentorCountWarning } = _lib('validate.js');
             const { lookupProject } = _lib('projects.js');
             const { isProposalTitle, looksLikeProposalForm } = _lib('labels.js');
+            const { resolveProjectMaintainer } = _lib('authorize.js');
+            const { computeConfirm } = _lib('confirm.js');
+            const { gateLabelChanges } = _lib('gates.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const title = context.payload.issue.title || '';
@@ -305,6 +315,55 @@ jobs:
               'https://mentorship.lfx.linuxfoundation.org.'
             );
 
+            // ── Proposer-implied approval & confirmation ──
+            // A proposal filed by a project maintainer implies their approval;
+            // one filed by a listed mentor implies that mentor's confirmation
+            // (both actions the proposer could take by hand). Resolve them here
+            // so the comment wording and the gate labels reflect them. Only
+            // meaningful when validation passes. Existing recorded approvals /
+            // confirmations are honored and never downgraded.
+            const currentLabels = (context.payload.issue.labels || []).map(l => l.name);
+            const proposer = context.payload.issue.user?.login || '';
+            let issueComments = [];
+            try {
+              issueComments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number, per_page: 100,
+              });
+            } catch (e) {
+              core.warning(`Could not read issue comments: ${e.message}`);
+            }
+
+            let maintainerApproved = currentLabels.includes('Maintainer/Contribex Approved');
+            let mentorsConfirmed = currentLabels.includes('Mentors Confirmed');
+            let approvalNote = '';
+            if (errors.length === 0) {
+              // Maintainer gate: is the proposer a project maintainer?
+              if (!maintainerApproved && proposer) {
+                try {
+                  const projYaml = fs.readFileSync('programs/lfx-mentorship/automation/projects.yml', 'utf8');
+                  const info = lookupProject(projYaml, project) || {};
+                  const r = await resolveProjectMaintainer({
+                    handle: proposer, project, org: info.org, hasDotProject: info.hasDotProject,
+                    fetchFn: fetch, log: (m) => console.log(m),
+                  });
+                  if (r.authorized) {
+                    maintainerApproved = true;
+                    approvalNote = r.source;
+                  }
+                } catch (e) {
+                  console.log(`proposer maintainer check failed: ${e.message}`);
+                }
+              }
+              // Mentor gate: does the proposer's own slot complete the roster?
+              // (computeConfirm also counts any mentors who already /confirmed.)
+              if (!mentorsConfirmed) {
+                const roster = parseMentors(mentorsRaw).map(m => m.github_handle);
+                if (computeConfirm(roster, null, issueComments, proposer).flip) {
+                  mentorsConfirmed = true;
+                }
+              }
+            }
+
             // ── Build validation comment ──
             const lines = ['## 🤖 LFX Proposal Validation', ''];
 
@@ -331,18 +390,21 @@ jobs:
             if (errors.length === 0) {
               const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
               const guideUrl = `${repoUrl}/blob/main/programs/lfx-mentorship/README.md#what-happens-after-you-submit`;
+              lines.push('', '### What happens next', '');
               lines.push(
+                (maintainerApproved && mentorsConfirmed)
+                  ? 'Maintainer approval and mentor confirmation are already in place (the proposer is a project maintainer and/or listed mentor), so this proposal goes straight to final CNCF admin review.'
+                  : 'This proposal is now waiting on the people below. No further action is needed from the proposer unless validation flags a change.',
                 '',
-                '### What happens next',
-                '',
-                'This proposal is now waiting on the people below. No further action is needed from the proposer unless validation flags a change.',
-                '',
-                '1. **Maintainer approval:** a maintainer of the CNCF project (or an authorized delegate) comments `/approve`.',
-                '2. **Mentor confirmation:** each mentor listed on the proposal comments `/confirm`.',
-                '3. **CNCF approval:** once both are in place, a CNCF mentorship admin comments `/cncf-approve` to finalize.',
-                '',
-                `See the [proposal process guide](${guideUrl}) for full details.`
               );
+              lines.push(maintainerApproved
+                ? `1. **Maintainer approval:** ✅ recorded${approvalNote ? ` — proposer @${proposer} is a project maintainer` : ''}.`
+                : '1. **Maintainer approval:** a maintainer of the CNCF project (or an authorized delegate) comments `/approve`.');
+              lines.push(mentorsConfirmed
+                ? '2. **Mentor confirmation:** ✅ recorded.'
+                : '2. **Mentor confirmation:** each mentor listed on the proposal comments `/confirm`.');
+              lines.push('3. **CNCF approval:** once both are in place, a CNCF mentorship admin comments `/cncf-approve` to finalize.');
+              lines.push('', `See the [proposal process guide](${guideUrl}) for full details.`);
             }
 
             lines.push('', '---', '_Re-run by editing the issue._');
@@ -350,10 +412,7 @@ jobs:
 
             // ── Upsert comment ──
             const marker = '## 🤖 LFX Proposal Validation';
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number, per_page: 100,
-            });
-            const prior = comments.find(c =>
+            const prior = issueComments.find(c =>
               c.user?.login === 'github-actions[bot]' && c.body?.startsWith(marker)
             );
             if (prior) {
@@ -363,7 +422,6 @@ jobs:
             }
 
             // ── Manage labels ──
-            const currentLabels = (context.payload.issue.labels || []).map(l => l.name);
             const pass = errors.length === 0;
             const addLabel = pass ? 'Validation Passed' : 'Validation Failed';
             const dropLabel = pass ? 'Validation Failed' : 'Validation Passed';
@@ -386,30 +444,18 @@ jobs:
               try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'Over Quota' }); } catch {}
             }
 
-            // ── Set awaiting labels when validation passes ──
-            // These signal to maintainers and mentors that slash commands are expected.
-            if (pass) {
-              const awaiting = [];
-              if (!currentLabels.includes('Maintainer/Contribex Approved')
-                  && !currentLabels.includes('Awaiting Maintainer/Contribex Approval')) {
-                awaiting.push('Awaiting Maintainer/Contribex Approval');
-              }
-              if (!currentLabels.includes('Mentors Confirmed')
-                  && !currentLabels.includes('Awaiting Mentor Confirmation')) {
-                awaiting.push('Awaiting Mentor Confirmation');
-              }
-              if (awaiting.length) {
-                await github.rest.issues.addLabels({ owner, repo, issue_number, labels: awaiting });
-              }
-            } else {
-              // Validation regressed (previously passing, now failing): clear the
-              // awaiting labels so the board does not show "waiting on approvals"
-              // while slash commands are gated off by the lost Validation Passed.
-              for (const name of ['Awaiting Maintainer/Contribex Approval', 'Awaiting Mentor Confirmation']) {
-                if (currentLabels.includes(name)) {
-                  try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name }); } catch {}
-                }
-              }
+            // ── Approval / confirmation gates (decision in lib/gates.js) ──
+            // Auto-satisfy the maintainer gate when the proposer is a project
+            // maintainer, and the mentor gate when the proposer's slot completes
+            // the roster; otherwise fall back to the awaiting labels. When both
+            // gates end up satisfied, signal the CNCF admin. Regressed
+            // validation just clears the awaiting labels.
+            const gate = gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, currentLabels });
+            for (const name of gate.remove) {
+              try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name }); } catch {}
+            }
+            if (gate.add.length) {
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: gate.add });
             }
 
             // ── Term labels ──

--- a/programs/lfx-mentorship/README.md
+++ b/programs/lfx-mentorship/README.md
@@ -110,6 +110,15 @@ The form asks for:
    platform and the term's README. You'll be notified on your issue when the
    export happens.
 
+> [!IMPORTANT]
+> **Editing a proposal after approval resets it.** If you make a substantive
+> edit (change a form field — description, mentors, dates, etc.) after a
+> maintainer or CNCF admin has approved, that approval is automatically cleared
+> and must be granted again; the bot tags the approver(s) to re-review. Cosmetic
+> edits (whitespace) don't reset anything. Mentor confirmations aren't cleared by
+> content edits, but adding or swapping a mentor re-opens confirmation for the
+> new mentor.
+
 You can track your proposal's progress via the labels on the issue and on
 the [project board](https://github.com/orgs/cncf/projects/93).
 

--- a/programs/lfx-mentorship/README.md
+++ b/programs/lfx-mentorship/README.md
@@ -92,11 +92,15 @@ The form asks for:
 
 2. **Maintainer approval** — a maintainer of the CNCF project (or an
    authorized delegate) must comment `/approve` on the issue. The bot checks
-   the commenter against the project's maintainer list.
+   the commenter against the project's maintainer list. **If the proposer is
+   themselves a project maintainer, this is granted automatically** — filing
+   the proposal implies their approval, so no `/approve` is needed.
 
 3. **Mentor confirmation** — each mentor listed on the proposal must comment
    `/confirm` on the issue. This verifies they've agreed to mentor for this
-   term and that their GitHub handle is correct.
+   term and that their GitHub handle is correct. **A mentor who filed the
+   proposal is counted as confirmed automatically** for their own slot; any
+   other listed mentors still `/confirm`.
 
 4. **CNCF admin approval** — once maintainer approval and mentor
    confirmation are in place, a CNCF mentorship admin reviews and comments

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -62,9 +62,11 @@ Before using `/cncf-approve` on a proposal, verify:
 
 - [ ] Validation has passed (green `Validation Passed` label)
 - [ ] A project maintainer has commented `/approve` (`Maintainer/Contribex
-  Approved` label is present)
+  Approved` label is present) — or the proposer is themselves a project
+  maintainer, in which case validation grants it automatically
 - [ ] All listed mentors have commented `/confirm` (`Mentors Confirmed`
-  label is present)
+  label is present) — a mentor who filed the proposal is auto-counted for
+  their own slot
 - [ ] The program description is appropriate and clearly scoped
 - [ ] If the issue has the `Over Quota` label, confirm the project is aware
   they're over the per-term limit and the exception is intentional

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -76,6 +76,17 @@ To approve, comment `/cncf-approve` on the issue. The bot will:
 - Remove the `Awaiting CNCF Admin Approval` label
 - Update the project board status
 
+> [!NOTE]
+> **Edits after approval reset the content approvals.** If a proposal is edited
+> so that a form field changes (a "material" edit) after maintainer or CNCF
+> approval, validation clears those approvals, re-adds the `Awaiting …` labels,
+> and posts a comment tagging the prior approver(s) to re-review. Cosmetic edits
+> (whitespace, re-triggering validation) don't reset anything. Mentor
+> confirmations persist across content edits; adding or swapping a mentor
+> re-opens confirmation for the new mentor only. This means a maintainer who is
+> the proposer keeps their approval across their own edits (re-granted
+> automatically), but a CNCF admin must always re-approve after a material edit.
+
 Only users listed in `approvers.yml` under `global_approvers` can use
 `/cncf-approve`.
 

--- a/programs/lfx-mentorship/automation/lib/approvals.js
+++ b/programs/lfx-mentorship/automation/lib/approvals.js
@@ -13,19 +13,22 @@ const MAINTAINER_RE = /Maintainer approval recorded from @([A-Za-z0-9-]+)/g;
 const CNCF_RE = /CNCF admin approval granted by @([A-Za-z0-9-]+)/g;
 
 // comments: [{ user: { login }, body }] → { maintainers: [], cncfAdmins: [] }
-// (handles in first-seen order, de-duplicated).
+// (handles in first-seen order; de-duplicated case-insensitively, since GitHub
+// logins are case-insensitive, while preserving the first-seen casing).
 function findRecordedApprovers(comments) {
   const maintainers = [];
   const cncfAdmins = [];
+  const seenM = new Set();
+  const seenC = new Set();
+  const add = (arr, seen, handle) => {
+    const key = handle.toLowerCase();
+    if (!seen.has(key)) { seen.add(key); arr.push(handle); }
+  };
   for (const c of comments || []) {
     if ((c.user && c.user.login) !== 'github-actions[bot]') continue;
     const body = c.body || '';
-    for (const m of body.matchAll(MAINTAINER_RE)) {
-      if (!maintainers.includes(m[1])) maintainers.push(m[1]);
-    }
-    for (const m of body.matchAll(CNCF_RE)) {
-      if (!cncfAdmins.includes(m[1])) cncfAdmins.push(m[1]);
-    }
+    for (const m of body.matchAll(MAINTAINER_RE)) add(maintainers, seenM, m[1]);
+    for (const m of body.matchAll(CNCF_RE)) add(cncfAdmins, seenC, m[1]);
   }
   return { maintainers, cncfAdmins };
 }

--- a/programs/lfx-mentorship/automation/lib/approvals.js
+++ b/programs/lfx-mentorship/automation/lib/approvals.js
@@ -1,0 +1,33 @@
+'use strict';
+
+// Scan an issue's comments for the approval records that the /approve and
+// /cncf-approve handlers post (lfx-proposal-approvals.yml), so the validation
+// workflow can @-tag the people whose approval it clears after a material edit.
+//
+// Coupled to those confirmation-comment strings — if the approvals workflow
+// changes the wording, update these patterns (and their tests) with it. Only
+// github-actions[bot] comments are scanned, so a user quoting the phrase can't
+// spoof an approver.
+
+const MAINTAINER_RE = /Maintainer approval recorded from @([A-Za-z0-9-]+)/g;
+const CNCF_RE = /CNCF admin approval granted by @([A-Za-z0-9-]+)/g;
+
+// comments: [{ user: { login }, body }] → { maintainers: [], cncfAdmins: [] }
+// (handles in first-seen order, de-duplicated).
+function findRecordedApprovers(comments) {
+  const maintainers = [];
+  const cncfAdmins = [];
+  for (const c of comments || []) {
+    if ((c.user && c.user.login) !== 'github-actions[bot]') continue;
+    const body = c.body || '';
+    for (const m of body.matchAll(MAINTAINER_RE)) {
+      if (!maintainers.includes(m[1])) maintainers.push(m[1]);
+    }
+    for (const m of body.matchAll(CNCF_RE)) {
+      if (!cncfAdmins.includes(m[1])) cncfAdmins.push(m[1]);
+    }
+  }
+  return { maintainers, cncfAdmins };
+}
+
+module.exports = { findRecordedApprovers };

--- a/programs/lfx-mentorship/automation/lib/authorize.js
+++ b/programs/lfx-mentorship/automation/lib/authorize.js
@@ -1,0 +1,68 @@
+'use strict';
+
+// Project-maintainer authorization resolver shared by the LFX proposal
+// workflows. Extracted from the inline tier-1 + tier-2 block of the `/approve`
+// handler (lfx-proposal-approvals.yml) so the same "is @handle a maintainer of
+// this project?" decision drives both `/approve` (commenter) and the
+// validation workflow's proposer-implied approval (issue author).
+//
+// Tier 1: {org}/.project/maintainers.yaml (source of truth once adopted).
+// Tier 2: cncf/foundation/project-maintainers.csv (legacy/fallback).
+// The tier-3 approvers.yml fallbacks (per-project delegates, global approvers)
+// are intentionally NOT included here: a delegate or global approver filing a
+// proposal is not the project maintainers endorsing it, so proposer-implied
+// approval is limited to real project maintainers.
+//
+// Network I/O is injected via `fetchFn` (defaults to global fetch) so the
+// resolver is unit-testable without hitting the network.
+
+const { isProjectMaintainer, findMaintainerInCsv } = require('./maintainers.js');
+
+const DOT_PROJECT_URL = (org) => `https://raw.githubusercontent.com/${org}/.project/main/maintainers.yaml`;
+const CSV_URL = 'https://raw.githubusercontent.com/cncf/foundation/main/project-maintainers.csv';
+
+// Resolve whether `handle` is a project maintainer authorized to approve
+// proposals for `project`. Returns { authorized: boolean, source: string },
+// where source is a human-readable origin for the approval (empty when not
+// authorized). Mirrors the source strings the /approve handler reported.
+async function resolveProjectMaintainer({ handle, project, org, hasDotProject, fetchFn = fetch, log = () => {} }) {
+  if (!handle) return { authorized: false, source: '' };
+
+  // Tier 1: {org}/.project/maintainers.yaml (only when the project adopted it)
+  if (org && hasDotProject) {
+    try {
+      const resp = await fetchFn(DOT_PROJECT_URL(org));
+      if (resp.ok) {
+        const yaml = await resp.text();
+        if (isProjectMaintainer(yaml, handle)) {
+          return { authorized: true, source: `${org}/.project/maintainers.yaml` };
+        }
+        log(`.project/maintainers.yaml found for ${org} but ${handle} not in project-maintainers team`);
+      } else {
+        log(`${org}/.project not found (HTTP ${resp.status}); falling back to CSV`);
+      }
+    } catch (e) {
+      log(`.project check failed: ${e.message}`);
+    }
+  }
+
+  // Tier 2: cncf/foundation project-maintainers.csv
+  if (project) {
+    try {
+      const resp = await fetchFn(CSV_URL);
+      if (resp.ok) {
+        const csv = await resp.text();
+        const hit = findMaintainerInCsv(csv, project, handle);
+        if (hit.authorized) {
+          return { authorized: true, source: `project-maintainers.csv (${hit.project})` };
+        }
+      }
+    } catch (e) {
+      log(`project-maintainers.csv check failed: ${e.message}`);
+    }
+  }
+
+  return { authorized: false, source: '' };
+}
+
+module.exports = { resolveProjectMaintainer, DOT_PROJECT_URL, CSV_URL };

--- a/programs/lfx-mentorship/automation/lib/authorize.js
+++ b/programs/lfx-mentorship/automation/lib/authorize.js
@@ -56,6 +56,8 @@ async function resolveProjectMaintainer({ handle, project, org, hasDotProject, f
         if (hit.authorized) {
           return { authorized: true, source: `project-maintainers.csv (${hit.project})` };
         }
+      } else {
+        log(`project-maintainers.csv fetch failed (HTTP ${resp.status})`);
       }
     } catch (e) {
       log(`project-maintainers.csv check failed: ${e.message}`);

--- a/programs/lfx-mentorship/automation/lib/confirm.js
+++ b/programs/lfx-mentorship/automation/lib/confirm.js
@@ -1,27 +1,35 @@
 'use strict';
 
 // Per-mentor confirmation tally for the `/confirm` handler in
-// lfx-proposal-approvals.yml. The Mentor Confirmation gate flips only once
+// lfx-proposal-approvals.yml and the proposer-implied confirmation in
+// lfx-proposal-validate.yml. The Mentor Confirmation gate flips only once
 // EVERY listed mentor has confirmed. Confirmations are gathered from the
-// issue's comment history (plus the current commenter) and compared to the
-// roster.
+// issue's comment history (plus the current commenter and the issue author)
+// and compared to the roster.
 //
 // mentorHandles: GitHub handles parsed from the Mentors field (with or without
 //   a leading '@'); deduplicated and lower-cased here.
-// commenter: the login of the mentor issuing this `/confirm`.
+// commenter: the login of the mentor issuing this `/confirm` (may be null when
+//   evaluated outside a comment, e.g. at validation time).
 // comments: prior issue comments, each { user: { login }, body }.
+// author: the issue author (proposer). Counted as a confirmation when on the
+//   roster — filing a proposal that lists yourself as a mentor is itself your
+//   commitment to mentor, so it counts as that mentor's `/confirm`.
 //
 // A comment counts as a confirmation only when its author is on the roster and
 // a line in its body starts with `/confirm` (mid-sentence mentions do not
 // count).
-function computeConfirm(mentorHandles, commenter, comments) {
-  const roster = [...new Set(mentorHandles.map(h => h.replace(/^@/, '').toLowerCase()))];
-  const confirmed = new Set([commenter.toLowerCase()]);
+function computeConfirm(mentorHandles, commenter, comments, author) {
+  const norm = (h) => String(h || '').replace(/^@/, '').trim().toLowerCase();
+  const roster = [...new Set(mentorHandles.map(norm))];
+  const confirmed = new Set();
+  if (commenter) confirmed.add(norm(commenter));
+  if (author && roster.includes(norm(author))) confirmed.add(norm(author));
   const hasConfirm = (body) => (body || '').split(/\r?\n/)
     .some(l => /^\/confirm\b/.test(l.trim()));
   for (const c of comments) {
-    const author = (c.user?.login || '').toLowerCase();
-    if (roster.includes(author) && hasConfirm(c.body)) confirmed.add(author);
+    const commentAuthor = norm(c.user?.login);
+    if (roster.includes(commentAuthor) && hasConfirm(c.body)) confirmed.add(commentAuthor);
   }
   const remaining = roster.filter(h => !confirmed.has(h));
   return { flip: remaining.length === 0, remaining, count: confirmed.size, total: roster.length };

--- a/programs/lfx-mentorship/automation/lib/confirm.js
+++ b/programs/lfx-mentorship/automation/lib/confirm.js
@@ -18,13 +18,15 @@
 //
 // A comment counts as a confirmation only when its author is on the roster and
 // a line in its body starts with `/confirm` (mid-sentence mentions do not
-// count).
+// count). The commenter and issue author are likewise only counted when they
+// are on the roster, so `count` never exceeds the roster.
 function computeConfirm(mentorHandles, commenter, comments, author) {
   const norm = (h) => String(h || '').replace(/^@/, '').trim().toLowerCase();
   const roster = [...new Set(mentorHandles.map(norm))];
+  const onRoster = (h) => h && roster.includes(norm(h));
   const confirmed = new Set();
-  if (commenter) confirmed.add(norm(commenter));
-  if (author && roster.includes(norm(author))) confirmed.add(norm(author));
+  if (onRoster(commenter)) confirmed.add(norm(commenter));
+  if (onRoster(author)) confirmed.add(norm(author));
   const hasConfirm = (body) => (body || '').split(/\r?\n/)
     .some(l => /^\/confirm\b/.test(l.trim()));
   for (const c of comments) {

--- a/programs/lfx-mentorship/automation/lib/gates.js
+++ b/programs/lfx-mentorship/automation/lib/gates.js
@@ -39,12 +39,12 @@ function gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, material
   const add = [];
   const remove = [];
 
-  // Validation regressed (previously passing, now failing): clear only the
-  // awaiting labels so the board doesn't show "waiting on approvals" while the
-  // slash commands are gated off by the lost Validation Passed. Recorded
-  // approvals/confirmations are left intact (as before).
+  // Validation regressed (previously passing, now failing): clear the awaiting
+  // prompts (maintainer, mentor, and CNCF-admin) so nothing shows "waiting on
+  // approvals" while the slash commands are gated off by the lost Validation
+  // Passed. Recorded approvals/confirmations are left intact (as before).
   if (!pass) {
-    for (const l of [AWAITING_MAINTAINER, AWAITING_MENTORS]) if (has(l)) remove.push(l);
+    for (const l of [AWAITING_MAINTAINER, AWAITING_MENTORS, AWAITING_CNCF]) if (has(l)) remove.push(l);
     return { add, remove };
   }
 

--- a/programs/lfx-mentorship/automation/lib/gates.js
+++ b/programs/lfx-mentorship/automation/lib/gates.js
@@ -1,0 +1,67 @@
+'use strict';
+
+// Pure label-transition logic for the LFX proposal validation workflow's
+// approval/confirmation gates. Given the resolved gate state (whether the
+// proposer implies maintainer approval and/or mentor confirmation) and the
+// labels currently on the issue, return the label mutations to apply. The
+// workflow performs the I/O; the decision lives here so it is unit-tested.
+//
+// Gates:
+//   - Maintainer: 'Maintainer/Contribex Approved' vs 'Awaiting Maintainer/Contribex Approval'
+//   - Mentor:     'Mentors Confirmed'              vs 'Awaiting Mentor Confirmation'
+// When BOTH are satisfied, signal readiness for the CNCF admin with
+// 'Awaiting CNCF Admin Approval' (mirrors the approvals workflow's
+// checkBothGates), unless already CNCF-approved.
+
+const MAINTAINER_APPROVED = 'Maintainer/Contribex Approved';
+const AWAITING_MAINTAINER = 'Awaiting Maintainer/Contribex Approval';
+const MENTORS_CONFIRMED = 'Mentors Confirmed';
+const AWAITING_MENTORS = 'Awaiting Mentor Confirmation';
+const AWAITING_CNCF = 'Awaiting CNCF Admin Approval';
+const CNCF_APPROVED = 'CNCF Approved';
+
+// { pass, maintainerApproved, mentorsConfirmed, currentLabels } → { add, remove }.
+// maintainerApproved / mentorsConfirmed reflect the proposer-implied resolution
+// for THIS run; existing labels are still honored (idempotent, never downgrades
+// an approval/confirmation already recorded by a slash command).
+function gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, currentLabels }) {
+  const has = (l) => currentLabels.includes(l);
+  const add = [];
+  const remove = [];
+
+  // Validation regressed (previously passing, now failing): clear only the
+  // awaiting labels so the board doesn't show "waiting on approvals" while the
+  // slash commands are gated off by the lost Validation Passed. Recorded
+  // approvals/confirmations are left intact (as before).
+  if (!pass) {
+    for (const l of [AWAITING_MAINTAINER, AWAITING_MENTORS]) if (has(l)) remove.push(l);
+    return { add, remove };
+  }
+
+  // Maintainer gate
+  if (maintainerApproved) {
+    if (!has(MAINTAINER_APPROVED)) add.push(MAINTAINER_APPROVED);
+    if (has(AWAITING_MAINTAINER)) remove.push(AWAITING_MAINTAINER);
+  } else if (!has(MAINTAINER_APPROVED) && !has(AWAITING_MAINTAINER)) {
+    add.push(AWAITING_MAINTAINER);
+  }
+
+  // Mentor gate
+  if (mentorsConfirmed) {
+    if (!has(MENTORS_CONFIRMED)) add.push(MENTORS_CONFIRMED);
+    if (has(AWAITING_MENTORS)) remove.push(AWAITING_MENTORS);
+  } else if (!has(MENTORS_CONFIRMED) && !has(AWAITING_MENTORS)) {
+    add.push(AWAITING_MENTORS);
+  }
+
+  // Both gates satisfied (now or already) → await CNCF admin.
+  const willHaveMaintainer = maintainerApproved || has(MAINTAINER_APPROVED);
+  const willHaveMentors = mentorsConfirmed || has(MENTORS_CONFIRMED);
+  if (willHaveMaintainer && willHaveMentors && !has(CNCF_APPROVED) && !has(AWAITING_CNCF)) {
+    add.push(AWAITING_CNCF);
+  }
+
+  return { add, remove };
+}
+
+module.exports = { gateLabelChanges };

--- a/programs/lfx-mentorship/automation/lib/gates.js
+++ b/programs/lfx-mentorship/automation/lib/gates.js
@@ -20,18 +20,21 @@ const AWAITING_MENTORS = 'Awaiting Mentor Confirmation';
 const AWAITING_CNCF = 'Awaiting CNCF Admin Approval';
 const CNCF_APPROVED = 'CNCF Approved';
 
-// { pass, maintainerApproved, mentorsConfirmed, currentLabels } → { add, remove }.
+// { pass, maintainerApproved, mentorsConfirmed, materialChange, currentLabels }
+//   → { add, remove }.
 //
-// maintainerApproved: is the maintainer gate satisfied (an existing /approve OR
-//   the proposer being a project maintainer)? MONOTONIC — honored once set and
-//   never downgraded here, since an approval may have come from a maintainer
-//   other than the author.
+// maintainerApproved: is the maintainer gate satisfied THIS run — an existing
+//   /approve (honored on non-material edits) OR the proposer being a project
+//   maintainer? A material edit that is NOT re-approved clears it (content the
+//   maintainer signed off on changed).
 // mentorsConfirmed: are ALL current mentors confirmed, freshly recomputed from
-//   the current roster (proposer's own slot + any /confirm comments)? This can
-//   go false again when a new, unconfirmed mentor is added, so the label may be
-//   downgraded back to "awaiting" — unless the proposal is already CNCF-approved
-//   (finalized, left alone).
-function gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, currentLabels }) {
+//   the current roster (proposer's own slot + persisted /confirm comments)?
+//   Roster-driven: adding an unconfirmed mentor flips it false; a non-roster
+//   edit keeps everyone confirmed (their /confirm comments still count).
+// materialChange: did a parsed form field change (vs a cosmetic edit)? A
+//   material edit invalidates content approvals — the maintainer's (unless
+//   re-approved) and the CNCF admin's.
+function gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, materialChange, currentLabels }) {
   const has = (l) => currentLabels.includes(l);
   const add = [];
   const remove = [];
@@ -45,29 +48,42 @@ function gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, currentL
     return { add, remove };
   }
 
-  // Maintainer gate (monotonic)
+  // Maintainer gate: satisfied when approved this run; a material edit that
+  // isn't re-approved clears it (see maintainerApproved above).
   if (maintainerApproved) {
     if (!has(MAINTAINER_APPROVED)) add.push(MAINTAINER_APPROVED);
     if (has(AWAITING_MAINTAINER)) remove.push(AWAITING_MAINTAINER);
+  } else if (materialChange && has(MAINTAINER_APPROVED)) {
+    remove.push(MAINTAINER_APPROVED);
+    if (!has(AWAITING_MAINTAINER)) add.push(AWAITING_MAINTAINER);
   } else if (!has(MAINTAINER_APPROVED) && !has(AWAITING_MAINTAINER)) {
     add.push(AWAITING_MAINTAINER);
   }
 
-  // Mentor gate (reflects the current roster; can downgrade unless finalized)
+  // Mentor gate: roster-driven. Not cleared by content edits (persisted
+  // /confirm comments still count); only a roster change moves it.
   if (mentorsConfirmed) {
     if (!has(MENTORS_CONFIRMED)) add.push(MENTORS_CONFIRMED);
     if (has(AWAITING_MENTORS)) remove.push(AWAITING_MENTORS);
-  } else if (!has(CNCF_APPROVED)) {
+  } else {
     if (has(MENTORS_CONFIRMED)) remove.push(MENTORS_CONFIRMED);
     if (!has(AWAITING_MENTORS)) add.push(AWAITING_MENTORS);
   }
 
-  // Both gates satisfied AFTER the changes above → signal the CNCF admin;
-  // otherwise clear that signal if a gate just regressed (unless finalized).
+  // CNCF approval is valid only while both gates hold AND the approved content
+  // is unchanged. A material edit, or either gate regressing, invalidates it.
   const willHaveMaintainer = (maintainerApproved || has(MAINTAINER_APPROVED)) && !remove.includes(MAINTAINER_APPROVED);
   const willHaveMentors = (mentorsConfirmed || has(MENTORS_CONFIRMED)) && !remove.includes(MENTORS_CONFIRMED);
-  if (willHaveMaintainer && willHaveMentors) {
-    if (!has(CNCF_APPROVED) && !has(AWAITING_CNCF)) add.push(AWAITING_CNCF);
+  const bothGates = willHaveMaintainer && willHaveMentors;
+  if (has(CNCF_APPROVED) && (materialChange || !bothGates)) {
+    remove.push(CNCF_APPROVED);
+  }
+  const cncfApprovedAfter = has(CNCF_APPROVED) && !remove.includes(CNCF_APPROVED);
+
+  // Signal the CNCF admin when both gates hold and it isn't already approved;
+  // otherwise clear that signal if a gate regressed.
+  if (bothGates && !cncfApprovedAfter) {
+    if (!has(AWAITING_CNCF)) add.push(AWAITING_CNCF);
   } else if (has(AWAITING_CNCF)) {
     remove.push(AWAITING_CNCF);
   }

--- a/programs/lfx-mentorship/automation/lib/gates.js
+++ b/programs/lfx-mentorship/automation/lib/gates.js
@@ -21,9 +21,16 @@ const AWAITING_CNCF = 'Awaiting CNCF Admin Approval';
 const CNCF_APPROVED = 'CNCF Approved';
 
 // { pass, maintainerApproved, mentorsConfirmed, currentLabels } → { add, remove }.
-// maintainerApproved / mentorsConfirmed reflect the proposer-implied resolution
-// for THIS run; existing labels are still honored (idempotent, never downgrades
-// an approval/confirmation already recorded by a slash command).
+//
+// maintainerApproved: is the maintainer gate satisfied (an existing /approve OR
+//   the proposer being a project maintainer)? MONOTONIC — honored once set and
+//   never downgraded here, since an approval may have come from a maintainer
+//   other than the author.
+// mentorsConfirmed: are ALL current mentors confirmed, freshly recomputed from
+//   the current roster (proposer's own slot + any /confirm comments)? This can
+//   go false again when a new, unconfirmed mentor is added, so the label may be
+//   downgraded back to "awaiting" — unless the proposal is already CNCF-approved
+//   (finalized, left alone).
 function gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, currentLabels }) {
   const has = (l) => currentLabels.includes(l);
   const add = [];
@@ -38,7 +45,7 @@ function gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, currentL
     return { add, remove };
   }
 
-  // Maintainer gate
+  // Maintainer gate (monotonic)
   if (maintainerApproved) {
     if (!has(MAINTAINER_APPROVED)) add.push(MAINTAINER_APPROVED);
     if (has(AWAITING_MAINTAINER)) remove.push(AWAITING_MAINTAINER);
@@ -46,19 +53,23 @@ function gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, currentL
     add.push(AWAITING_MAINTAINER);
   }
 
-  // Mentor gate
+  // Mentor gate (reflects the current roster; can downgrade unless finalized)
   if (mentorsConfirmed) {
     if (!has(MENTORS_CONFIRMED)) add.push(MENTORS_CONFIRMED);
     if (has(AWAITING_MENTORS)) remove.push(AWAITING_MENTORS);
-  } else if (!has(MENTORS_CONFIRMED) && !has(AWAITING_MENTORS)) {
-    add.push(AWAITING_MENTORS);
+  } else if (!has(CNCF_APPROVED)) {
+    if (has(MENTORS_CONFIRMED)) remove.push(MENTORS_CONFIRMED);
+    if (!has(AWAITING_MENTORS)) add.push(AWAITING_MENTORS);
   }
 
-  // Both gates satisfied (now or already) → await CNCF admin.
-  const willHaveMaintainer = maintainerApproved || has(MAINTAINER_APPROVED);
-  const willHaveMentors = mentorsConfirmed || has(MENTORS_CONFIRMED);
-  if (willHaveMaintainer && willHaveMentors && !has(CNCF_APPROVED) && !has(AWAITING_CNCF)) {
-    add.push(AWAITING_CNCF);
+  // Both gates satisfied AFTER the changes above → signal the CNCF admin;
+  // otherwise clear that signal if a gate just regressed (unless finalized).
+  const willHaveMaintainer = (maintainerApproved || has(MAINTAINER_APPROVED)) && !remove.includes(MAINTAINER_APPROVED);
+  const willHaveMentors = (mentorsConfirmed || has(MENTORS_CONFIRMED)) && !remove.includes(MENTORS_CONFIRMED);
+  if (willHaveMaintainer && willHaveMentors) {
+    if (!has(CNCF_APPROVED) && !has(AWAITING_CNCF)) add.push(AWAITING_CNCF);
+  } else if (has(AWAITING_CNCF)) {
+    remove.push(AWAITING_CNCF);
   }
 
   return { add, remove };

--- a/programs/lfx-mentorship/automation/lib/parse.js
+++ b/programs/lfx-mentorship/automation/lib/parse.js
@@ -59,15 +59,18 @@ function parseMentors(raw) {
 module.exports = { parseIssueForm, parseCheckboxes, parseMentors, formFieldsChanged };
 
 // True when two issue-form bodies differ in any parsed field value — i.e. the
-// edit was "material" (a field changed), not merely cosmetic (whitespace, a
-// prepended HTML comment, or a trailing newline, none of which change a parsed
-// field). Compares the { label: value } maps from parseIssueForm.
+// edit was "material" (a field's content changed), not merely cosmetic
+// (whitespace anywhere, a prepended HTML comment, a trailing newline, or
+// reflowing/re-indenting a field's text). Field values are whitespace-
+// normalized (runs of whitespace collapsed) before comparison, so only a real
+// content change counts. Compares the { label: value } maps from parseIssueForm.
 function formFieldsChanged(oldBody, newBody) {
   const a = parseIssueForm(oldBody || '');
   const b = parseIssueForm(newBody || '');
+  const norm = (v) => String(v || '').replace(/\s+/g, ' ').trim();
   const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
   for (const k of keys) {
-    if ((a[k] || '') !== (b[k] || '')) return true;
+    if (norm(a[k]) !== norm(b[k])) return true;
   }
   return false;
 }

--- a/programs/lfx-mentorship/automation/lib/parse.js
+++ b/programs/lfx-mentorship/automation/lib/parse.js
@@ -56,4 +56,18 @@ function parseMentors(raw) {
     .filter(Boolean);
 }
 
-module.exports = { parseIssueForm, parseCheckboxes, parseMentors };
+module.exports = { parseIssueForm, parseCheckboxes, parseMentors, formFieldsChanged };
+
+// True when two issue-form bodies differ in any parsed field value — i.e. the
+// edit was "material" (a field changed), not merely cosmetic (whitespace, a
+// prepended HTML comment, or a trailing newline, none of which change a parsed
+// field). Compares the { label: value } maps from parseIssueForm.
+function formFieldsChanged(oldBody, newBody) {
+  const a = parseIssueForm(oldBody || '');
+  const b = parseIssueForm(newBody || '');
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) {
+    if ((a[k] || '') !== (b[k] || '')) return true;
+  }
+  return false;
+}

--- a/programs/lfx-mentorship/automation/lib/title.js
+++ b/programs/lfx-mentorship/automation/lib/title.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// The LFX program title format, shared by the validation workflow (Program Name
+// budget check + the title shown to proposers) and the export workflow. LFX
+// caps the full title at 100 characters.
+
+const LFX_TITLE_MAX = 100;
+
+// Strip the month parenthetical from a term:
+// "2026 Term 3 (Sep-Nov)" → "2026 Term 3".
+function termToken(term) {
+  return String(term || '').replace(/\s*\(.*$/, '');
+}
+
+// Full LFX title: "CNCF - <project>: <programName> (<term token>)".
+function lfxTitle({ project, programName, term } = {}) {
+  return `CNCF - ${project || ''}: ${programName || ''} (${termToken(term)})`;
+}
+
+// Characters available for the Program Name so the full title fits within
+// LFX_TITLE_MAX (i.e. 100 minus the fixed overhead of the surrounding format).
+function programNameBudget({ project, term } = {}) {
+  return LFX_TITLE_MAX - lfxTitle({ project, programName: '', term }).length;
+}
+
+module.exports = { LFX_TITLE_MAX, termToken, lfxTitle, programNameBudget };

--- a/programs/lfx-mentorship/automation/test/approvals.test.js
+++ b/programs/lfx-mentorship/automation/test/approvals.test.js
@@ -30,3 +30,11 @@ test('empty / null input → empty result', () => {
   assert.deepEqual(findRecordedApprovers([]), { maintainers: [], cncfAdmins: [] });
   assert.deepEqual(findRecordedApprovers(null), { maintainers: [], cncfAdmins: [] });
 });
+
+test('de-dupes case-insensitively, preserving first-seen casing', () => {
+  const comments = [
+    bot('✅ Maintainer approval recorded from @CarlesArnal (source).'),
+    bot('✅ Maintainer approval recorded from @carlesarnal (again).'),
+  ];
+  assert.deepEqual(findRecordedApprovers(comments), { maintainers: ['CarlesArnal'], cncfAdmins: [] });
+});

--- a/programs/lfx-mentorship/automation/test/approvals.test.js
+++ b/programs/lfx-mentorship/automation/test/approvals.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { findRecordedApprovers } = require('../lib/approvals');
+
+const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
+
+test('finds the maintainer approver from the recorded comment', () => {
+  const comments = [bot('✅ Maintainer approval recorded from @carlesarnal (Apicurio/.project/maintainers.yaml).')];
+  assert.deepEqual(findRecordedApprovers(comments), { maintainers: ['carlesarnal'], cncfAdmins: [] });
+});
+
+test('finds the CNCF admin from the granted comment', () => {
+  const comments = [bot('🎉 CNCF admin approval granted by @nate-double-u.\n\nThis proposal is approved.')];
+  assert.deepEqual(findRecordedApprovers(comments), { maintainers: [], cncfAdmins: ['nate-double-u'] });
+});
+
+test('collects both, de-duplicates, ignores non-bot comments (anti-spoof)', () => {
+  const comments = [
+    bot('✅ Maintainer approval recorded from @alice (source).'),
+    { user: { login: 'someuser' }, body: 'Maintainer approval recorded from @evil (spoof).' },
+    bot('🎉 CNCF admin approval granted by @bob.'),
+    bot('✅ Maintainer approval recorded from @alice (again).'),
+  ];
+  assert.deepEqual(findRecordedApprovers(comments), { maintainers: ['alice'], cncfAdmins: ['bob'] });
+});
+
+test('empty / null input → empty result', () => {
+  assert.deepEqual(findRecordedApprovers([]), { maintainers: [], cncfAdmins: [] });
+  assert.deepEqual(findRecordedApprovers(null), { maintainers: [], cncfAdmins: [] });
+});

--- a/programs/lfx-mentorship/automation/test/authorize.test.js
+++ b/programs/lfx-mentorship/automation/test/authorize.test.js
@@ -136,3 +136,11 @@ test('handle match is case-insensitive and tolerates a leading @', async () => {
   const r = await resolveProjectMaintainer({ handle: '@CarlesArnal', ...APICURIO, fetchFn });
   assert.equal(r.authorized, true);
 });
+
+test('tier-2 CSV non-2xx is logged (not silently swallowed)', async () => {
+  const logs = [];
+  const fetchFn = makeFetch({ [CSV_URL]: { ok: false, status: 500 } });
+  const r = await resolveProjectMaintainer({ handle: 'someone', project: 'Foobar', org: '', hasDotProject: false, fetchFn, log: (m) => logs.push(m) });
+  assert.equal(r.authorized, false);
+  assert.ok(logs.some((m) => /project-maintainers\.csv fetch failed \(HTTP 500\)/.test(m)), `expected CSV HTTP log, got: ${JSON.stringify(logs)}`);
+});

--- a/programs/lfx-mentorship/automation/test/authorize.test.js
+++ b/programs/lfx-mentorship/automation/test/authorize.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  resolveProjectMaintainer,
+  DOT_PROJECT_URL,
+  CSV_URL,
+} = require('../lib/authorize');
+
+// ── Fixtures mirroring the real rosters ───────────────────────────────
+const dotProjectYaml = `maintainers:
+  - project_id: "apicurio-registry"
+    org: "Apicurio"
+    teams:
+      - name: "project-maintainers"
+        members:
+          - EricWittmann
+          - carlesarnal
+`;
+
+// CSV: grouped — Project column set only on a group's first row.
+// Columns: Maturity,Project,Name,Company,GitHub,OWNERS
+const csv = `Maturity,Project,Name,Company,GitHub,OWNERS
+sandbox,Foobar,Alice Example,Acme,aliceh,
+,,Bob Example,Acme,bobh,
+graduated,Kubernetes,Carol,Acme,carolh,
+`;
+
+// A fetch stub: maps URL -> { ok, status, text }. Records calls.
+function makeFetch(routes) {
+  const calls = [];
+  const fetchFn = async (url) => {
+    calls.push(url);
+    const r = routes[url];
+    if (!r) return { ok: false, status: 404, text: async () => '' };
+    if (r.throw) throw new Error('network boom');
+    return { ok: r.ok !== false, status: r.status || 200, text: async () => r.body || '' };
+  };
+  fetchFn.calls = calls;
+  return fetchFn;
+}
+
+const APICURIO = { org: 'Apicurio', hasDotProject: true, project: 'Apicurio Registry' };
+
+// ── URL builders ──────────────────────────────────────────────────────
+test('DOT_PROJECT_URL / CSV_URL match the raw.githubusercontent paths', () => {
+  assert.equal(DOT_PROJECT_URL('Apicurio'), 'https://raw.githubusercontent.com/Apicurio/.project/main/maintainers.yaml');
+  assert.equal(CSV_URL, 'https://raw.githubusercontent.com/cncf/foundation/main/project-maintainers.csv');
+});
+
+// ── Tier 1: .project/maintainers.yaml ─────────────────────────────────
+test('tier-1 authorizes a project-maintainers team member', async () => {
+  const fetchFn = makeFetch({ [DOT_PROJECT_URL('Apicurio')]: { body: dotProjectYaml } });
+  const r = await resolveProjectMaintainer({ handle: 'carlesarnal', ...APICURIO, fetchFn });
+  assert.deepEqual(r, { authorized: true, source: 'Apicurio/.project/maintainers.yaml' });
+  // Tier-2 not consulted once tier-1 authorizes.
+  assert.deepEqual(fetchFn.calls, [DOT_PROJECT_URL('Apicurio')]);
+});
+
+test('tier-1 is skipped when hasDotProject is false (goes to CSV)', async () => {
+  const fetchFn = makeFetch({ [CSV_URL]: { body: csv } });
+  const r = await resolveProjectMaintainer({ handle: 'aliceh', project: 'Foobar', org: 'Foobar', hasDotProject: false, fetchFn });
+  assert.equal(r.authorized, true);
+  assert.equal(r.source, 'project-maintainers.csv (Foobar)');
+  assert.deepEqual(fetchFn.calls, [CSV_URL]); // never fetched .project
+});
+
+test('tier-1 is skipped when org is empty', async () => {
+  const fetchFn = makeFetch({ [CSV_URL]: { body: csv } });
+  const r = await resolveProjectMaintainer({ handle: 'aliceh', project: 'Foobar', org: '', hasDotProject: true, fetchFn });
+  assert.equal(r.authorized, true);
+  assert.deepEqual(fetchFn.calls, [CSV_URL]);
+});
+
+// ── Tier 1 miss → Tier 2 fallback ─────────────────────────────────────
+test('tier-1 present but handle not on team → falls through to CSV', async () => {
+  const fetchFn = makeFetch({
+    [DOT_PROJECT_URL('Apicurio')]: { body: dotProjectYaml },
+    [CSV_URL]: { body: csv },
+  });
+  // handle only in CSV (as "aliceh" under Foobar), not in the .project team
+  const r = await resolveProjectMaintainer({ handle: 'aliceh', org: 'Apicurio', hasDotProject: true, project: 'Foobar', fetchFn });
+  assert.equal(r.authorized, true);
+  assert.equal(r.source, 'project-maintainers.csv (Foobar)');
+  assert.deepEqual(fetchFn.calls, [DOT_PROJECT_URL('Apicurio'), CSV_URL]);
+});
+
+test('tier-1 fetch 404 → falls through to CSV', async () => {
+  const fetchFn = makeFetch({
+    [DOT_PROJECT_URL('Apicurio')]: { ok: false, status: 404 },
+    [CSV_URL]: { body: csv },
+  });
+  const r = await resolveProjectMaintainer({ handle: 'bobh', ...APICURIO, project: 'Foobar', fetchFn });
+  assert.equal(r.authorized, true);
+  assert.equal(r.source, 'project-maintainers.csv (Foobar)'); // forward-filled group
+});
+
+test('tier-1 fetch throwing is caught → falls through to CSV', async () => {
+  const logs = [];
+  const fetchFn = makeFetch({
+    [DOT_PROJECT_URL('Apicurio')]: { throw: true },
+    [CSV_URL]: { body: csv },
+  });
+  const r = await resolveProjectMaintainer({ handle: 'aliceh', ...APICURIO, project: 'Foobar', fetchFn, log: (m) => logs.push(m) });
+  assert.equal(r.authorized, true);
+  assert.ok(logs.some((m) => /check failed/i.test(m)));
+});
+
+// ── Negative cases ────────────────────────────────────────────────────
+test('neither tier authorizes → not authorized, empty source', async () => {
+  const fetchFn = makeFetch({
+    [DOT_PROJECT_URL('Apicurio')]: { body: dotProjectYaml },
+    [CSV_URL]: { body: csv },
+  });
+  const r = await resolveProjectMaintainer({ handle: 'nobody', ...APICURIO, fetchFn });
+  assert.deepEqual(r, { authorized: false, source: '' });
+});
+
+test('empty handle → not authorized, no fetches', async () => {
+  const fetchFn = makeFetch({});
+  const r = await resolveProjectMaintainer({ handle: '', ...APICURIO, fetchFn });
+  assert.deepEqual(r, { authorized: false, source: '' });
+  assert.deepEqual(fetchFn.calls, []);
+});
+
+test('tier-2 not consulted when project is empty', async () => {
+  const fetchFn = makeFetch({ [DOT_PROJECT_URL('Apicurio')]: { body: dotProjectYaml } });
+  const r = await resolveProjectMaintainer({ handle: 'nobody', org: 'Apicurio', hasDotProject: true, project: '', fetchFn });
+  assert.equal(r.authorized, false);
+  assert.deepEqual(fetchFn.calls, [DOT_PROJECT_URL('Apicurio')]); // no CSV fetch
+});
+
+test('handle match is case-insensitive and tolerates a leading @', async () => {
+  const fetchFn = makeFetch({ [DOT_PROJECT_URL('Apicurio')]: { body: dotProjectYaml } });
+  const r = await resolveProjectMaintainer({ handle: '@CarlesArnal', ...APICURIO, fetchFn });
+  assert.equal(r.authorized, true);
+});

--- a/programs/lfx-mentorship/automation/test/confirm.test.js
+++ b/programs/lfx-mentorship/automation/test/confirm.test.js
@@ -71,3 +71,56 @@ test('@-prefixed roster handles are normalized', () => {
     { flip: false, remaining: ['b'], count: 1, total: 2 },
   );
 });
+
+// ── Issue author (proposer) counts as a confirmation for their own slot ──
+// A mentor who files the proposal is committing to mentor, so their authorship
+// counts as their /confirm. Passed as the 4th arg; only counts if on roster.
+
+test('the issue author is counted when on the roster (no commenter)', () => {
+  assert.deepEqual(
+    computeConfirm(['solo'], null, [], 'solo'),
+    { flip: true, remaining: [], count: 1, total: 1 },
+  );
+});
+
+test('a proposer-mentor among several does not flip alone', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [], 'a'),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('an author not on the roster is ignored', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [], 'zzz'),
+    { flip: false, remaining: ['a', 'b'], count: 0, total: 2 },
+  );
+});
+
+test('author + commenter together can complete the roster', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'b', [], 'a'),
+    { flip: true, remaining: [], count: 2, total: 2 },
+  );
+});
+
+test('author counting is case-insensitive and @-tolerant', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [], '@A'),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('author already present via a /confirm comment is not double-counted', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [{ user: { login: 'a' }, body: '/confirm' }], 'a'),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('omitting the author preserves the original 3-arg behavior', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'a', []),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});

--- a/programs/lfx-mentorship/automation/test/confirm.test.js
+++ b/programs/lfx-mentorship/automation/test/confirm.test.js
@@ -124,3 +124,39 @@ test('omitting the author preserves the original 3-arg behavior', () => {
     { flip: false, remaining: ['b'], count: 1, total: 2 },
   );
 });
+
+// ── Mentor swap / drop-out (roster changes) ───────────────────────────
+// Mentors sometimes drop out after confirming and are replaced. The tally is
+// computed from the CURRENT roster, so a dropped mentor stops counting and a
+// newly added one must confirm; kept mentors stay confirmed via their prior
+// /confirm comment.
+
+test('a dropped mentor no longer counts (off the current roster)', () => {
+  // Was [a,b] both confirmed; b dropped, c added → [a,c]. c must still confirm.
+  assert.deepEqual(
+    computeConfirm(['a', 'c'], null, [
+      { user: { login: 'a' }, body: '/confirm' },
+      { user: { login: 'b' }, body: '/confirm' },
+    ]),
+    { flip: false, remaining: ['c'], count: 1, total: 2 },
+  );
+});
+
+test('a kept mentor stays confirmed via their prior comment after a swap', () => {
+  // [a,b] both confirmed → a dropped, c added → [b,c]; b kept, c pending.
+  assert.deepEqual(
+    computeConfirm(['b', 'c'], null, [
+      { user: { login: 'a' }, body: '/confirm' },
+      { user: { login: 'b' }, body: '/confirm' },
+    ], 'someproposer'),
+    { flip: false, remaining: ['c'], count: 1, total: 2 },
+  );
+});
+
+test('removing the only unconfirmed mentor completes the roster', () => {
+  // [a,b] with only a confirmed → b removed → [a] → gate flips.
+  assert.deepEqual(
+    computeConfirm(['a'], null, [{ user: { login: 'a' }, body: '/confirm' }]),
+    { flip: true, remaining: [], count: 1, total: 1 },
+  );
+});

--- a/programs/lfx-mentorship/automation/test/confirm.test.js
+++ b/programs/lfx-mentorship/automation/test/confirm.test.js
@@ -160,3 +160,10 @@ test('removing the only unconfirmed mentor completes the roster', () => {
     { flip: true, remaining: [], count: 1, total: 1 },
   );
 });
+
+test('an off-roster commenter is not counted (self-consistent contract)', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'zzz', []),
+    { flip: false, remaining: ['a', 'b'], count: 0, total: 2 },
+  );
+});

--- a/programs/lfx-mentorship/automation/test/gates.test.js
+++ b/programs/lfx-mentorship/automation/test/gates.test.js
@@ -76,7 +76,7 @@ test('pass, already fully awaiting (re-validation, nothing auto) → no changes'
     [], []);
 });
 
-// ── Mentor gate reflects the CURRENT roster (can downgrade) ───────────
+// ── Mentor gate reflects the CURRENT roster (roster-driven; can downgrade) ──
 // If a proposal was Mentors Confirmed (e.g. sole proposer-mentor) and a new,
 // unconfirmed mentor is later added, re-validation must re-open confirmation.
 
@@ -90,12 +90,43 @@ test('pass, downgrade also clears the CNCF-admin signal', () => {
     [AMC], [MC, ACNCF]);
 });
 
-test('pass, mentor gate not met but already CNCF-approved → do NOT downgrade', () => {
-  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: false, currentLabels: [MA, MC, 'CNCF Approved'] }),
+test('pass, still confirmed on re-validation (recompute true) → no churn', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: true, currentLabels: [MA, MC, ACNCF] }),
     [], []);
 });
 
-test('pass, still confirmed on re-validation (recompute true) → no churn', () => {
-  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: true, currentLabels: [MA, MC, ACNCF] }),
+// ── Material edit clears CONTENT approvals (maintainer + CNCF) ──────────
+// A field-level edit invalidates the maintainer's and CNCF admin's approval of
+// the content. Maintainer approval survives only when re-granted this run
+// (proposer is a maintainer → maintainerApproved true). Mentor confirmation is
+// NOT cleared here (participation commitment; roster changes handle it).
+
+test('material edit, proposer not a maintainer → clear Maintainer Approved', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: true, materialChange: true, currentLabels: [MA, MC] }),
+    [AMA], [MA]);
+});
+
+test('material edit, proposer not a maintainer, CNCF-approved → clear both, re-await maintainer', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: true, materialChange: true, currentLabels: [MA, MC, 'CNCF Approved'] }),
+    [AMA], [MA, 'CNCF Approved']);
+});
+
+test('material edit by a maintainer-proposer, CNCF-approved → keep maintainer, clear CNCF', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: true, materialChange: true, currentLabels: [MA, MC, 'CNCF Approved'] }),
+    [ACNCF], ['CNCF Approved']);
+});
+
+test('material edit, roster also grew, CNCF-approved → clear maintainer + mentor + CNCF', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: false, materialChange: true, currentLabels: [MA, MC, 'CNCF Approved'] }),
+    [AMA, AMC], [MA, MC, 'CNCF Approved']);
+});
+
+test('trivial edit (not material) while CNCF-approved → leave everything', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: true, materialChange: false, currentLabels: [MA, MC, 'CNCF Approved'] }),
+    [], []);
+});
+
+test('material edit while only awaiting CNCF (not yet approved) → no churn', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: true, materialChange: true, currentLabels: [MA, MC, ACNCF] }),
     [], []);
 });

--- a/programs/lfx-mentorship/automation/test/gates.test.js
+++ b/programs/lfx-mentorship/automation/test/gates.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { gateLabelChanges } = require('../lib/gates');
+
+const MA = 'Maintainer/Contribex Approved';
+const AMA = 'Awaiting Maintainer/Contribex Approval';
+const MC = 'Mentors Confirmed';
+const AMC = 'Awaiting Mentor Confirmation';
+const ACNCF = 'Awaiting CNCF Admin Approval';
+
+// Helper to compare add/remove as sets (order-independent).
+function eq(actual, add, remove) {
+  assert.deepEqual([...actual.add].sort(), [...add].sort());
+  assert.deepEqual([...actual.remove].sort(), [...remove].sort());
+}
+
+test('pass, neither gate auto-satisfied, no labels → add both Awaiting', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [] }),
+    [AMA, AMC], []);
+});
+
+test('pass, maintainer auto but not mentors → approve maintainer, await mentors', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: false, currentLabels: [] }),
+    [MA, AMC], []);
+});
+
+test('pass, both auto-satisfied → approve+confirm and await CNCF admin', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: true, currentLabels: [] }),
+    [MA, MC, ACNCF], []);
+});
+
+test('pass, maintainer auto with a stale Awaiting label → add approved, drop awaiting', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: false, currentLabels: [AMA] }),
+    [MA, AMC], [AMA]);
+});
+
+test('pass, mentor auto-confirmed while maintainer already approved → confirm + await CNCF', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: true, currentLabels: [MA, AMC] }),
+    [MC, ACNCF], [AMC]);
+});
+
+test('pass, both already satisfied in labels → only add Awaiting CNCF', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [MA, MC] }),
+    [ACNCF], []);
+});
+
+test('pass, both satisfied and Awaiting CNCF already present → no changes', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [MA, MC, ACNCF] }),
+    [], []);
+});
+
+test('pass, both satisfied but already CNCF Approved → do NOT re-add Awaiting CNCF', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: true, currentLabels: ['CNCF Approved'] }),
+    [MA, MC], []);
+});
+
+test('pass, maintainer already approved (idempotent) → no maintainer add, still await mentors', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: false, currentLabels: [MA] }),
+    [AMC], []);
+});
+
+test('validation failed → clear only the awaiting labels present, no adds', () => {
+  eq(gateLabelChanges({ pass: false, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [AMA, AMC, 'Validation Passed'] }),
+    [], [AMA, AMC]);
+});
+
+test('validation failed leaves approved/confirmed labels intact', () => {
+  eq(gateLabelChanges({ pass: false, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [MA, MC] }),
+    [], []);
+});
+
+test('pass, already fully awaiting (re-validation, nothing auto) → no changes', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [AMA, AMC] }),
+    [], []);
+});

--- a/programs/lfx-mentorship/automation/test/gates.test.js
+++ b/programs/lfx-mentorship/automation/test/gates.test.js
@@ -41,13 +41,13 @@ test('pass, mentor auto-confirmed while maintainer already approved → confirm 
     [MC, ACNCF], [AMC]);
 });
 
-test('pass, both already satisfied in labels → only add Awaiting CNCF', () => {
-  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [MA, MC] }),
+test('pass, both already satisfied (recomputed) → only add Awaiting CNCF', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: true, currentLabels: [MA, MC] }),
     [ACNCF], []);
 });
 
 test('pass, both satisfied and Awaiting CNCF already present → no changes', () => {
-  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [MA, MC, ACNCF] }),
+  eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: true, currentLabels: [MA, MC, ACNCF] }),
     [], []);
 });
 
@@ -73,5 +73,29 @@ test('validation failed leaves approved/confirmed labels intact', () => {
 
 test('pass, already fully awaiting (re-validation, nothing auto) → no changes', () => {
   eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [AMA, AMC] }),
+    [], []);
+});
+
+// ── Mentor gate reflects the CURRENT roster (can downgrade) ───────────
+// If a proposal was Mentors Confirmed (e.g. sole proposer-mentor) and a new,
+// unconfirmed mentor is later added, re-validation must re-open confirmation.
+
+test('pass, roster grew (recompute not-all-confirmed) → downgrade Confirmed to Awaiting', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: false, currentLabels: [MA, MC] }),
+    [AMC], [MC]);
+});
+
+test('pass, downgrade also clears the CNCF-admin signal', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: false, currentLabels: [MA, MC, ACNCF] }),
+    [AMC], [MC, ACNCF]);
+});
+
+test('pass, mentor gate not met but already CNCF-approved → do NOT downgrade', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: false, currentLabels: [MA, MC, 'CNCF Approved'] }),
+    [], []);
+});
+
+test('pass, still confirmed on re-validation (recompute true) → no churn', () => {
+  eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: true, currentLabels: [MA, MC, ACNCF] }),
     [], []);
 });

--- a/programs/lfx-mentorship/automation/test/gates.test.js
+++ b/programs/lfx-mentorship/automation/test/gates.test.js
@@ -71,6 +71,11 @@ test('validation failed leaves approved/confirmed labels intact', () => {
     [], []);
 });
 
+test('validation failed also clears the Awaiting CNCF Admin prompt', () => {
+  eq(gateLabelChanges({ pass: false, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [MA, MC, ACNCF] }),
+    [], [ACNCF]);
+});
+
 test('pass, already fully awaiting (re-validation, nothing auto) → no changes', () => {
   eq(gateLabelChanges({ pass: true, maintainerApproved: false, mentorsConfirmed: false, currentLabels: [AMA, AMC] }),
     [], []);

--- a/programs/lfx-mentorship/automation/test/parse.test.js
+++ b/programs/lfx-mentorship/automation/test/parse.test.js
@@ -122,3 +122,8 @@ test('formFieldsChanged: removing a mentor is material', () => {
   const v2 = bodyV1.replace('\nJane | @jane | jane@x.io | jane', '');
   assert.equal(formFieldsChanged(bodyV1, v2), true);
 });
+
+test('formFieldsChanged: internal whitespace reflow/indent is not material', () => {
+  const v2 = bodyV1.replace('Do cool things.', 'Do    cool\n   things.');
+  assert.equal(formFieldsChanged(bodyV1, v2), false);
+});

--- a/programs/lfx-mentorship/automation/test/parse.test.js
+++ b/programs/lfx-mentorship/automation/test/parse.test.js
@@ -71,3 +71,54 @@ test('parseMentors: lfid is captured distinct from the github handle', () => {
 test('parseMentors: empty input yields empty array', () => {
   assert.deepEqual(parseMentors(''), []);
 });
+
+// ── formFieldsChanged: material (field-level) diff of two issue bodies ──
+// Used to decide whether an edit is "non-trivial" (a form field changed) vs
+// cosmetic (whitespace, a prepended HTML comment, a trailing newline).
+const { formFieldsChanged } = require('../lib/parse');
+
+const bodyV1 = [
+  '### CNCF Project', '', 'Kubernetes', '',
+  '### Program Description', '', 'Do cool things.', '',
+  '### Mentors', '', 'Jane | @jane | jane@x.io | jane', '',
+].join('\n');
+
+test('formFieldsChanged: identical bodies → false', () => {
+  assert.equal(formFieldsChanged(bodyV1, bodyV1), false);
+});
+
+test('formFieldsChanged: a trailing newline is not material', () => {
+  assert.equal(formFieldsChanged(bodyV1, bodyV1 + '\n'), false);
+});
+
+test('formFieldsChanged: a prepended HTML comment is not material', () => {
+  assert.equal(formFieldsChanged(bodyV1, '<!-- re-validate -->\n\n' + bodyV1), false);
+});
+
+test('formFieldsChanged: changing a field value is material', () => {
+  const v2 = bodyV1.replace('Do cool things.', 'Do cooler things.');
+  assert.equal(formFieldsChanged(bodyV1, v2), true);
+});
+
+test('formFieldsChanged: adding a mentor is material', () => {
+  const v2 = bodyV1.replace(
+    'Jane | @jane | jane@x.io | jane',
+    'Jane | @jane | jane@x.io | jane\nBob | @bob | bob@x.io | bob',
+  );
+  assert.equal(formFieldsChanged(bodyV1, v2), true);
+});
+
+test('formFieldsChanged: adding a whole new field/section is material', () => {
+  assert.equal(formFieldsChanged(bodyV1, bodyV1 + '\n### Technologies\n\nGo\n'), true);
+});
+
+test('formFieldsChanged: tolerates empty/undefined bodies', () => {
+  assert.equal(formFieldsChanged('', ''), false);
+  assert.equal(formFieldsChanged(undefined, undefined), false);
+  assert.equal(formFieldsChanged('', bodyV1), true);
+});
+
+test('formFieldsChanged: removing a mentor is material', () => {
+  const v2 = bodyV1.replace('\nJane | @jane | jane@x.io | jane', '');
+  assert.equal(formFieldsChanged(bodyV1, v2), true);
+});

--- a/programs/lfx-mentorship/automation/test/title.test.js
+++ b/programs/lfx-mentorship/automation/test/title.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { lfxTitle, termToken, programNameBudget, LFX_TITLE_MAX } = require('../lib/title');
+
+test('LFX_TITLE_MAX is 100', () => {
+  assert.equal(LFX_TITLE_MAX, 100);
+});
+
+test('termToken strips the month parenthetical', () => {
+  assert.equal(termToken('2026 Term 3 (Sep-Nov)'), '2026 Term 3');
+  assert.equal(termToken('2026 Term 3'), '2026 Term 3'); // no parenthetical
+  assert.equal(termToken(''), '');
+  assert.equal(termToken(undefined), '');
+});
+
+test('lfxTitle builds "CNCF - <project>: <programName> (<term>)"', () => {
+  assert.equal(
+    lfxTitle({ project: 'Apicurio Registry', programName: 'Federated AI Agent Search', term: '2026 Term 3 (Sep-Nov)' }),
+    'CNCF - Apicurio Registry: Federated AI Agent Search (2026 Term 3)',
+  );
+});
+
+test('lfxTitle tolerates missing parts', () => {
+  assert.equal(lfxTitle({}), 'CNCF - :  ()');
+});
+
+test('programNameBudget = 100 minus the fixed overhead (matches the KServe/Term 3 example)', () => {
+  // project "KServe" (6) + term token "2026 Term 3" (11) + fixed 12 = 29 overhead.
+  assert.equal(programNameBudget({ project: 'KServe', term: '2026 Term 3 (Sep-Nov)' }), 71);
+});
+
+test('programNameBudget + programName length === full title length', () => {
+  const project = 'KServe';
+  const term = '2026 Term 3 (Sep-Nov)';
+  const programName = 'x'.repeat(programNameBudget({ project, term }));
+  assert.equal(lfxTitle({ project, programName, term }).length, LFX_TITLE_MAX);
+});


### PR DESCRIPTION
## What
Three related improvements to LFX proposal handling:

1. **Auto-satisfy gates from the proposer.** On validation pass, grant
   maintainer approval when the proposer is a project maintainer, and mentor
   confirmation for the proposer's own slot when they're a listed mentor — both
   actions the proposer could already take by hand (`/approve`, `/confirm`).
2. **Invalidate content approvals on material edits.** If a form field changes
   after a maintainer or CNCF admin approved, that approval is cleared,
   re-requested, and the approver is tagged to re-review. Cosmetic edits
   (whitespace, text reflow, re-trigger newlines, title-only tweaks) reset
   nothing.
3. **Show the full LFX title.** The validation comment now displays the program's
   platform title — `CNCF - <project>: <name> (<term>)` — up top, with its
   length against the 100-char cap.

## Why
An approval endorses specific content: auto-granting removes friction when a
maintainer/mentor is clearly responsible for it; clearing-on-edit keeps an
approval meaningful when it changes. Surfacing the title lets proposers see
exactly what their program will be called.

## Behavior
- **Maintainer gate:** cleared by a material edit unless the proposer is a
  maintainer (they re-approve by authoring the edit; only trusted CNCF/TOC
  collaborators can edit others' issues, so keying off the proposer is safe).
  Limited to real project maintainers (tier-1 `.project` + tier-2 CSV).
- **CNCF gate:** any material edit clears it → re-enters the admin queue.
- **Mentor confirmation:** a participation commitment, so NOT cleared by content
  edits. Roster changes re-open it — a dropped/swapped mentor stops counting, a
  kept one stays confirmed via their `/confirm`, a new one must confirm.
- **Material edit** = a parsed form field's content changed (whitespace-
  normalized); the auto-derived title is not itself a signal.
- **Notification:** one comment tags whoever recorded a cleared approval, only
  on the clearing transition.

## Changes
- `lib/authorize.js` (new): extracted `/approve` tier-1/2 maintainer resolution.
- `lib/gates.js` (new): pure gate→label decision, incl. material-edit clearing.
- `lib/approvals.js` (new): finds recorded approvers to tag.
- `lib/title.js` (new): shared LFX title format + Program Name budget (also used
  by the export workflow — removes duplication).
- `lib/parse.js`: `formFieldsChanged` (whitespace-normalized material detection).
- `lib/confirm.js`: `computeConfirm` counts the issue author; `/confirm` passes it.
- validate workflow: resolves gates, applies labels, tags cleared approvers,
  shows the title; pinned `js-yaml` install.
- Docs: README + ADMIN_GUIDE.

## Test plan
`node --test` in `programs/lfx-mentorship/automation` — 241 pass.
