### PR TITLE
Show proposers their implied approval/confirmation in the validation message

### DIFF
--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -81,6 +81,7 @@ jobs:
             const { gateLabelChanges } = _lib('gates.js');
             const { findRecordedApprovers } = _lib('approvals.js');
             const { lfxTitle, programNameBudget, LFX_TITLE_MAX } = _lib('title.js');
+            const { nextSteps } = _lib('next-steps.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const title = context.payload.issue.title || '';
@@ -352,6 +353,8 @@ jobs:
             let maintainerApproved = currentLabels.includes('Maintainer/Contribex Approved') && !materialChange;
             let mentorsConfirmed = currentLabels.includes('Mentors Confirmed');
             let maintainerAutoApproved = false;
+            let confirmResult = { count: 0, total: 0, remaining: [] };
+            let proposerIsMentor = false;
             if (errors.length === 0) {
               // Maintainer gate: is the proposer a project maintainer?
               // Deliberately keyed off the PROPOSER, not the editor: a project
@@ -380,7 +383,10 @@ jobs:
               // mentor resolves from persisted /confirm comments). Counts the
               // proposer's own slot. NOT monotonic — reflects the present roster.
               const roster = parseMentors(mentorsRaw).map(m => m.github_handle);
-              mentorsConfirmed = computeConfirm(roster, null, issueComments, proposer).flip;
+              confirmResult = computeConfirm(roster, null, issueComments, proposer);
+              mentorsConfirmed = confirmResult.flip;
+              const normHandle = (h) => String(h || '').replace(/^@/, '').trim().toLowerCase();
+              proposerIsMentor = roster.map(normHandle).includes(normHandle(proposer));
             }
 
             // ── Build validation comment ──
@@ -425,21 +431,17 @@ jobs:
             if (errors.length === 0) {
               const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
               const guideUrl = `${repoUrl}/blob/main/programs/lfx-mentorship/README.md#what-happens-after-you-submit`;
-              lines.push('', '### What happens next', '');
-              lines.push(
-                (maintainerApproved && mentorsConfirmed)
-                  ? 'Maintainer approval and mentor confirmation are already in place, so this proposal goes straight to final CNCF admin review.'
-                  : 'This proposal is now waiting on the people below. No further action is needed from the proposer unless validation flags a change.',
-                '',
-              );
-              lines.push(maintainerApproved
-                ? `1. **Maintainer approval:** ✅ recorded${maintainerAutoApproved ? ` — proposer @${proposer} is a project maintainer` : ''}.`
-                : '1. **Maintainer approval:** a maintainer of the CNCF project (or an authorized delegate) comments `/approve`.');
-              lines.push(mentorsConfirmed
-                ? '2. **Mentor confirmation:** ✅ recorded.'
-                : '2. **Mentor confirmation:** each mentor listed on the proposal comments `/confirm`.');
-              lines.push('3. **CNCF approval:** once both are in place, a CNCF mentorship admin comments `/cncf-approve` to finalize.');
-              lines.push('', `See the [proposal process guide](${guideUrl}) for full details.`);
+              // "What happens next" — decision + copy live in lib/next-steps.js
+              // so the message reflects partial mentor tallies and proposer
+              // auto-counting (cncf/mentoring#1928) and is unit-tested.
+              lines.push('', ...nextSteps({
+                proposer,
+                maintainerApproved,
+                maintainerAutoApproved,
+                confirm: confirmResult,
+                proposerIsMentor,
+                guideUrl,
+              }));
             }
 
             lines.push('', '---', '_Re-run by editing the issue._');

--- a/programs/lfx-mentorship/automation/lib/next-steps.js
+++ b/programs/lfx-mentorship/automation/lib/next-steps.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// Builds the "What happens next" section of the LFX proposal validation
+// comment. Pure and unit-tested so the copy (and the gate-state it reflects)
+// is verifiable, not buried inline in the workflow YAML.
+//
+// The prior inline version was binary per gate ("✅ recorded" vs a generic
+// prompt), so a proposer who is also a listed mentor and/or a project
+// maintainer got no signal that their own slot was already satisfied and would
+// needlessly comment `/confirm` (cncf/mentoring#1928). This surfaces the
+// partial mentor tally, notes when the proposer is auto-counted, and lists who
+// is still needed.
+
+// state:
+//   proposer              issue author's handle (no leading '@'); may be null
+//   maintainerApproved    is the maintainer gate satisfied this run?
+//   maintainerAutoApproved satisfied because the proposer is a project maintainer?
+//   confirm               computeConfirm result: { count, total, remaining }
+//                         (remaining = normalized handles still to `/confirm`)
+//   proposerIsMentor      is the proposer on the current mentor roster?
+//   guideUrl              link to the proposal-process guide
+// → array of markdown lines for the "What happens next" section.
+function nextSteps({
+  proposer,
+  maintainerApproved,
+  maintainerAutoApproved,
+  confirm,
+  proposerIsMentor,
+  guideUrl,
+}) {
+  const { count = 0, total = 0, remaining = [] } = confirm || {};
+  const mentorsConfirmed = remaining.length === 0;
+  const at = (h) => `@${String(h || '').replace(/^@/, '')}`;
+
+  const lines = ['### What happens next', ''];
+
+  // 1. Maintainer approval
+  if (maintainerApproved && maintainerAutoApproved) {
+    lines.push(`1. **Maintainer approval** — ✅ recorded; proposer ${at(proposer)} is a project maintainer.`);
+  } else if (maintainerApproved) {
+    lines.push('1. **Maintainer approval** — ✅ recorded.');
+  } else {
+    lines.push('1. **Maintainer approval** — ⏳ a project maintainer (or authorized delegate) comments `/approve`.');
+  }
+
+  // 2. Mentor confirmation
+  if (mentorsConfirmed) {
+    lines.push(`2. **Mentor confirmation** — ✅ all ${total} confirmed.`);
+  } else {
+    const auto = proposerIsMentor ? ` (${at(proposer)} auto-counted as proposer)` : '';
+    lines.push(`2. **Mentor confirmation** — ⏳ ${count} of ${total} confirmed${auto}. Awaiting \`/confirm\` from ${remaining.map(at).join(', ')}.`);
+  }
+
+  // 3. CNCF approval — always pending at validation time
+  lines.push('3. **CNCF approval** — ⏳ a CNCF admin comments `/cncf-approve` to finalize.');
+
+  lines.push('', `[Proposal process guide](${guideUrl})`);
+  return lines;
+}
+
+module.exports = { nextSteps };

--- a/programs/lfx-mentorship/automation/test/next-steps.test.js
+++ b/programs/lfx-mentorship/automation/test/next-steps.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { nextSteps } = require('../lib/next-steps');
+
+const GUIDE = 'https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md#what-happens-after-you-submit';
+
+// Build the section and join to a single string for substring assertions.
+// We assert the invariants (counts, auto-count note, remaining handles, gate
+// state) rather than exact prose, so wording tweaks don't break the tests but
+// the semantics stay locked.
+function render(state) {
+  return nextSteps({ guideUrl: GUIDE, ...state }).join('\n');
+}
+
+test('always includes the section header and the guide link', () => {
+  const out = render({
+    proposer: 'someone', maintainerApproved: false, maintainerAutoApproved: false,
+    confirm: { count: 0, total: 1, remaining: ['someone'] }, proposerIsMentor: true,
+  });
+  assert.match(out, /### What happens next/);
+  assert.match(out, /Proposal process guide/);
+  assert.ok(out.includes(GUIDE), 'links to the guide URL');
+});
+
+// ── The #1928 case: proposer is a listed mentor, co-mentor still pending ──
+test('proposer who is a listed mentor is shown as auto-counted, with the partial tally and who is still needed', () => {
+  const out = render({
+    proposer: 'alyssacgoins',
+    maintainerApproved: false, maintainerAutoApproved: false,
+    confirm: { count: 1, total: 2, remaining: ['mprahl'] },
+    proposerIsMentor: true,
+  });
+  assert.match(out, /1 of 2 confirmed/);
+  assert.match(out, /auto-counted as proposer/);
+  assert.match(out, /@alyssacgoins/);
+  assert.match(out, /Awaiting `\/confirm`/);
+  assert.match(out, /@mprahl/);
+  // Maintainer gate still open → shows the /approve prompt.
+  assert.match(out, /`\/approve`/);
+  // CNCF approval is always surfaced as still pending.
+  assert.match(out, /`\/cncf-approve`/);
+});
+
+// ── Proposer is a project maintainer AND the sole mentor (both auto) ──
+// Both of the proposer's own gates are auto-satisfied, but the proposal is NOT
+// finished — CNCF admin approval is still pending. The message must show that
+// and must not over-reassure the proposer that they're done.
+test('proposer who is maintainer and sole mentor sees both gates satisfied but is still told CNCF approval is pending', () => {
+  const out = render({
+    proposer: 'carlesarnal',
+    maintainerApproved: true, maintainerAutoApproved: true,
+    confirm: { count: 1, total: 1, remaining: [] },
+    proposerIsMentor: true,
+  });
+  assert.match(out, /project maintainer/);
+  assert.match(out, /all 1 confirmed/);
+  assert.match(out, /`\/cncf-approve`/);
+  assert.doesNotMatch(out, /Awaiting `\/confirm`/);
+  assert.doesNotMatch(out, /Nothing more/i);
+});
+
+// ── Proposer is NOT a mentor → no auto-count note ──
+test('proposer who is not a listed mentor gets no auto-count note and every mentor is still needed', () => {
+  const out = render({
+    proposer: 'outsider',
+    maintainerApproved: false, maintainerAutoApproved: false,
+    confirm: { count: 0, total: 2, remaining: ['alice', 'bob'] },
+    proposerIsMentor: false,
+  });
+  assert.match(out, /0 of 2 confirmed/);
+  assert.doesNotMatch(out, /auto-counted/);
+  assert.match(out, /Awaiting `\/confirm`/);
+  assert.match(out, /@alice/);
+  assert.match(out, /@bob/);
+});
+
+// ── Maintainer approved by a real /approve (not the proposer) ──
+test('a maintainer approval recorded via /approve (not proposer-implied) reads as plainly recorded', () => {
+  const out = render({
+    proposer: 'somementor',
+    maintainerApproved: true, maintainerAutoApproved: false,
+    confirm: { count: 1, total: 2, remaining: ['comentor'] },
+    proposerIsMentor: true,
+  });
+  assert.match(out, /Maintainer approval\*\* — ✅ recorded\./);
+  assert.doesNotMatch(out, /project maintainer/);
+});


### PR DESCRIPTION
## What
The proposal validation comment now shows a per-gate status (⏳/✅), the partial mentor tally, whether the proposer is auto-counted, and exactly who must still `/approve` or `/confirm`.

## Why
On #1928 the proposer was also a listed mentor. The gate already counted her own slot, but the message showed a generic "each mentor comments `/confirm`" with no sign her slot was counted — so she needlessly commented `/confirm`. Proposers who are maintainers/mentors got no signal their own gate was satisfied.

## How
- Extracted the "What happens next" section into a tested `lib/next-steps.js` (+5 tests).
- CNCF approval is always shown outstanding, so a proposer whose own gates are met isn't misled that the proposal is finished.
- Full suite: 247/247. Hotfix branched off prod.