### PR TITLE
Show LFX proposal passed-checks inline instead of collapsed

### DIFF
--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -423,9 +423,9 @@ jobs:
             }
 
             if (passed.length) {
-              lines.push('<details><summary>✅ Passed checks</summary>', '');
+              lines.push('**✅ Passed checks**', '');
               for (const p of passed) lines.push(`- ${p}`);
-              lines.push('', '</details>');
+              lines.push('');
             }
 
             if (errors.length === 0) {


### PR DESCRIPTION
The validation comment tucked the passed checks (LFX title budget, field lengths, mentor parse, quota) behind a `<details>` fold. I open it nearly every time, so surface it inline under a bold heading like the errors and warnings above it.