### PR TITLE
Authorize the full OpenTelemetry Governance Committee for /approve

### DIFF
--- a/programs/lfx-mentorship/automation/approvers.yml
+++ b/programs/lfx-mentorship/automation/approvers.yml
@@ -40,7 +40,22 @@ kubernetes:
     - kubernetes/sig-contribex
 
 open-telemetry:
+  # OTel governance (per @maryliag, cncf/mentoring#1930): each SIG has an
+  # assigned GC liaison who ideally reviews that SIG's proposal, but any
+  # Governance Committee member may /approve. SIG → liaison map:
+  #   https://github.com/open-telemetry/community#specification-sigs
+  # The governance-committee team is cross-org (token can't read it), so GC
+  # members are listed individually. Roster (prune as terms end):
+  #   https://github.com/open-telemetry/community/blob/main/community-members.md
   fallback_teams:
     - open-telemetry/governance-committee
   fallback_handles:
-    - maryliag    # GC liaison for mentorship
+    - alolita        # until Oct 2026
+    - austinlparker  # until Oct 2027
+    - jpkrohling     # until Oct 2027
+    - maryliag       # until Oct 2027
+    - mtwo           # until Oct 2026
+    - mx-psi         # until Oct 2026
+    - svrnm          # until Oct 2027
+    - tedsuo         # until Oct 2027
+    - trask          # until Oct 2026


### PR DESCRIPTION
Expands OpenTelemetry's tier-3 fallback approvers from just @maryliag to the full 9-member Governance Committee, so any GC member's `/approve` is recognized on an OTel proposal.

The `open-telemetry/governance-committee` team is cross-org, so the workflow token can't resolve its membership — GC members must be listed individually. Roster verified against open-telemetry/community `community-members.md`; dated so we can prune as terms end.

Prompted by @maryliag on https://github.com/cncf/mentoring/issues/1930#issuecomment-5025754379 (SIG liaison @jpkrohling wasn't authorized). Per-SIG routing stays a human convention; the tool authorizes per project.