### PR TITLE
Harden LFX proposal approval gates against validation regressions

### DIFF
--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -333,6 +333,10 @@ jobs:
                     `This command is restricted to CNCF program admins.`);
                 } else if (decision.reason === 'already-approved') {
                   await reply('ℹ️', 'This proposal has already been CNCF-approved.');
+                } else if (decision.reason === 'not-validated') {
+                  await reply('❌',
+                    'Cannot `/cncf-approve` — this proposal is not currently passing validation. ' +
+                    'The proposer needs to resolve the validation errors (see the validation comment) first.');
                 } else if (decision.reason === 'missing-gates') {
                   await reply('❌',
                     `Cannot \`/cncf-approve\` — still missing: ${decision.missing.map(l => `\`${l}\``).join(' and ')}.\n\n` +

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -37,6 +37,7 @@ jobs:
             const { computeConfirm } = _lib('confirm.js');
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
+            const { cncfApproveDecision } = _lib('cncf-approve.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const comment = context.payload.comment;
@@ -312,7 +313,7 @@ jobs:
             // ══════════════════════════════════════════════════
             if (command === 'cncf-approve') {
 
-              // Authorization: read from approvers.yml global_approvers
+              // Authorization allowlist: approvers.yml global_approvers.
               let admins = [];
               try {
                 const raw = fs.readFileSync('programs/lfx-mentorship/automation/approvers.yml', 'utf8');
@@ -320,28 +321,23 @@ jobs:
               } catch (e) {
                 console.log(`Failed to read approvers.yml: ${e.message}`);
               }
-              if (!admins.includes(commenter.toLowerCase())) {
-                await reply('❌',
-                  `@${commenter} is not authorized to use \`/cncf-approve\`. ` +
-                  `This command is restricted to CNCF program admins.`);
-                return;
-              }
-              if (currentLabels.includes('CNCF Approved')) {
-                await reply('ℹ️', 'This proposal has already been CNCF-approved.');
-                return;
-              }
 
-              // Gate: both maintainer + mentor must be done
-              const missing = [];
-              if (!currentLabels.includes('Maintainer/Contribex Approved'))
-                missing.push('Maintainer/Contribex Approved');
-              if (!currentLabels.includes('Mentors Confirmed'))
-                missing.push('Mentors Confirmed');
-
-              if (missing.length) {
-                await reply('❌',
-                  `Cannot \`/cncf-approve\` — still missing: ${missing.map(l => `\`${l}\``).join(' and ')}.\n\n` +
-                  `A maintainer must \`/approve\` and a listed mentor must \`/confirm\` first.`);
+              // Gate decision (admin allowlist + already-approved + both gates)
+              // lives in lib/cncf-approve.js so it is unit-tested; the workflow
+              // just maps the outcome to a reply and, when ok, sets the label.
+              const decision = cncfApproveDecision({ commenter, admins, currentLabels });
+              if (!decision.ok) {
+                if (decision.reason === 'not-admin') {
+                  await reply('❌',
+                    `@${commenter} is not authorized to use \`/cncf-approve\`. ` +
+                    `This command is restricted to CNCF program admins.`);
+                } else if (decision.reason === 'already-approved') {
+                  await reply('ℹ️', 'This proposal has already been CNCF-approved.');
+                } else if (decision.reason === 'missing-gates') {
+                  await reply('❌',
+                    `Cannot \`/cncf-approve\` — still missing: ${decision.missing.map(l => `\`${l}\``).join(' and ')}.\n\n` +
+                    `A maintainer must \`/approve\` and a listed mentor must \`/confirm\` first.`);
+                }
                 return;
               }
 

--- a/programs/lfx-mentorship/README.md
+++ b/programs/lfx-mentorship/README.md
@@ -114,8 +114,10 @@ The form asks for:
 > **Editing a proposal after approval resets it.** If you make a substantive
 > edit (change a form field — description, mentors, dates, etc.) after a
 > maintainer or CNCF admin has approved, that approval is automatically cleared
-> and must be granted again; the bot tags the approver(s) to re-review. Cosmetic
-> edits (whitespace) don't reset anything. Mentor confirmations aren't cleared by
+> and must be granted again; the bot tags the approver(s) to re-review. This
+> applies even if the edit breaks validation — and a proposal that isn't
+> currently passing validation can't be `/cncf-approve`'d. Cosmetic edits
+> (whitespace) don't reset anything. Mentor confirmations aren't cleared by
 > content edits, but adding or swapping a mentor re-opens confirmation for the
 > new mentor.
 

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -60,7 +60,8 @@ the [LFX Mentorship README](../README.md#how-to-propose-a-program).
 
 Before using `/cncf-approve` on a proposal, verify:
 
-- [ ] Validation has passed (green `Validation Passed` label)
+- [ ] Validation is currently passing (green `Validation Passed` label) — the
+  bot refuses `/cncf-approve` on a proposal in the `Validation Failed` state
 - [ ] A project maintainer has commented `/approve` (`Maintainer/Contribex
   Approved` label is present) — or the proposer is themselves a project
   maintainer, in which case validation grants it automatically
@@ -79,13 +80,20 @@ To approve, comment `/cncf-approve` on the issue. The bot will:
 > [!NOTE]
 > **Edits after approval reset the content approvals.** If a proposal is edited
 > so that a form field changes (a "material" edit) after maintainer or CNCF
-> approval, validation clears those approvals, re-adds the `Awaiting …` labels,
-> and posts a comment tagging the prior approver(s) to re-review. Cosmetic edits
-> (whitespace, re-triggering validation) don't reset anything. Mentor
-> confirmations persist across content edits; adding or swapping a mentor
-> re-opens confirmation for the new mentor only. This means a maintainer who is
-> the proposer keeps their approval across their own edits (re-granted
+> approval, validation clears those approvals and posts a comment tagging the
+> prior approver(s) to re-review — **whether or not the edit leaves validation
+> passing**. When the edit still passes, the `Awaiting …` labels are re-added;
+> when it fails, they aren't (nothing should read as "waiting"), but the
+> maintainer/CNCF approvals are cleared just the same, so nothing stale carries
+> over. Cosmetic edits (whitespace, re-triggering validation) don't reset
+> anything. Mentor confirmations persist across content edits; adding or swapping
+> a mentor re-opens confirmation for the new mentor only. This means a maintainer
+> who is the proposer keeps their approval across their own edits (re-granted
 > automatically), but a CNCF admin must always re-approve after a material edit.
+>
+> `/cncf-approve` additionally requires the proposal to be **currently passing
+> validation**: the bot refuses it in the `Validation Failed` state, so an
+> approval can't be finalized on a regressed proposal.
 
 Only users listed in `approvers.yml` under `global_approvers` can use
 `/cncf-approve`.

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -88,8 +88,9 @@ To approve, comment `/cncf-approve` on the issue. The bot will:
 > over. Cosmetic edits (whitespace, re-triggering validation) don't reset
 > anything. Mentor confirmations persist across content edits; adding or swapping
 > a mentor re-opens confirmation for the new mentor only. This means a maintainer
-> who is the proposer keeps their approval across their own edits (re-granted
-> automatically), but a CNCF admin must always re-approve after a material edit.
+> who is the proposer keeps their approval across their own edits that still pass
+> validation (re-granted automatically); an edit that breaks validation clears it
+> until they fix it, and a CNCF admin must always re-approve after a material edit.
 >
 > `/cncf-approve` additionally requires the proposal to be **currently passing
 > validation**: the bot refuses it in the `Validation Failed` state, so an

--- a/programs/lfx-mentorship/automation/lib/cncf-approve.js
+++ b/programs/lfx-mentorship/automation/lib/cncf-approve.js
@@ -1,0 +1,40 @@
+'use strict';
+
+// Decision logic for the `/cncf-approve` command (CNCF admin finalization),
+// extracted from the inline block in lfx-proposal-approvals.yml so the gate is
+// unit-tested. The workflow keeps the I/O (reading approvers.yml, posting the
+// reply, and setting labels); this returns the decision only.
+//
+// Returns { ok: true } when the command may proceed, otherwise
+// { ok: false, reason, missing? } where reason is one of:
+//   'not-admin'        commenter is not a CNCF global approver
+//   'already-approved' the proposal is already CNCF Approved
+//   'missing-gates'    maintainer approval and/or mentor confirmation missing
+//                      (missing: the outstanding label names)
+
+const MAINTAINER_APPROVED = 'Maintainer/Contribex Approved';
+const MENTORS_CONFIRMED = 'Mentors Confirmed';
+const CNCF_APPROVED = 'CNCF Approved';
+
+// admins: lowercased global-approver handles (as returned by
+// approvers.js getGlobalApprovers). commenter is compared case-insensitively,
+// matching the original inline check.
+function cncfApproveDecision({ commenter, admins, currentLabels }) {
+  const labels = currentLabels || [];
+  const has = (l) => labels.includes(l);
+
+  if (!(admins || []).includes(String(commenter || '').toLowerCase())) {
+    return { ok: false, reason: 'not-admin' };
+  }
+  if (has(CNCF_APPROVED)) {
+    return { ok: false, reason: 'already-approved' };
+  }
+  const missing = [];
+  if (!has(MAINTAINER_APPROVED)) missing.push(MAINTAINER_APPROVED);
+  if (!has(MENTORS_CONFIRMED)) missing.push(MENTORS_CONFIRMED);
+  if (missing.length) return { ok: false, reason: 'missing-gates', missing };
+
+  return { ok: true };
+}
+
+module.exports = { cncfApproveDecision };

--- a/programs/lfx-mentorship/automation/lib/cncf-approve.js
+++ b/programs/lfx-mentorship/automation/lib/cncf-approve.js
@@ -9,12 +9,14 @@
 // { ok: false, reason, missing? } where reason is one of:
 //   'not-admin'        commenter is not a CNCF global approver
 //   'already-approved' the proposal is already CNCF Approved
+//   'not-validated'    the proposal is not currently passing validation
 //   'missing-gates'    maintainer approval and/or mentor confirmation missing
 //                      (missing: the outstanding label names)
 
 const MAINTAINER_APPROVED = 'Maintainer/Contribex Approved';
 const MENTORS_CONFIRMED = 'Mentors Confirmed';
 const CNCF_APPROVED = 'CNCF Approved';
+const VALIDATION_PASSED = 'Validation Passed';
 
 // admins: lowercased global-approver handles (as returned by
 // approvers.js getGlobalApprovers). commenter is compared case-insensitively,
@@ -28,6 +30,12 @@ function cncfApproveDecision({ commenter, admins, currentLabels }) {
   }
   if (has(CNCF_APPROVED)) {
     return { ok: false, reason: 'already-approved' };
+  }
+  // A proposal must be currently passing validation to be finalized. Without
+  // this, a proposal approved earlier then edited into a failing state (labels
+  // may linger for a non-material regression) could still be CNCF-approved.
+  if (!has(VALIDATION_PASSED)) {
+    return { ok: false, reason: 'not-validated' };
   }
   const missing = [];
   if (!has(MAINTAINER_APPROVED)) missing.push(MAINTAINER_APPROVED);

--- a/programs/lfx-mentorship/automation/lib/gates.js
+++ b/programs/lfx-mentorship/automation/lib/gates.js
@@ -44,15 +44,17 @@ function gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, material
   // approvals" while the slash commands are gated off by the lost Validation
   // Passed. If the regression was caused by a MATERIAL edit, the content the
   // approvers signed off on changed, so the maintainer + CNCF approvals are
-  // invalidated here too — exactly as on the passing path (a stale approval must
-  // not survive on a now-failing proposal, where it could still be
-  // /cncf-approve'd). The maintainer's approval survives only when re-granted
-  // this run (proposer is a project maintainer); mentor confirmation persists
-  // (participation commitment). A non-material failure leaves approvals intact.
+  // cleared here too — a stale approval must not survive on a now-failing
+  // proposal (where /cncf-approve could otherwise finalize it). There is no
+  // proposer-implied re-approval on this path: the caller resolves that only on
+  // a passing run, so a maintainer-proposer's approval is cleared here as well
+  // and re-granted automatically once they fix validation. Mentor confirmation
+  // persists (participation commitment). A non-material failure leaves approvals
+  // intact.
   if (!pass) {
     for (const l of [AWAITING_MAINTAINER, AWAITING_MENTORS, AWAITING_CNCF]) if (has(l)) remove.push(l);
     if (materialChange) {
-      if (has(MAINTAINER_APPROVED) && !maintainerApproved) remove.push(MAINTAINER_APPROVED);
+      if (has(MAINTAINER_APPROVED)) remove.push(MAINTAINER_APPROVED);
       if (has(CNCF_APPROVED)) remove.push(CNCF_APPROVED);
     }
     return { add, remove };

--- a/programs/lfx-mentorship/automation/lib/gates.js
+++ b/programs/lfx-mentorship/automation/lib/gates.js
@@ -42,9 +42,19 @@ function gateLabelChanges({ pass, maintainerApproved, mentorsConfirmed, material
   // Validation regressed (previously passing, now failing): clear the awaiting
   // prompts (maintainer, mentor, and CNCF-admin) so nothing shows "waiting on
   // approvals" while the slash commands are gated off by the lost Validation
-  // Passed. Recorded approvals/confirmations are left intact (as before).
+  // Passed. If the regression was caused by a MATERIAL edit, the content the
+  // approvers signed off on changed, so the maintainer + CNCF approvals are
+  // invalidated here too — exactly as on the passing path (a stale approval must
+  // not survive on a now-failing proposal, where it could still be
+  // /cncf-approve'd). The maintainer's approval survives only when re-granted
+  // this run (proposer is a project maintainer); mentor confirmation persists
+  // (participation commitment). A non-material failure leaves approvals intact.
   if (!pass) {
     for (const l of [AWAITING_MAINTAINER, AWAITING_MENTORS, AWAITING_CNCF]) if (has(l)) remove.push(l);
+    if (materialChange) {
+      if (has(MAINTAINER_APPROVED) && !maintainerApproved) remove.push(MAINTAINER_APPROVED);
+      if (has(CNCF_APPROVED)) remove.push(CNCF_APPROVED);
+    }
     return { add, remove };
   }
 

--- a/programs/lfx-mentorship/automation/test/cncf-approve.test.js
+++ b/programs/lfx-mentorship/automation/test/cncf-approve.test.js
@@ -50,3 +50,9 @@ test('both gates present and validated → ok', () => {
     cncfApproveDecision({ commenter: 'natedoubleu', admins, currentLabels: [MA, MC, VP] }),
     { ok: true });
 });
+
+test('both gates present but validation NOT passing → not-validated (cannot finalize a failing proposal)', () => {
+  assert.deepEqual(
+    cncfApproveDecision({ commenter: 'natedoubleu', admins, currentLabels: [MA, MC] }),
+    { ok: false, reason: 'not-validated' });
+});

--- a/programs/lfx-mentorship/automation/test/cncf-approve.test.js
+++ b/programs/lfx-mentorship/automation/test/cncf-approve.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { cncfApproveDecision } = require('../lib/cncf-approve');
+
+const MA = 'Maintainer/Contribex Approved';
+const MC = 'Mentors Confirmed';
+const VP = 'Validation Passed';
+const admins = ['natedoubleu', 'dkrook'];
+
+test('commenter not a global approver → not-admin', () => {
+  assert.deepEqual(
+    cncfApproveDecision({ commenter: 'randomuser', admins, currentLabels: [MA, MC, VP] }),
+    { ok: false, reason: 'not-admin' });
+});
+
+test('commenter match is case-insensitive', () => {
+  assert.deepEqual(
+    cncfApproveDecision({ commenter: 'NateDoubleU', admins, currentLabels: [MA, MC, VP] }),
+    { ok: true });
+});
+
+test('already CNCF-approved → already-approved', () => {
+  assert.deepEqual(
+    cncfApproveDecision({ commenter: 'natedoubleu', admins, currentLabels: [MA, MC, VP, 'CNCF Approved'] }),
+    { ok: false, reason: 'already-approved' });
+});
+
+test('missing both gates → missing-gates lists both', () => {
+  assert.deepEqual(
+    cncfApproveDecision({ commenter: 'natedoubleu', admins, currentLabels: [VP] }),
+    { ok: false, reason: 'missing-gates', missing: [MA, MC] });
+});
+
+test('missing only maintainer approval', () => {
+  assert.deepEqual(
+    cncfApproveDecision({ commenter: 'natedoubleu', admins, currentLabels: [MC, VP] }),
+    { ok: false, reason: 'missing-gates', missing: [MA] });
+});
+
+test('missing only mentor confirmation', () => {
+  assert.deepEqual(
+    cncfApproveDecision({ commenter: 'natedoubleu', admins, currentLabels: [MA, VP] }),
+    { ok: false, reason: 'missing-gates', missing: [MC] });
+});
+
+test('both gates present and validated → ok', () => {
+  assert.deepEqual(
+    cncfApproveDecision({ commenter: 'natedoubleu', admins, currentLabels: [MA, MC, VP] }),
+    { ok: true });
+});

--- a/programs/lfx-mentorship/automation/test/gates.test.js
+++ b/programs/lfx-mentorship/automation/test/gates.test.js
@@ -141,8 +141,11 @@ test('material edit while only awaiting CNCF (not yet approved) → no churn', (
 // the edit leaves validation passing. Previously the !pass branch returned early
 // and kept them, so a materially-changed, now-failing proposal still carried a
 // stale maintainer/CNCF approval (and could be /cncf-approve'd). Awaiting prompts
-// are still cleared on failure; mentor confirmation persists (participation);
-// a maintainer-proposer's approval survives (re-granted this run).
+// are still cleared on failure; mentor confirmation persists (participation).
+// Note: on the failing path the validation workflow always passes
+// maintainerApproved=false (proposer-implied approval is resolved only on a
+// passing run), so the maintainer approval is cleared here and re-granted once
+// validation passes again — there is no "keep maintainer on a failing edit" case.
 
 test('material edit breaks validation, proposer not a maintainer → clear Maintainer Approved and the awaiting prompt', () => {
   eq(gateLabelChanges({ pass: false, maintainerApproved: false, mentorsConfirmed: false, materialChange: true, currentLabels: [MA, AMC] }),
@@ -152,11 +155,6 @@ test('material edit breaks validation, proposer not a maintainer → clear Maint
 test('material edit breaks validation while CNCF-approved (proposer not a maintainer) → clear maintainer + CNCF, keep mentors', () => {
   eq(gateLabelChanges({ pass: false, maintainerApproved: false, mentorsConfirmed: true, materialChange: true, currentLabels: [MA, MC, 'CNCF Approved'] }),
     [], [MA, 'CNCF Approved']);
-});
-
-test('material edit breaks validation, maintainer-proposer re-grants → keep maintainer, still clear CNCF', () => {
-  eq(gateLabelChanges({ pass: false, maintainerApproved: true, mentorsConfirmed: true, materialChange: true, currentLabels: [MA, MC, 'CNCF Approved'] }),
-    [], ['CNCF Approved']);
 });
 
 test('non-material validation failure keeps content approvals intact', () => {

--- a/programs/lfx-mentorship/automation/test/gates.test.js
+++ b/programs/lfx-mentorship/automation/test/gates.test.js
@@ -135,3 +135,31 @@ test('material edit while only awaiting CNCF (not yet approved) → no churn', (
   eq(gateLabelChanges({ pass: true, maintainerApproved: true, mentorsConfirmed: true, materialChange: true, currentLabels: [MA, MC, ACNCF] }),
     [], []);
 });
+
+// ── A material edit clears content approvals even when it BREAKS validation ──
+// A field edit invalidates the maintainer + CNCF approvals regardless of whether
+// the edit leaves validation passing. Previously the !pass branch returned early
+// and kept them, so a materially-changed, now-failing proposal still carried a
+// stale maintainer/CNCF approval (and could be /cncf-approve'd). Awaiting prompts
+// are still cleared on failure; mentor confirmation persists (participation);
+// a maintainer-proposer's approval survives (re-granted this run).
+
+test('material edit breaks validation, proposer not a maintainer → clear Maintainer Approved and the awaiting prompt', () => {
+  eq(gateLabelChanges({ pass: false, maintainerApproved: false, mentorsConfirmed: false, materialChange: true, currentLabels: [MA, AMC] }),
+    [], [MA, AMC]);
+});
+
+test('material edit breaks validation while CNCF-approved (proposer not a maintainer) → clear maintainer + CNCF, keep mentors', () => {
+  eq(gateLabelChanges({ pass: false, maintainerApproved: false, mentorsConfirmed: true, materialChange: true, currentLabels: [MA, MC, 'CNCF Approved'] }),
+    [], [MA, 'CNCF Approved']);
+});
+
+test('material edit breaks validation, maintainer-proposer re-grants → keep maintainer, still clear CNCF', () => {
+  eq(gateLabelChanges({ pass: false, maintainerApproved: true, mentorsConfirmed: true, materialChange: true, currentLabels: [MA, MC, 'CNCF Approved'] }),
+    [], ['CNCF Approved']);
+});
+
+test('non-material validation failure keeps content approvals intact', () => {
+  eq(gateLabelChanges({ pass: false, maintainerApproved: false, mentorsConfirmed: false, materialChange: false, currentLabels: [MA, MC, 'CNCF Approved'] }),
+    [], []);
+});


### PR DESCRIPTION
## What
Promotes the approval-gate hardening (already merged and e2e-tested on the dev fork as #118) to prod. Two integrity fixes:

1. A material edit that breaks validation now clears the maintainer + CNCF approvals (previously they survived on a failing proposal). Mentor confirmations persist; a maintainer-proposer's approval is re-granted.
2. `/cncf-approve` now requires the proposal to be currently passing validation, so a regressed proposal can't be finalized.

## How
- `gates.js`: clear stale content approvals on a material regression (+tests).
- Extracted the `/cncf-approve` gate into a tested `lib/cncf-approve.js`, then added the `Validation Passed` requirement (+tests).
- README + ADMIN_GUIDE updated. Full suite: 259/259.

## Notes
Rebased onto current prod; the emoji removal (#1925) and the #1928 messaging fix (#1931) are preserved.