### PR TITLE
Authorize Kubernetes SIG ContribEx chairs for /approve

### DIFF
--- a/programs/lfx-mentorship/automation/approvers.yml
+++ b/programs/lfx-mentorship/automation/approvers.yml
@@ -36,8 +36,16 @@ global_approvers:
 # project-maintainers CSV). Add fallback_handles below for a guaranteed
 # per-person override.
 kubernetes:
+  # Kubernetes mentorship approvals run through SIG ContributorEx. The
+  # sig-contribex team is cross-org (token can't read it), so current
+  # SIG ContribEx chairs are listed individually. Source: kubernetes/community
+  # sig-contributor-experience leadership.
   fallback_teams:
     - kubernetes/sig-contribex
+  fallback_handles:
+    - kaslin       # Kaslin Fields — SIG ContribEx chair
+    - mfahlandt    # Mario Fahlandt — SIG ContribEx chair
+    - palnabarun   # Nabarun Pal — SIG ContribEx chair
 
 open-telemetry:
   fallback_teams:

--- a/programs/lfx-mentorship/automation/approvers.yml
+++ b/programs/lfx-mentorship/automation/approvers.yml
@@ -36,9 +36,9 @@ global_approvers:
 # project-maintainers CSV). Add fallback_handles below for a guaranteed
 # per-person override.
 kubernetes:
-  # Kubernetes mentorship approvals run through SIG ContributorEx. The
-  # sig-contribex team is cross-org (token can't read it), so current
-  # SIG ContribEx chairs are listed individually. Source: kubernetes/community
+  # Kubernetes mentorship approvals run through SIG Contributor Experience
+  # (SIG ContribEx). The sig-contribex team is cross-org (token can't read it), so
+  # current SIG ContribEx chairs are listed individually. Source: kubernetes/community
   # sig-contributor-experience leadership.
   fallback_teams:
     - kubernetes/sig-contribex

--- a/programs/lfx-mentorship/automation/approvers.yml
+++ b/programs/lfx-mentorship/automation/approvers.yml
@@ -38,14 +38,16 @@ global_approvers:
 kubernetes:
   # Kubernetes mentorship approvals run through SIG Contributor Experience
   # (SIG ContribEx). The sig-contribex team is cross-org (token can't read it), so
-  # current SIG ContribEx chairs are listed individually. Source: kubernetes/community
+  # current SIG ContribEx leads are listed individually. Source: kubernetes/community
   # sig-contributor-experience leadership.
   fallback_teams:
     - kubernetes/sig-contribex
   fallback_handles:
-    - kaslin       # Kaslin Fields — SIG ContribEx chair
-    - mfahlandt    # Mario Fahlandt — SIG ContribEx chair
-    - palnabarun   # Nabarun Pal — SIG ContribEx chair
+    - kaslin              # Kaslin Fields
+    - mfahlandt           # Mario Fahlandt
+    - palnabarun          # Nabarun Pal
+    - MadhavJivrajani     # Madhav Jivrajani
+    - Priyankasaggu11929  # Priyanka Saggu
 
 open-telemetry:
   # OTel governance (per @maryliag, cncf/mentoring#1930): each SIG has an


### PR DESCRIPTION
Kubernetes' tier-3 fallback listed only the `kubernetes/sig-contribex` team,
which is cross-org — the workflow token can't resolve it, so no one was actually
authorized via approvers.yml. This lists the three current SIG ContributorEx
chairs individually so their `/approve` is recognized on Kubernetes proposals.

Source: kubernetes/community `sig-contributor-experience` leadership.

@kaslin @mfahlandt @palnabarun — flagging this for you. Want your two tech leads
(@MadhavJivrajani, @Priyankasaggu11929) added here as well? Happy to include them.
