### PR TITLE
Add the /lfx-url command to record LFX program URLs

### DIFF
--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -36,6 +36,7 @@ jobs:
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
             const { parseRecordedLfxUrl } = _lib('lfx-url.js');
+            const { termPaths } = _lib('term-paths.js');
             const { lookupProject } = _lib('projects.js');
             const { lfxTitle } = _lib('title.js');
             const { owner, repo } = context.repo;
@@ -138,18 +139,8 @@ jobs:
 
             // ── Determine output path ──
             // Term format: "2026 Term 3 (Sep-Nov)" → year=2026, dir=03-Sep-Nov
-            const yearMatch = term.match(/^(\d{4})/);
-            const termNumMatch = term.match(/Term\s+(\d)/);
-            const monthsMatch = term.match(/\(([^)]+)\)/);
-
-            const year = yearMatch ? yearMatch[1] : 'unknown';
-            const termNum = termNumMatch ? termNumMatch[1].padStart(2, '0') : '00';
-            const months = monthsMatch
-              ? monthsMatch[1].replace(/[\u2013\u2014]/g, '-')
-              : 'unknown';
-            const termDir = `${termNum}-${months}`;
-
-            const outDir = `programs/lfx-mentorship/${year}/${termDir}`;
+            // (path derivation shared with /lfx-url via lib/term-paths.js).
+            const { year, termNum, months, termDir, outDir } = termPaths(term);
             fs.mkdirSync(outDir, { recursive: true });
 
             const outPath = `${outDir}/lfx-export.json`;

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -35,6 +35,7 @@ jobs:
             const { standardPrerequisites } = _lib('prerequisites.js');
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
+            const { parseRecordedLfxUrl } = _lib('lfx-url.js');
             const { lookupProject } = _lib('projects.js');
             const { lfxTitle } = _lib('title.js');
             const { owner, repo } = context.repo;
@@ -88,6 +89,19 @@ jobs:
 
               const meta = lookupProject(projYaml, project) || {};
 
+              // Read the LFX URL recorded on the issue by /lfx-url (§4.3.5), if
+              // any. The issue is the source of truth, so a re-export keeps the
+              // URL without re-keying it.
+              let issueComments = [];
+              try {
+                issueComments = await github.paginate(github.rest.issues.listComments, {
+                  owner, repo, issue_number: iss.number, per_page: 100,
+                });
+              } catch (e) {
+                core.warning(`Could not read comments for #${iss.number}: ${e.message}`);
+              }
+              const lfxUrl = parseRecordedLfxUrl(issueComments);
+
               programs.push({
                 issue_number: iss.number,
                 issue_url: iss.html_url,
@@ -102,6 +116,7 @@ jobs:
                 skills: skills,
                 mentors: parseMentors(get('Mentors')),
                 upstream_issue_url: get('Upstream Issue URL'),
+                lfx_url: lfxUrl,
                 prerequisites: {
                   resume: prerequisites.includes('Resume'),
                   cover_letter: prerequisites.includes('Cover Letter'),

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -33,9 +33,8 @@ jobs:
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
             const { parseIssueForm, parseCheckboxes, parseMentors } = _lib('parse.js');
             const { standardPrerequisites } = _lib('prerequisites.js');
-            const { slugify } = _lib('slug.js');
-            const { buildReadme } = _lib('readme.js');
-            const { csvEscape } = _lib('csv.js');
+            const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
+            const { renderTrackingCsv } = _lib('csv.js');
             const { lookupProject } = _lib('projects.js');
             const { lfxTitle } = _lib('title.js');
             const { owner, repo } = context.repo;
@@ -150,17 +149,6 @@ jobs:
             console.log(`Wrote ${programs.length} programs to ${outPath}`);
 
             // ── Generate README.md ──
-            // Group programs by CNCF project
-            const byProject = {};
-            for (const prog of programs) {
-              const proj = prog.cncf_project;
-              if (!byProject[proj]) byProject[proj] = [];
-              byProject[proj].push(prog);
-            }
-            const sortedProjects = Object.keys(byProject).sort(
-              (a, b) => a.toLowerCase().localeCompare(b.toLowerCase())
-            );
-
             // Term display: "2026 Term 3 (Sep-Nov)" → "Term 03 - 2026 September - November"
             const monthMap = {
               'Mar': 'March', 'May': 'May', 'Jun': 'June',
@@ -169,100 +157,25 @@ jobs:
             const monthParts = months.split('-').map(m => monthMap[m.trim()] || m.trim());
             const readmeTitle = `Term ${termNum} - ${year} ${monthParts.join(' - ')}`;
 
-            // Build the auto-generated section (Table of Contents + Accepted
-            // Projects). The term frontmatter above it is preserved separately
-            // so re-running the export never wipes the term timeline and
-            // instructions.
-            const md = [];
-
-            // Table of contents
-            md.push('## Table of Contents');
-            md.push('');
-            for (const proj of sortedProjects) {
-              const projSlug = slugify(proj);
-              md.push(`- [${proj}](#${projSlug})`);
-              for (const prog of byProject[proj]) {
-                const progSlug = slugify(prog.program_name_short);
-                md.push(`  - [${prog.program_name_short}](#${progSlug})`);
-              }
-            }
-            md.push('');
-
-            // Accepted projects
-            md.push('## Accepted Projects');
-            md.push('');
-            for (const proj of sortedProjects) {
-              md.push(`### ${proj}`);
-              md.push('');
-              for (const prog of byProject[proj]) {
-                md.push(`#### ${prog.program_name_short}`);
-                md.push('');
-                md.push(prog.program_name_full);
-                md.push('');
-                md.push('- Description:');
-                md.push('');
-                for (const line of prog.description.split('\n')) {
-                  md.push(`  > ${line}`);
-                }
-                md.push('');
-                md.push(`- Recommended Skills: ${prog.skills}`);
-                md.push(`- Technologies: ${prog.technologies}`);
-                md.push('- Mentor(s):');
-                for (const m of prog.mentors) {
-                  md.push(`  - ${m.name} (@${m.github_handle}, ${m.email})`);
-                }
-                md.push(`- Upstream Issue: ${prog.upstream_issue_url}`);
-                md.push(`- LFX URL: TBD`);
-                md.push('');
-              }
-            }
+            // The body (Table of Contents + Accepted Projects) is rendered by
+            // lib/readme.js so the same renderer backs both the export and the
+            // /lfx-url command (§4.3.5). The term frontmatter above the first
+            // horizontal rule is preserved by buildReadme; only the body below
+            // it is regenerated, so a re-export never wipes the term timeline.
+            const md = renderAcceptedProgramsBody(programs);
 
             const readmePath = `${outDir}/README.md`;
-
-            // Preserve the term frontmatter (title, timeline, project and
-            // application instructions) up to and including the first horizontal
-            // rule, then regenerate only the Table of Contents and Accepted
-            // Projects below it. Fall back to a minimal header only when the
-            // term README has no frontmatter yet.
             let existingReadme = null;
             if (fs.existsSync(readmePath)) {
               existingReadme = fs.readFileSync(readmePath, 'utf8');
             }
             fs.writeFileSync(readmePath, buildReadme(existingReadme, md, readmeTitle));
-            console.log(`Wrote README.md with ${sortedProjects.length} projects, ${programs.length} programs`);
+            const projectCount = new Set(programs.map(p => p.cncf_project)).size;
+            console.log(`Wrote README.md with ${projectCount} projects, ${programs.length} programs`);
 
-            // ── Generate tracking CSV ──
-            const csvHeaders = [
-              'PROJECT', 'LFX URL', 'Upstream issue', '',
-              'mentor count',
-              'Mentor 1', 'Mentor 1 GitHub', 'Mentor 1 email address', 'Mentor 1 LFID',
-              'Mentor 2', 'Mentor 2 GitHub', 'Mentor 2 email address', 'Mentor 2 LFID',
-              'Mentor 3', 'Mentor 3 GitHub', 'Mentor 3 email address', 'Mentor 3 LFID',
-              'Mentor 4', 'Mentor 4 GitHub', 'Mentor 4 email address', 'Mentor 4 LFID',
-            ];
-
-            const csvRows = [csvHeaders.map(csvEscape).join(',')];
-            for (const prog of programs) {
-              const mentors = prog.mentors || [];
-              const row = [
-                prog.program_name_full,
-                '',  // LFX URL — filled in after posting to LFX
-                prog.upstream_issue_url,
-                '',  // spacer column
-                mentors.length,
-              ];
-              for (let i = 0; i < 4; i++) {
-                const m = mentors[i];
-                row.push(m ? m.name : '');
-                row.push(m ? m.github_handle : '');
-                row.push(m ? m.email : '');
-                row.push(m ? m.lfid : '');
-              }
-              csvRows.push(row.map(csvEscape).join(','));
-            }
-
+            // ── Generate tracking CSV (rendered by lib/csv.js) ──
             const csvPath = `${outDir}/lfx-tracking.csv`;
-            fs.writeFileSync(csvPath, csvRows.join('\n') + '\n');
+            fs.writeFileSync(csvPath, renderTrackingCsv(programs));
             console.log(`Wrote ${programs.length} rows to ${csvPath}`);
 
             // ── Store path and issue numbers for later steps ──

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -92,14 +92,18 @@ jobs:
 
               // Read the LFX URL recorded on the issue by /lfx-url (§4.3.5), if
               // any. The issue is the source of truth, so a re-export keeps the
-              // URL without re-keying it.
+              // URL without re-keying it. Skip the API call when the issue has
+              // no comments (listForRepo returns the count) to avoid needless
+              // requests and secondary rate-limit pressure on large terms.
               let issueComments = [];
-              try {
-                issueComments = await github.paginate(github.rest.issues.listComments, {
-                  owner, repo, issue_number: iss.number, per_page: 100,
-                });
-              } catch (e) {
-                core.warning(`Could not read comments for #${iss.number}: ${e.message}`);
+              if (iss.comments > 0) {
+                try {
+                  issueComments = await github.paginate(github.rest.issues.listComments, {
+                    owner, repo, issue_number: iss.number, per_page: 100,
+                  });
+                } catch (e) {
+                  core.warning(`Could not read comments for #${iss.number}: ${e.message}`);
+                }
               }
               const lfxUrl = parseRecordedLfxUrl(issueComments);
 

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -138,9 +138,10 @@ jobs:
             }
 
             // ── Determine output path ──
-            // Term format: "2026 Term 3 (Sep-Nov)" → year=2026, dir=03-Sep-Nov
-            // (path derivation shared with /lfx-url via lib/term-paths.js).
-            const { year, termNum, months, termDir, outDir } = termPaths(term);
+            // Term format: "2026 Term 3 (Sep-Nov)" → year=2026, dir=03-Sep-Nov,
+            // readmeTitle="Term 03 - 2026 September - November" (all derivation
+            // shared with /lfx-url via lib/term-paths.js).
+            const { year, termDir, outDir, readmeTitle } = termPaths(term);
             fs.mkdirSync(outDir, { recursive: true });
 
             const outPath = `${outDir}/lfx-export.json`;
@@ -155,14 +156,6 @@ jobs:
             console.log(`Wrote ${programs.length} programs to ${outPath}`);
 
             // ── Generate README.md ──
-            // Term display: "2026 Term 3 (Sep-Nov)" → "Term 03 - 2026 September - November"
-            const monthMap = {
-              'Mar': 'March', 'May': 'May', 'Jun': 'June',
-              'Aug': 'August', 'Sep': 'September', 'Nov': 'November',
-            };
-            const monthParts = months.split('-').map(m => monthMap[m.trim()] || m.trim());
-            const readmeTitle = `Term ${termNum} - ${year} ${monthParts.join(' - ')}`;
-
             // The body (Table of Contents + Accepted Projects) is rendered by
             // lib/readme.js so the same renderer backs both the export and the
             // /lfx-url command (§4.3.5). The term frontmatter above the first

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -429,7 +429,7 @@ jobs:
               if (!prog) {
                 await reply('❌',
                   `This term's export isn't on \`main\` yet (with this program). ` +
-                  `Merge the export PR for ${lfxTerm}, then re-run: \`/lfx-url ${decision.url}\``);
+                  `Merge its export PR (\`${outDir}/\`), then re-run: \`/lfx-url ${decision.url}\``);
                 return;
               }
 

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -406,7 +406,7 @@ jobs:
               // truth; re-render README + CSV from it). The issue's Term field
               // selects the term; the next step lands the change in a per-term PR.
               const lfxTerm = (parseIssueForm(issueBody)['Term'] || '').trim();
-              const { outDir, year, termDir } = termPaths(lfxTerm);
+              const { outDir, year, termDir, readmeTitle } = termPaths(lfxTerm);
               const jsonPath = `${outDir}/lfx-export.json`;
               try {
                 const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
@@ -422,7 +422,7 @@ jobs:
                   fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2) + '\n');
                   const readmePath = `${outDir}/README.md`;
                   const existingReadme = fs.existsSync(readmePath) ? fs.readFileSync(readmePath, 'utf8') : null;
-                  fs.writeFileSync(readmePath, buildReadme(existingReadme, renderAcceptedProgramsBody(data.programs), ''));
+                  fs.writeFileSync(readmePath, buildReadme(existingReadme, renderAcceptedProgramsBody(data.programs), readmeTitle));
                   fs.writeFileSync(`${outDir}/lfx-tracking.csv`, renderTrackingCsv(data.programs));
                   core.exportVariable('LFX_URL_FILES_CHANGED', 'true');
                   core.exportVariable('LFX_URL_TERM', lfxTerm);

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -402,7 +402,7 @@ jobs:
                   await reply('❌', 'Usage: `/lfx-url <url>` — include the LFX program URL.');
                 } else if (decision.reason === 'invalid-url') {
                   await reply('❌',
-                    `\`${commandArg}\` is not an LFX Mentorship program URL. ` +
+                    'That isn\'t an LFX Mentorship program URL. ' +
                     'Expected `https://mentorship.lfx.linuxfoundation.org/project/<id>`.');
                 }
                 return;

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -6,7 +6,8 @@ on:
 
 permissions:
   issues: write
-  contents: read
+  contents: write
+  pull-requests: write
 
 jobs:
   handle-command:
@@ -38,6 +39,10 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
+            const { lfxUrlDecision, recordedLfxUrlComment, LFX_HOST } = _lib('lfx-url.js');
+            const { termPaths } = _lib('term-paths.js');
+            const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
+            const { renderTrackingCsv } = _lib('csv.js');
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
             const comment = context.payload.comment;
@@ -48,11 +53,13 @@ jobs:
 
             // ── Detect slash command ──
             // Scan every line; the command may not be the first line (e.g.
-            // someone writes context before their /approve).
+            // someone writes context before their /approve). /lfx-url takes a
+            // URL argument (the rest of the line); the others take none.
             let command = null;
+            let commandArg = '';
             for (const line of commentBody.split('\n')) {
-              const m = line.trim().match(/^\/(cncf-approve|approve|confirm)\b/);
-              if (m) { command = m[1]; break; }
+              const m = line.trim().match(/^\/(lfx-url|cncf-approve|approve|confirm)\b\s*(.*)$/);
+              if (m) { command = m[1]; commandArg = (m[2] || '').trim(); break; }
             }
             if (!command) return;  // no slash command found
             console.log(`/${command} from @${commenter}`);
@@ -353,6 +360,105 @@ jobs:
               return;
             }
 
+            // ══════════════════════════════════════════════════
+            //  /lfx-url: record the LFX program URL (§4.3.5)
+            // ══════════════════════════════════════════════════
+            if (command === 'lfx-url') {
+
+              // Authorization: same allowlist as /cncf-approve.
+              let admins = [];
+              try {
+                const raw = fs.readFileSync('programs/lfx-mentorship/automation/approvers.yml', 'utf8');
+                admins = getGlobalApprovers(raw);
+              } catch (e) {
+                console.log(`Failed to read approvers.yml: ${e.message}`);
+              }
+
+              const decision = lfxUrlDecision({ commenter, admins, currentLabels, arg: commandArg });
+              if (!decision.ok) {
+                if (decision.reason === 'not-admin') {
+                  await reply('❌',
+                    `@${commenter} is not authorized to use \`/lfx-url\`. ` +
+                    `This command is restricted to CNCF program admins.`);
+                } else if (decision.reason === 'not-exported') {
+                  await reply('❌',
+                    'Cannot `/lfx-url` — this proposal has not been exported yet ' +
+                    '(no `Exported` label). Run the export first.');
+                } else if (decision.reason === 'missing-url') {
+                  await reply('❌', 'Usage: `/lfx-url <url>` — include the LFX program URL.');
+                } else if (decision.reason === 'invalid-url') {
+                  await reply('❌',
+                    `\`${commandArg}\` is not a valid URL. Provide the full LFX program URL (https://…).`);
+                }
+                return;
+              }
+
+              // Record the URL on the issue — the durable source of truth the
+              // export reads back (§4.5). Advance the board regardless of the
+              // file-update outcome below: the program IS posted once recorded.
+              const hostNote = decision.hostWarning
+                ? `\n\n⚠️ That URL isn't on \`${LFX_HOST}\`; recorded anyway — double-check it's correct.`
+                : '';
+              await reply('✅', recordedLfxUrlComment(commenter, decision.url) + hostNote);
+              core.exportVariable('LFX_URL_POSTED', 'true');
+
+              // Fill the URL into that term's export files (JSON is the source of
+              // truth; re-render README + CSV from it). The issue's Term field
+              // selects the term; the next step lands the change in a per-term PR.
+              const lfxTerm = (parseIssueForm(issueBody)['Term'] || '').trim();
+              const { outDir, year, termDir } = termPaths(lfxTerm);
+              const jsonPath = `${outDir}/lfx-export.json`;
+              try {
+                const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+                const prog = (data.programs || []).find(p => p.issue_number === issue_number);
+                if (!prog) {
+                  await reply('ℹ️',
+                    `Recorded the URL, but couldn't find this program in \`${jsonPath}\`. ` +
+                    `Re-run the export for ${lfxTerm} to materialize it into the files.`);
+                } else if (prog.lfx_url === decision.url) {
+                  console.log('lfx_url already set to this value; no file change.');
+                } else {
+                  prog.lfx_url = decision.url;
+                  fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2) + '\n');
+                  const readmePath = `${outDir}/README.md`;
+                  const existingReadme = fs.existsSync(readmePath) ? fs.readFileSync(readmePath, 'utf8') : null;
+                  fs.writeFileSync(readmePath, buildReadme(existingReadme, renderAcceptedProgramsBody(data.programs), ''));
+                  fs.writeFileSync(`${outDir}/lfx-tracking.csv`, renderTrackingCsv(data.programs));
+                  core.exportVariable('LFX_URL_FILES_CHANGED', 'true');
+                  core.exportVariable('LFX_URL_TERM', lfxTerm);
+                  core.exportVariable('LFX_URL_YEAR', year);
+                  core.exportVariable('LFX_URL_TERM_DIR', termDir);
+                  console.log(`Updated export files in ${outDir}`);
+                }
+              } catch (e) {
+                await reply('ℹ️',
+                  `Recorded the URL, but couldn't update \`${jsonPath}\` (${e.message}). ` +
+                  `Re-run the export for ${lfxTerm}.`);
+              }
+              return;
+            }
+
+      - name: Open or update the LFX URL pull request
+        if: env.LFX_URL_FILES_CHANGED == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: programs/lfx-mentorship/${{ env.LFX_URL_YEAR }}/${{ env.LFX_URL_TERM_DIR }}
+          commit-message: |
+            chore: record LFX URL for ${{ env.LFX_URL_TERM }}
+
+            Recorded via /lfx-url on issue #${{ github.event.issue.number }}.
+          branch: automation/lfx-urls-${{ env.LFX_URL_YEAR }}-${{ env.LFX_URL_TERM_DIR }}
+          title: "LFX URLs — ${{ env.LFX_URL_TERM }}"
+          body: |
+            Accumulating LFX program URLs recorded via `/lfx-url` for **${{ env.LFX_URL_TERM }}**.
+
+            Each `/lfx-url <url>` comment on an exported proposal issue updates this
+            PR, filling the URL into that term's `lfx-export.json`, `README.md`, and
+            `lfx-tracking.csv`. Merge once the term's programs have been posted to LFX.
+
+            Generated by the LFX Proposal Approvals workflow.
+
       - name: Sync board status
         if: always()
         uses: actions/github-script@v7
@@ -401,8 +507,13 @@ jobs:
 
             // Automation owns the lifecycle only through "Exported"; the
             // post-export columns are manual admin moves (see board guard below
-            // and lib/board.js).
-            const status = determineStatus(labels, issue.state === 'closed' ? 'closed' : null);
+            // and lib/board.js). The one exception: a successful /lfx-url
+            // command explicitly advances the card to "Posted to LFX" (§4.3.5),
+            // signalled via the LFX_URL_POSTED env from the command step.
+            const forcePosted = process.env.LFX_URL_POSTED === 'true';
+            const status = forcePosted
+              ? 'Posted to LFX'
+              : determineStatus(labels, issue.state === 'closed' ? 'closed' : null);
 
             const optionId = STATUS_OPTIONS[status];
             if (!optionId) {
@@ -435,7 +546,9 @@ jobs:
               `, { itemId }),
               { onError: (attempt, e) => core.warning(`Could not read current board status (attempt ${attempt}/2): ${e.message}`) },
             );
-            if (shouldSkipSync(currentStatus, status, readFailed)) {
+            // The /lfx-url advance is the intentional exception to the
+            // admin-owned guard, so bypass the skip check for it.
+            if (!forcePosted && shouldSkipSync(currentStatus, status, readFailed)) {
               if (currentStatus) {
                 console.log(`Card is in admin-owned column "${currentStatus}"; leaving placement to the administrator.`);
               } else {

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -5,6 +5,13 @@ on:
     types: [created]
 
 permissions:
+  # Runs on issue_comment, so any commenter can trigger a run. The write scopes
+  # let a successful /lfx-url open the per-term URLs PR via peter-evans (same
+  # token and perms as the workflow_dispatch lfx-export.yml). They are never
+  # exercised for untrusted commenters: the file writes and PR step are gated on
+  # LFX_URL_FILES_CHANGED, set only after the global-approver auth check; the
+  # comment body is parsed as a string (no shell interpolation); and PRs target
+  # branch-protected main. Board moves use PROJECT_TOKEN, not GITHUB_TOKEN.
   issues: write
   contents: write
   pull-requests: write

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -46,7 +46,7 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
-            const { lfxUrlDecision, recordedLfxUrlComment, findExportedProgram } = _lib('lfx-url.js');
+            const { lfxUrlDecision, recordedLfxUrlComment, findExportedProgram, exportTermLabel } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
@@ -449,7 +449,7 @@ jobs:
                 fs.writeFileSync(readmePath, buildReadme(existingReadme, renderAcceptedProgramsBody(data.programs), readmeTitle));
                 fs.writeFileSync(`${outDir}/lfx-tracking.csv`, renderTrackingCsv(data.programs));
                 core.exportVariable('LFX_URL_FILES_CHANGED', 'true');
-                core.exportVariable('LFX_URL_TERM', lfxTerm);
+                core.exportVariable('LFX_URL_TERM', exportTermLabel(data, lfxTerm));
                 core.exportVariable('LFX_URL_YEAR', year);
                 core.exportVariable('LFX_URL_TERM_DIR', termDir);
                 console.log(`Updated export files in ${outDir}`);

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -566,13 +566,15 @@ jobs:
               `, { itemId }),
               { onError: (attempt, e) => core.warning(`Could not read current board status (attempt ${attempt}/2): ${e.message}`) },
             );
-            // The /lfx-url advance is the intentional exception to the
-            // admin-owned guard, so bypass the skip check for it.
-            if (!forcePosted && shouldSkipSync(currentStatus, status, readFailed)) {
+            // Honor the admin-owned guard even for the /lfx-url advance. The
+            // Exported → "Posted to LFX" move isn't blocked (Exported isn't
+            // admin-owned), but a card an admin already moved further must not be
+            // pulled back to "Posted to LFX", and a failed read fails closed.
+            if (shouldSkipSync(currentStatus, status, readFailed)) {
               if (currentStatus) {
                 console.log(`Card is in admin-owned column "${currentStatus}"; leaving placement to the administrator.`);
               } else {
-                core.warning('Status read failed while about to set "Exported"; skipping to avoid clobbering a manual placement.');
+                core.warning(`Status read failed while about to set "${status}"; skipping to avoid clobbering a manual placement.`);
               }
               return;
             }

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -473,7 +473,7 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
-            const { determineStatus, shouldSkipSync, readStatusWithRetry } = _lib('board.js');
+            const { resolveBoardStatus, shouldSkipSync, readStatusWithRetry } = _lib('board.js');
             const _board = JSON.parse(fs.readFileSync('programs/lfx-mentorship/automation/board.json', 'utf8'));
             const _envCfg = (_board.environments || {})[process.env.GITHUB_REPOSITORY];
             if (!_envCfg || !_envCfg.projectId || String(_envCfg.projectId).startsWith('REPLACE_')) {
@@ -509,11 +509,12 @@ jobs:
             // post-export columns are manual admin moves (see board guard below
             // and lib/board.js). The one exception: a successful /lfx-url
             // command explicitly advances the card to "Posted to LFX" (§4.3.5),
-            // signalled via the LFX_URL_POSTED env from the command step.
-            const forcePosted = process.env.LFX_URL_POSTED === 'true';
-            const status = forcePosted
-              ? 'Posted to LFX'
-              : determineStatus(labels, issue.state === 'closed' ? 'closed' : null);
+            // signalled via the LFX_URL_POSTED env from the command step — but a
+            // closed issue always resolves to "Closed" (the force never
+            // resurrects a closed card). Precedence lives in resolveBoardStatus.
+            const closed = issue.state === 'closed';
+            const forcePosted = process.env.LFX_URL_POSTED === 'true' && !closed;
+            const status = resolveBoardStatus({ labels, closed, forcePosted });
 
             const optionId = STATUS_OPTIONS[status];
             if (!optionId) {

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -46,7 +46,7 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
-            const { lfxUrlDecision, recordedLfxUrlComment, LFX_HOST } = _lib('lfx-url.js');
+            const { lfxUrlDecision, recordedLfxUrlComment } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
@@ -395,7 +395,8 @@ jobs:
                   await reply('❌', 'Usage: `/lfx-url <url>` — include the LFX program URL.');
                 } else if (decision.reason === 'invalid-url') {
                   await reply('❌',
-                    `\`${commandArg}\` is not a valid URL. Provide the full LFX program URL (https://…).`);
+                    `\`${commandArg}\` is not an LFX Mentorship program URL. ` +
+                    'Expected `https://mentorship.lfx.linuxfoundation.org/project/<id>`.');
                 }
                 return;
               }
@@ -403,10 +404,7 @@ jobs:
               // Record the URL on the issue — the durable source of truth the
               // export reads back (§4.5). Advance the board regardless of the
               // file-update outcome below: the program IS posted once recorded.
-              const hostNote = decision.hostWarning
-                ? `\n\n⚠️ That URL isn't on \`${LFX_HOST}\`; recorded anyway — double-check it's correct.`
-                : '';
-              await reply('✅', recordedLfxUrlComment(commenter, decision.url) + hostNote);
+              await reply('✅', recordedLfxUrlComment(commenter, decision.url));
               core.exportVariable('LFX_URL_POSTED', 'true');
 
               // Fill the URL into that term's export files (JSON is the source of

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -381,12 +381,19 @@ jobs:
                 console.log(`Failed to read approvers.yml: ${e.message}`);
               }
 
-              const decision = lfxUrlDecision({ commenter, admins, currentLabels, arg: commandArg });
+              const decision = lfxUrlDecision({
+                commenter, admins, currentLabels, arg: commandArg,
+                closed: context.payload.issue.state === 'closed',
+              });
               if (!decision.ok) {
                 if (decision.reason === 'not-admin') {
                   await reply('❌',
                     `@${commenter} is not authorized to use \`/lfx-url\`. ` +
                     `This command is restricted to CNCF program admins.`);
+                } else if (decision.reason === 'issue-closed') {
+                  await reply('❌',
+                    'Cannot `/lfx-url` — this proposal is closed. Reopen it first ' +
+                    'if it really was posted to LFX.');
                 } else if (decision.reason === 'not-exported') {
                   await reply('❌',
                     'Cannot `/lfx-url` — this proposal has not been exported yet ' +

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -46,7 +46,7 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
-            const { lfxUrlDecision, recordedLfxUrlComment } = _lib('lfx-url.js');
+            const { lfxUrlDecision, recordedLfxUrlComment, findExportedProgram } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
@@ -408,44 +408,51 @@ jobs:
                 return;
               }
 
-              // Record the URL on the issue — the durable source of truth the
-              // export reads back (§4.5). Advance the board regardless of the
-              // file-update outcome below: the program IS posted once recorded.
-              await reply('✅', recordedLfxUrlComment(commenter, decision.url));
-              core.exportVariable('LFX_URL_POSTED', 'true');
-
-              // Fill the URL into that term's export files (JSON is the source of
-              // truth; re-render README + CSV from it). The issue's Term field
-              // selects the term; the next step lands the change in a per-term PR.
+              // Guard (§4.3.5, option C): the term's export must be merged to
+              // `main` and contain this program before we touch anything. If the
+              // export PR is still open, the files live only on its branch, so
+              // recording now would move the board and leave the files unsynced.
+              // Reject atomically instead — nothing recorded, no board move — and
+              // hand back the exact command to re-run after the export PR merges.
+              // decision.url already passed the strict format gate, so it is safe
+              // to echo here.
               const lfxTerm = (parseIssueForm(issueBody)['Term'] || '').trim();
               const { outDir, year, termDir, readmeTitle } = termPaths(lfxTerm);
               const jsonPath = `${outDir}/lfx-export.json`;
+              let data = null;
               try {
-                const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
-                const prog = (data.programs || []).find(p => p.issue_number === issue_number);
-                if (!prog) {
-                  await reply('ℹ️',
-                    `Recorded the URL, but couldn't find this program in \`${jsonPath}\`. ` +
-                    `Re-run the export for ${lfxTerm} to materialize it into the files.`);
-                } else if (prog.lfx_url === decision.url) {
-                  console.log('lfx_url already set to this value; no file change.');
-                } else {
-                  prog.lfx_url = decision.url;
-                  fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2) + '\n');
-                  const readmePath = `${outDir}/README.md`;
-                  const existingReadme = fs.existsSync(readmePath) ? fs.readFileSync(readmePath, 'utf8') : null;
-                  fs.writeFileSync(readmePath, buildReadme(existingReadme, renderAcceptedProgramsBody(data.programs), readmeTitle));
-                  fs.writeFileSync(`${outDir}/lfx-tracking.csv`, renderTrackingCsv(data.programs));
-                  core.exportVariable('LFX_URL_FILES_CHANGED', 'true');
-                  core.exportVariable('LFX_URL_TERM', lfxTerm);
-                  core.exportVariable('LFX_URL_YEAR', year);
-                  core.exportVariable('LFX_URL_TERM_DIR', termDir);
-                  console.log(`Updated export files in ${outDir}`);
-                }
-              } catch (e) {
-                await reply('ℹ️',
-                  `Recorded the URL, but couldn't update \`${jsonPath}\` (${e.message}). ` +
-                  `Re-run the export for ${lfxTerm}.`);
+                data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+              } catch {
+                // Missing/unreadable on main → treated as not-yet-merged below.
+              }
+              const prog = findExportedProgram(data, issue_number);
+              if (!prog) {
+                await reply('❌',
+                  `This term's export isn't on \`main\` yet (with this program). ` +
+                  `Merge the export PR for ${lfxTerm}, then re-run: \`/lfx-url ${decision.url}\``);
+                return;
+              }
+
+              // Record the URL on the issue — the durable source of truth the
+              // export reads back (§4.5) — then fill the term's files and advance
+              // the board. The guard above guarantees this completes fully.
+              await reply('✅', recordedLfxUrlComment(commenter, decision.url));
+              core.exportVariable('LFX_URL_POSTED', 'true');
+
+              if (prog.lfx_url === decision.url) {
+                console.log('lfx_url already set to this value; no file change.');
+              } else {
+                prog.lfx_url = decision.url;
+                fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2) + '\n');
+                const readmePath = `${outDir}/README.md`;
+                const existingReadme = fs.existsSync(readmePath) ? fs.readFileSync(readmePath, 'utf8') : null;
+                fs.writeFileSync(readmePath, buildReadme(existingReadme, renderAcceptedProgramsBody(data.programs), readmeTitle));
+                fs.writeFileSync(`${outDir}/lfx-tracking.csv`, renderTrackingCsv(data.programs));
+                core.exportVariable('LFX_URL_FILES_CHANGED', 'true');
+                core.exportVariable('LFX_URL_TERM', lfxTerm);
+                core.exportVariable('LFX_URL_YEAR', year);
+                core.exportVariable('LFX_URL_TERM_DIR', termDir);
+                console.log(`Updated export files in ${outDir}`);
               }
               return;
             }

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -423,7 +423,7 @@ jobs:
             }
 
             if (passed.length) {
-              lines.push('**✅ Passed checks**', '');
+              lines.push('✅ **Passed checks**', '');
               for (const p of passed) lines.push(`- ${p}`);
               lines.push('');
             }

--- a/programs/lfx-mentorship/README.md
+++ b/programs/lfx-mentorship/README.md
@@ -131,7 +131,7 @@ the [project board](https://github.com/orgs/cncf/projects/93).
 | `/approve` | Project maintainers, authorized delegates, global approvers | Grants maintainer/project approval |
 | `/confirm` | Mentors listed on the proposal | Confirms mentor participation |
 | `/cncf-approve` | CNCF mentorship admins | Final approval — proposal moves to "CNCF Approved" |
-| `/lfx-url <url>` | CNCF mentorship admins | After export: records the LFX program URL, fills it into the term's export files, and moves the card to "Posted to LFX" |
+| `/lfx-url <url>` | CNCF mentorship admins | After the term's export PR is merged to `main`: records the LFX program URL, fills it into the term's export files, and moves the card to "Posted to LFX" (rejected if the export isn't merged yet) |
 
 #### Mentees
 

--- a/programs/lfx-mentorship/README.md
+++ b/programs/lfx-mentorship/README.md
@@ -131,6 +131,7 @@ the [project board](https://github.com/orgs/cncf/projects/93).
 | `/approve` | Project maintainers, authorized delegates, global approvers | Grants maintainer/project approval |
 | `/confirm` | Mentors listed on the proposal | Confirms mentor participation |
 | `/cncf-approve` | CNCF mentorship admins | Final approval — proposal moves to "CNCF Approved" |
+| `/lfx-url <url>` | CNCF mentorship admins | After export: records the LFX program URL, fills it into the term's export files, and moves the card to "Posted to LFX" |
 
 #### Mentees
 

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -137,8 +137,9 @@ the existing branch if the previous PR wasn't merged).
    the term's `lfx-export.json`, `README.md`, and `lfx-tracking.csv` (landing the
    change in a per-term `LFX URLs — <term>` PR), and advances the card to
    `Posted to LFX`. Restricted to global approvers; the issue must already be
-   `Exported`. A URL that isn't on `mentorship.lfx.linuxfoundation.org` is
-   recorded with a warning rather than rejected.
+   `Exported`. The URL must be a full LFX Mentorship program URL
+   (`https://mentorship.lfx.linuxfoundation.org/project/<id>`); anything else is
+   rejected, so the card only advances on a real program URL.
 5. **Continue tracking** by dragging cards through the remaining columns by
    hand as each step completes on the LFX platform (`LFX Approved` →
    `Mentors added` → `Open for Applications` → `Applications Closed`)

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -137,9 +137,10 @@ the existing branch if the previous PR wasn't merged).
    the term's `lfx-export.json`, `README.md`, and `lfx-tracking.csv` (landing the
    change in a per-term `LFX URLs — <term>` PR), and advances the card to
    `Posted to LFX`. Restricted to global approvers; the issue must already be
-   `Exported`. The URL must be a full LFX Mentorship program URL
+   `Exported` and open. The URL must be a full LFX Mentorship program URL
    (`https://mentorship.lfx.linuxfoundation.org/project/<id>`); anything else is
-   rejected, so the card only advances on a real program URL.
+   rejected, so the card only advances on a real program URL. A closed proposal
+   is rejected too (reopen it first) — a withdrawn program should not be posted.
 5. **Continue tracking** by dragging cards through the remaining columns by
    hand as each step completes on the LFX platform (`LFX Approved` →
    `Mentors added` → `Open for Applications` → `Applications Closed`)

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -132,9 +132,13 @@ the existing branch if the previous PR wasn't merged).
 2. **Merge the PR** — this triggers a notification to each exported issue
    confirming the files are on main
 3. **Share `lfx-export.json` with the LFX platform team** for bulk import
-4. **After programs are created on LFX:**
-   - Update LFX URLs in the README (manual step for now)
-   - Drag each issue's card to the `Posted to LFX` column on the board
+4. **After you create each program on LFX:** comment `/lfx-url <url>` on that
+   program's proposal issue. The bot records the URL on the issue, fills it into
+   the term's `lfx-export.json`, `README.md`, and `lfx-tracking.csv` (landing the
+   change in a per-term `LFX URLs — <term>` PR), and advances the card to
+   `Posted to LFX`. Restricted to global approvers; the issue must already be
+   `Exported`. A URL that isn't on `mentorship.lfx.linuxfoundation.org` is
+   recorded with a warning rather than rejected.
 5. **Continue tracking** by dragging cards through the remaining columns by
    hand as each step completes on the LFX platform (`LFX Approved` →
    `Mentors added` → `Open for Applications` → `Applications Closed`)
@@ -158,15 +162,16 @@ issue form and export workflow.
 
 ### approvers.yml
 
-Controls who can use `/approve` and `/cncf-approve`. The authorization
-check order is:
+Controls who can use `/approve`, `/cncf-approve`, and `/lfx-url`. The
+authorization check order is:
 
 1. `{org}/.project/maintainers.yaml` — project-maintainers team membership
 2. `cncf/foundation/project-maintainers.csv` — maintainer CSV lookup
 3. Per-project `fallback_teams` and `fallback_handles` in this file
 4. `global_approvers` in this file
 
-**Global approvers** can `/approve` for any project and use `/cncf-approve`.
+**Global approvers** can `/approve` for any project and use `/cncf-approve` and
+`/lfx-url`.
 
 **Per-project overrides** are useful when a project's governance isn't fully
 captured in the maintainers CSV:
@@ -221,15 +226,18 @@ issue labels to Project v2 board status columns:
 | `Exported` | Exported |
 | Issue closed | Closed |
 
-Everything after `Exported` is **yours to move by hand**. As you work with the
-LFX platform team, drag each card through the remaining columns:
+The `Exported` → `Posted to LFX` move is automated: comment `/lfx-url <url>`
+on an exported issue (see [After the export](#after-the-export)) and the bot
+advances the card. Everything after `Posted to LFX` is **yours to move by
+hand**. As you work with the LFX platform team, drag each card through the
+remaining columns:
 
-`Posted to LFX` → `LFX Approved` → `Mentors added` → `Open for Applications`
+`LFX Approved` → `Mentors added` → `Open for Applications`
 → `Applications Closed`
 
 Automation never moves a card once it sits in one of these post-export
-columns, so your manual placement is safe. (The one exception: closing the
-issue still sends its card to `Closed`.)
+columns (other than the `/lfx-url` advance above), so your manual placement is
+safe. (The one exception: closing the issue still sends its card to `Closed`.)
 
 > **Note:** `Mentors Registered` is reserved as a future signal (not yet
 > implemented). A later validation step is intended to set it once mentors are

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -141,6 +141,10 @@ the existing branch if the previous PR wasn't merged).
    (`https://mentorship.lfx.linuxfoundation.org/project/<id>`); anything else is
    rejected, so the card only advances on a real program URL. A closed proposal
    is rejected too (reopen it first) — a withdrawn program should not be posted.
+   The term's export must already be **merged to `main`** (step 2): `/lfx-url`
+   fills the merged files, so a command run while the export PR is still open is
+   rejected with the exact command to re-run once you merge it. Nothing is
+   recorded on a rejection, so re-running after the merge is safe.
 5. **Continue tracking** by dragging cards through the remaining columns by
    hand as each step completes on the LFX platform (`LFX Approved` →
    `Mentors added` → `Open for Applications` → `Applications Closed`)

--- a/programs/lfx-mentorship/automation/lib/board.js
+++ b/programs/lfx-mentorship/automation/lib/board.js
@@ -33,6 +33,16 @@ function determineStatus(labels, action) {
   return 'Inbox';
 }
 
+// Resolve the approvals workflow's target board status, honoring the precedence
+// closed > /lfx-url force > label-derived status. A closed issue always maps to
+// "Closed" so the §4.3.5 board move never resurrects a closed card; otherwise a
+// successful /lfx-url advance forces "Posted to LFX".
+function resolveBoardStatus({ labels, closed, forcePosted }) {
+  if (closed) return 'Closed';
+  if (forcePosted) return 'Posted to LFX';
+  return determineStatus(labels, null);
+}
+
 // Sync guard (board-sync / validate / approvals): skip the board write when the
 // card already sits in an admin-owned column (unless the issue just closed), or
 // when the status read failed and we are about to set "Exported" (fail closed,
@@ -79,6 +89,7 @@ async function readStatusWithRetry(readFn, { attempts = 2, delayMs = 1000, sleep
 module.exports = {
   ADMIN_OWNED,
   determineStatus,
+  resolveBoardStatus,
   shouldSkipSync,
   shouldSkipExport,
   readStatusWithRetry,

--- a/programs/lfx-mentorship/automation/lib/board.js
+++ b/programs/lfx-mentorship/automation/lib/board.js
@@ -45,11 +45,12 @@ function resolveBoardStatus({ labels, closed, forcePosted }) {
 
 // Sync guard (board-sync / validate / approvals): skip the board write when the
 // card already sits in an admin-owned column (unless the issue just closed), or
-// when the status read failed and we are about to set "Exported" (fail closed,
-// so a transient read error never pulls a manually-placed card back).
+// when the status read failed and we are about to advance the card (set
+// "Exported" or the /lfx-url "Posted to LFX"), so a transient read error never
+// pulls a manually-placed card back.
 function shouldSkipSync(currentStatus, targetStatus, readFailed) {
   if (currentStatus && ADMIN_OWNED.has(currentStatus) && targetStatus !== 'Closed') return true;
-  if (readFailed && targetStatus === 'Exported') return true;
+  if (readFailed && (targetStatus === 'Exported' || targetStatus === 'Posted to LFX')) return true;
   return false;
 }
 

--- a/programs/lfx-mentorship/automation/lib/csv.js
+++ b/programs/lfx-mentorship/automation/lib/csv.js
@@ -62,7 +62,7 @@ function renderTrackingCsv(programs) {
     const mentors = prog.mentors || [];
     const row = [
       prog.program_name_full,
-      '',  // LFX URL — filled in after posting to LFX
+      prog.lfx_url || '',  // LFX URL — recorded post-export by /lfx-url (§4.3.5)
       prog.upstream_issue_url,
       '',  // spacer column
       mentors.length,

--- a/programs/lfx-mentorship/automation/lib/csv.js
+++ b/programs/lfx-mentorship/automation/lib/csv.js
@@ -41,4 +41,42 @@ function csvEscape(val) {
   return s;
 }
 
-module.exports = { parseCsvLine, csvEscape };
+// Render the export tracking CSV from the program records. Extracted verbatim
+// from lfx-export.yml so the same renderer backs both the export and the
+// /lfx-url command (§4.3.5). Rows keep the input program order (the README body
+// sorts; this does not). The LFX URL column is blank at export time and later
+// populated from the issue's recorded URL. Returns the full file content,
+// including the trailing newline.
+function renderTrackingCsv(programs) {
+  const csvHeaders = [
+    'PROJECT', 'LFX URL', 'Upstream issue', '',
+    'mentor count',
+    'Mentor 1', 'Mentor 1 GitHub', 'Mentor 1 email address', 'Mentor 1 LFID',
+    'Mentor 2', 'Mentor 2 GitHub', 'Mentor 2 email address', 'Mentor 2 LFID',
+    'Mentor 3', 'Mentor 3 GitHub', 'Mentor 3 email address', 'Mentor 3 LFID',
+    'Mentor 4', 'Mentor 4 GitHub', 'Mentor 4 email address', 'Mentor 4 LFID',
+  ];
+
+  const csvRows = [csvHeaders.map(csvEscape).join(',')];
+  for (const prog of programs) {
+    const mentors = prog.mentors || [];
+    const row = [
+      prog.program_name_full,
+      '',  // LFX URL — filled in after posting to LFX
+      prog.upstream_issue_url,
+      '',  // spacer column
+      mentors.length,
+    ];
+    for (let i = 0; i < 4; i++) {
+      const m = mentors[i];
+      row.push(m ? m.name : '');
+      row.push(m ? m.github_handle : '');
+      row.push(m ? m.email : '');
+      row.push(m ? m.lfid : '');
+    }
+    csvRows.push(row.map(csvEscape).join(','));
+  }
+  return csvRows.join('\n') + '\n';
+}
+
+module.exports = { parseCsvLine, csvEscape, renderTrackingCsv };

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -76,4 +76,18 @@ function lfxUrlDecision({ commenter, admins, currentLabels, arg, closed }) {
   return { ok: true, url };
 }
 
-module.exports = { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, LFX_PROGRAM_URL_RE };
+// Locate a program in a term's parsed export data by issue number, or null.
+// /lfx-url uses this to confirm the term's export has been merged to `main`
+// (and contains this program) BEFORE recording a URL — so a command issued
+// while the export PR is still open is rejected atomically (nothing recorded,
+// no board move) rather than half-applied. exportData is the parsed
+// lfx-export.json, or null/undefined when the file isn't on main yet.
+function findExportedProgram(exportData, issueNumber) {
+  if (!exportData || !Array.isArray(exportData.programs)) return null;
+  return exportData.programs.find(p => p.issue_number === issueNumber) || null;
+}
+
+module.exports = {
+  recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision,
+  findExportedProgram, LFX_PROGRAM_URL_RE,
+};

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -47,17 +47,24 @@ function parseRecordedLfxUrl(comments) {
 // (url is the trimmed argument, recorded verbatim) when the command may proceed,
 // otherwise { ok: false, reason } where reason is one of:
 //   'not-admin'    commenter is not a CNCF global approver
+//   'issue-closed' the proposal issue is closed (reopen it to record a URL)
 //   'not-exported' the issue has not been exported yet (no `Exported` label)
 //   'missing-url'  no URL argument was given
 //   'invalid-url'  the argument is not an LFX Mentorship program URL
 //
 // admins: lowercased global-approver handles (approvers.js getGlobalApprovers);
-// commenter is compared case-insensitively, matching /cncf-approve.
-function lfxUrlDecision({ commenter, admins, currentLabels, arg }) {
+// commenter is compared case-insensitively, matching /cncf-approve. closed is
+// the issue's closed state: a closed proposal is not being posted to LFX, so it
+// is rejected outright (no record, no file change, no board move) rather than
+// leaking its URL into the published term files.
+function lfxUrlDecision({ commenter, admins, currentLabels, arg, closed }) {
   const labels = currentLabels || [];
 
   if (!(admins || []).includes(String(commenter || '').toLowerCase())) {
     return { ok: false, reason: 'not-admin' };
+  }
+  if (closed) {
+    return { ok: false, reason: 'issue-closed' };
   }
   if (!labels.includes('Exported')) {
     return { ok: false, reason: 'not-exported' };

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -87,7 +87,17 @@ function findExportedProgram(exportData, issueNumber) {
   return exportData.programs.find(p => p.issue_number === issueNumber) || null;
 }
 
+// The term label used in /lfx-url PR metadata (title, commit subject, body).
+// Prefer the canonical _term the export recorded (from the admin's export-time
+// workflow_dispatch input) over the issue-body Term, which is editable and may
+// contain newlines; collapse whitespace to a single line so it can't break the
+// PR title or commit subject. Falls back to the issue term, then ''.
+function exportTermLabel(exportData, fallbackTerm) {
+  const raw = (exportData && exportData._term) || fallbackTerm || '';
+  return String(raw).replace(/\s+/g, ' ').trim();
+}
+
 module.exports = {
   recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision,
-  findExportedProgram, LFX_PROGRAM_URL_RE,
+  findExportedProgram, exportTermLabel, LFX_PROGRAM_URL_RE,
 };

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -11,6 +11,11 @@
 const BOT_LOGIN = 'github-actions[bot]';
 const RECORD_RE = /LFX URL recorded from @[A-Za-z0-9-]+:\s*(\S+)/g;
 
+// The LFX platform host. A recorded URL on a different host is allowed but
+// flagged (a likely paste mistake), not blocked — LFX could add a redirect or
+// change hosts.
+const LFX_HOST = 'mentorship.lfx.linuxfoundation.org';
+
 // The canonical recorded-URL comment body. A leading '@' on the user is
 // normalized away so the phrasing is stable.
 function recordedLfxUrlComment(user, url) {
@@ -34,4 +39,40 @@ function parseRecordedLfxUrl(comments) {
   return url;
 }
 
-module.exports = { recordedLfxUrlComment, parseRecordedLfxUrl };
+// Decision for the `/lfx-url <url>` command (§4.3.5). Returns { ok: true, url,
+// hostWarning } when the command may proceed (url is the trimmed argument,
+// recorded verbatim; hostWarning flags a non-LFX host), otherwise
+// { ok: false, reason } where reason is one of:
+//   'not-admin'    commenter is not a CNCF global approver
+//   'not-exported' the issue has not been exported yet (no `Exported` label)
+//   'missing-url'  no URL argument was given
+//   'invalid-url'  the argument is not a valid http(s) URL
+//
+// admins: lowercased global-approver handles (approvers.js getGlobalApprovers);
+// commenter is compared case-insensitively, matching /cncf-approve.
+function lfxUrlDecision({ commenter, admins, currentLabels, arg }) {
+  const labels = currentLabels || [];
+
+  if (!(admins || []).includes(String(commenter || '').toLowerCase())) {
+    return { ok: false, reason: 'not-admin' };
+  }
+  if (!labels.includes('Exported')) {
+    return { ok: false, reason: 'not-exported' };
+  }
+  const url = String(arg || '').trim();
+  if (!url) return { ok: false, reason: 'missing-url' };
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, reason: 'invalid-url' };
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'invalid-url' };
+  }
+
+  return { ok: true, url, hostWarning: parsed.hostname !== LFX_HOST };
+}
+
+module.exports = { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, LFX_HOST };

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// LFX program URL recording, shared by the /lfx-url command (§4.3.5, which
+// writes the record) and the export (§4.5, which reads it back). Keeping the
+// writer and reader together guarantees they agree on the phrasing.
+//
+// The record is a github-actions[bot] comment on the proposal issue, mirroring
+// the approval-record pattern in approvals.js. Only bot comments are trusted:
+// a user cannot spoof a URL by typing the phrase themselves.
+
+const BOT_LOGIN = 'github-actions[bot]';
+const RECORD_RE = /LFX URL recorded from @[A-Za-z0-9-]+:\s*(\S+)/g;
+
+// The canonical recorded-URL comment body. A leading '@' on the user is
+// normalized away so the phrasing is stable.
+function recordedLfxUrlComment(user, url) {
+  return `LFX URL recorded from @${String(user || '').replace(/^@/, '')}: ${url}`;
+}
+
+// Extract the most recently recorded LFX URL from an issue's comments, or ''
+// when none is present. Comments are assumed chronological (as returned by the
+// issues API); the last recorded URL wins, so re-running /lfx-url to correct a
+// URL supersedes the earlier value. Only github-actions[bot] comments count.
+function parseRecordedLfxUrl(comments) {
+  let url = '';
+  for (const c of comments || []) {
+    if (c.user && c.user.login !== BOT_LOGIN) continue;
+    if (!c.user) continue;
+    const body = c.body || '';
+    let m;
+    RECORD_RE.lastIndex = 0;
+    while ((m = RECORD_RE.exec(body)) !== null) url = m[1];
+  }
+  return url;
+}
+
+module.exports = { recordedLfxUrlComment, parseRecordedLfxUrl };

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -11,10 +11,14 @@
 const BOT_LOGIN = 'github-actions[bot]';
 const RECORD_RE = /LFX URL recorded from @[A-Za-z0-9-]+:\s*(\S+)/g;
 
-// The LFX platform host. A recorded URL on a different host is allowed but
-// flagged (a likely paste mistake), not blocked — LFX could add a redirect or
-// change hosts.
-const LFX_HOST = 'mentorship.lfx.linuxfoundation.org';
+// The exact shape of an LFX Mentorship program URL, e.g.
+// https://mentorship.lfx.linuxfoundation.org/project/005db8db-7efe-4433-9605-91d14174c72c
+// Confirmed against every URL recorded in previous terms: https only, the
+// mentorship host, a /project/ segment, then a UUID. Anything else (the bare
+// host, other lfx.linuxfoundation.org products, a mistyped id) is not a program
+// URL. If LFX ever changes this shape, update this one pattern.
+const LFX_PROGRAM_URL_RE =
+  /^https:\/\/mentorship\.lfx\.linuxfoundation\.org\/project\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
 // The canonical recorded-URL comment body. A leading '@' on the user is
 // normalized away so the phrasing is stable.
@@ -39,14 +43,13 @@ function parseRecordedLfxUrl(comments) {
   return url;
 }
 
-// Decision for the `/lfx-url <url>` command (§4.3.5). Returns { ok: true, url,
-// hostWarning } when the command may proceed (url is the trimmed argument,
-// recorded verbatim; hostWarning flags a non-LFX host), otherwise
-// { ok: false, reason } where reason is one of:
+// Decision for the `/lfx-url <url>` command (§4.3.5). Returns { ok: true, url }
+// (url is the trimmed argument, recorded verbatim) when the command may proceed,
+// otherwise { ok: false, reason } where reason is one of:
 //   'not-admin'    commenter is not a CNCF global approver
 //   'not-exported' the issue has not been exported yet (no `Exported` label)
 //   'missing-url'  no URL argument was given
-//   'invalid-url'  the argument is not a valid http(s) URL
+//   'invalid-url'  the argument is not an LFX Mentorship program URL
 //
 // admins: lowercased global-approver handles (approvers.js getGlobalApprovers);
 // commenter is compared case-insensitively, matching /cncf-approve.
@@ -61,18 +64,9 @@ function lfxUrlDecision({ commenter, admins, currentLabels, arg }) {
   }
   const url = String(arg || '').trim();
   if (!url) return { ok: false, reason: 'missing-url' };
+  if (!LFX_PROGRAM_URL_RE.test(url)) return { ok: false, reason: 'invalid-url' };
 
-  let parsed;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return { ok: false, reason: 'invalid-url' };
-  }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return { ok: false, reason: 'invalid-url' };
-  }
-
-  return { ok: true, url, hostWarning: parsed.hostname !== LFX_HOST };
+  return { ok: true, url };
 }
 
-module.exports = { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, LFX_HOST };
+module.exports = { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, LFX_PROGRAM_URL_RE };

--- a/programs/lfx-mentorship/automation/lib/readme.js
+++ b/programs/lfx-mentorship/automation/lib/readme.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { slugify } = require('./slug.js');
+
 // Term README assembly for the LFX export, extracted from lfx-export.yml.
 //
 // The export preserves the term frontmatter (title, timeline, project and
@@ -30,4 +32,66 @@ function buildReadme(existingReadme, bodyLines, readmeTitle) {
   return header + bodyLines.join('\n') + '\n';
 }
 
-module.exports = { buildReadme };
+// Render the auto-generated README body (Table of Contents + Accepted Projects)
+// from the export's program records. Extracted verbatim from lfx-export.yml so
+// the same renderer backs both the export and the /lfx-url command (§4.3.5).
+// Programs are grouped by CNCF project and the projects sorted
+// case-insensitively (the tracking CSV keeps input order; this body sorts).
+// Returns the array of markdown lines for buildReadme to append below the term
+// frontmatter.
+function renderAcceptedProgramsBody(programs) {
+  const byProject = {};
+  for (const prog of programs) {
+    const proj = prog.cncf_project;
+    if (!byProject[proj]) byProject[proj] = [];
+    byProject[proj].push(prog);
+  }
+  const sortedProjects = Object.keys(byProject).sort(
+    (a, b) => a.toLowerCase().localeCompare(b.toLowerCase())
+  );
+
+  const md = [];
+
+  // Table of contents
+  md.push('## Table of Contents');
+  md.push('');
+  for (const proj of sortedProjects) {
+    md.push(`- [${proj}](#${slugify(proj)})`);
+    for (const prog of byProject[proj]) {
+      md.push(`  - [${prog.program_name_short}](#${slugify(prog.program_name_short)})`);
+    }
+  }
+  md.push('');
+
+  // Accepted projects
+  md.push('## Accepted Projects');
+  md.push('');
+  for (const proj of sortedProjects) {
+    md.push(`### ${proj}`);
+    md.push('');
+    for (const prog of byProject[proj]) {
+      md.push(`#### ${prog.program_name_short}`);
+      md.push('');
+      md.push(prog.program_name_full);
+      md.push('');
+      md.push('- Description:');
+      md.push('');
+      for (const line of prog.description.split('\n')) {
+        md.push(`  > ${line}`);
+      }
+      md.push('');
+      md.push(`- Recommended Skills: ${prog.skills}`);
+      md.push(`- Technologies: ${prog.technologies}`);
+      md.push('- Mentor(s):');
+      for (const m of prog.mentors) {
+        md.push(`  - ${m.name} (@${m.github_handle}, ${m.email})`);
+      }
+      md.push(`- Upstream Issue: ${prog.upstream_issue_url}`);
+      md.push(`- LFX URL: TBD`);
+      md.push('');
+    }
+  }
+  return md;
+}
+
+module.exports = { buildReadme, renderAcceptedProgramsBody };

--- a/programs/lfx-mentorship/automation/lib/readme.js
+++ b/programs/lfx-mentorship/automation/lib/readme.js
@@ -40,7 +40,9 @@ function buildReadme(existingReadme, bodyLines, readmeTitle) {
 // Returns the array of markdown lines for buildReadme to append below the term
 // frontmatter.
 function renderAcceptedProgramsBody(programs) {
-  const byProject = {};
+  // cncf_project is untrusted issue-form input used as a grouping key; a
+  // prototype-less object keeps a name like __proto__ from polluting Object.
+  const byProject = Object.create(null);
   for (const prog of programs) {
     const proj = prog.cncf_project;
     if (!byProject[proj]) byProject[proj] = [];

--- a/programs/lfx-mentorship/automation/lib/readme.js
+++ b/programs/lfx-mentorship/automation/lib/readme.js
@@ -87,7 +87,7 @@ function renderAcceptedProgramsBody(programs) {
         md.push(`  - ${m.name} (@${m.github_handle}, ${m.email})`);
       }
       md.push(`- Upstream Issue: ${prog.upstream_issue_url}`);
-      md.push(`- LFX URL: TBD`);
+      md.push(`- LFX URL: ${prog.lfx_url || 'TBD'}`);
       md.push('');
     }
   }

--- a/programs/lfx-mentorship/automation/lib/term-paths.js
+++ b/programs/lfx-mentorship/automation/lib/term-paths.js
@@ -14,9 +14,13 @@ function termPaths(term) {
 
   const year = yearMatch ? yearMatch[1] : 'unknown';
   const termNum = termNumMatch ? termNumMatch[1].padStart(2, '0') : '00';
-  const months = monthsMatch
+  const monthsRaw = monthsMatch
     ? monthsMatch[1].replace(/[\u2013\u2014]/g, '-')
     : 'unknown';
+  // months feeds outDir, and the Term field is untrusted issue-form input, so
+  // reject anything outside letters/hyphen (e.g. "../", ".", "/") to keep the
+  // path inside programs/lfx-mentorship/<year>/ rather than traversing out.
+  const months = /^[A-Za-z]+(-[A-Za-z]+)*$/.test(monthsRaw) ? monthsRaw : 'unknown';
   const termDir = `${termNum}-${months}`;
   const outDir = `programs/lfx-mentorship/${year}/${termDir}`;
 

--- a/programs/lfx-mentorship/automation/lib/term-paths.js
+++ b/programs/lfx-mentorship/automation/lib/term-paths.js
@@ -15,7 +15,7 @@ function termPaths(term) {
   const year = yearMatch ? yearMatch[1] : 'unknown';
   const termNum = termNumMatch ? termNumMatch[1].padStart(2, '0') : '00';
   const monthsRaw = monthsMatch
-    ? monthsMatch[1].replace(/[\u2013\u2014]/g, '-')
+    ? monthsMatch[1].replace(/[\u2013\u2014]/g, '-').trim()
     : 'unknown';
   // months feeds outDir, and the Term field is untrusted issue-form input, so
   // reject anything outside letters/hyphen (e.g. "../", ".", "/") to keep the

--- a/programs/lfx-mentorship/automation/lib/term-paths.js
+++ b/programs/lfx-mentorship/automation/lib/term-paths.js
@@ -1,10 +1,11 @@
 'use strict';
 
-// Derive the per-term output directory (and its components) from an LFX term
-// string like "2026 Term 3 (Sep-Nov)". Extracted from lfx-export.yml so the
-// export and the /lfx-url command (§4.3.5) resolve the same paths. En/em dashes
-// in the month range are normalized to a hyphen; a malformed term falls back to
-// safe placeholders rather than throwing.
+// Derive the per-term output directory (and its components) plus the README
+// display title from an LFX term string like "2026 Term 3 (Sep-Nov)". Extracted
+// from lfx-export.yml so the export and the /lfx-url command (§4.3.5) resolve
+// the same paths and synthesize an identical README header. En/em dashes in the
+// month range are normalized to a hyphen; a malformed term falls back to safe
+// placeholders rather than throwing.
 function termPaths(term) {
   const s = String(term || '');
   const yearMatch = s.match(/^(\d{4})/);
@@ -19,7 +20,17 @@ function termPaths(term) {
   const termDir = `${termNum}-${months}`;
   const outDir = `programs/lfx-mentorship/${year}/${termDir}`;
 
-  return { year, termNum, months, termDir, outDir };
+  // Human-readable README H1, e.g. "Term 03 - 2026 September - November". Only
+  // used when a term README has no frontmatter to preserve (buildReadme ignores
+  // it otherwise), so the export and /lfx-url never synthesize a broken "# ".
+  const monthMap = {
+    'Mar': 'March', 'May': 'May', 'Jun': 'June',
+    'Aug': 'August', 'Sep': 'September', 'Nov': 'November',
+  };
+  const monthParts = months.split('-').map(m => monthMap[m.trim()] || m.trim());
+  const readmeTitle = `Term ${termNum} - ${year} ${monthParts.join(' - ')}`;
+
+  return { year, termNum, months, termDir, outDir, readmeTitle };
 }
 
 module.exports = { termPaths };

--- a/programs/lfx-mentorship/automation/lib/term-paths.js
+++ b/programs/lfx-mentorship/automation/lib/term-paths.js
@@ -1,0 +1,25 @@
+'use strict';
+
+// Derive the per-term output directory (and its components) from an LFX term
+// string like "2026 Term 3 (Sep-Nov)". Extracted from lfx-export.yml so the
+// export and the /lfx-url command (§4.3.5) resolve the same paths. En/em dashes
+// in the month range are normalized to a hyphen; a malformed term falls back to
+// safe placeholders rather than throwing.
+function termPaths(term) {
+  const s = String(term || '');
+  const yearMatch = s.match(/^(\d{4})/);
+  const termNumMatch = s.match(/Term\s+(\d)/);
+  const monthsMatch = s.match(/\(([^)]+)\)/);
+
+  const year = yearMatch ? yearMatch[1] : 'unknown';
+  const termNum = termNumMatch ? termNumMatch[1].padStart(2, '0') : '00';
+  const months = monthsMatch
+    ? monthsMatch[1].replace(/[\u2013\u2014]/g, '-')
+    : 'unknown';
+  const termDir = `${termNum}-${months}`;
+  const outDir = `programs/lfx-mentorship/${year}/${termDir}`;
+
+  return { year, termNum, months, termDir, outDir };
+}
+
+module.exports = { termPaths };

--- a/programs/lfx-mentorship/automation/test/board.test.js
+++ b/programs/lfx-mentorship/automation/test/board.test.js
@@ -3,7 +3,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const {
-  determineStatus, shouldSkipSync, shouldSkipExport, readStatusWithRetry,
+  determineStatus, resolveBoardStatus, shouldSkipSync, shouldSkipExport, readStatusWithRetry,
 } = require('../lib/board');
 
 test('determineStatus: empty labels map to Inbox', () => {
@@ -29,6 +29,31 @@ test('determineStatus: the label cascade stops at Exported', () => {
 test('determineStatus: admin-only and flag labels do not drive the cascade', () => {
   assert.equal(determineStatus(['Posted to LFX', 'Exported', 'CNCF Approved']), 'Exported');
   assert.equal(determineStatus(['Mentors Registered', 'Exported']), 'Exported');
+});
+
+test('resolveBoardStatus: a /lfx-url force advances an open card to Posted to LFX', () => {
+  assert.equal(
+    resolveBoardStatus({ labels: ['Exported'], closed: false, forcePosted: true }),
+    'Posted to LFX',
+  );
+});
+
+test('resolveBoardStatus: a closed issue stays Closed even under a /lfx-url force', () => {
+  assert.equal(
+    resolveBoardStatus({ labels: ['Exported'], closed: true, forcePosted: true }),
+    'Closed',
+  );
+});
+
+test('resolveBoardStatus: without a force it falls back to the label cascade', () => {
+  assert.equal(
+    resolveBoardStatus({ labels: ['Exported'], closed: false, forcePosted: false }),
+    'Exported',
+  );
+  assert.equal(
+    resolveBoardStatus({ labels: [], closed: false, forcePosted: false }),
+    'Inbox',
+  );
 });
 
 test('shouldSkipSync: protects admin-owned columns except on close', () => {

--- a/programs/lfx-mentorship/automation/test/board.test.js
+++ b/programs/lfx-mentorship/automation/test/board.test.js
@@ -68,12 +68,23 @@ test('shouldSkipSync: non-admin statuses proceed when the read succeeded', () =>
   assert.equal(shouldSkipSync(null, 'Exported', false), false);
 });
 
-test('shouldSkipSync: fails closed only when about to set Exported after a read failure', () => {
+test('shouldSkipSync: fails closed when about to advance (Exported/Posted to LFX) after a read failure', () => {
   assert.equal(shouldSkipSync(null, 'Exported', true), true);
+  assert.equal(shouldSkipSync(null, 'Posted to LFX', true), true);
   assert.equal(shouldSkipSync(null, 'Awaiting approvals/confirmations', true), false);
   assert.equal(shouldSkipSync(null, 'CNCF Approved', true), false);
   assert.equal(shouldSkipSync(null, 'Closed', true), false);
   assert.equal(shouldSkipSync('Posted to LFX', 'Exported', true), true);
+});
+
+test('shouldSkipSync: a /lfx-url advance to Posted to LFX still honors the guard', () => {
+  // Exported → Posted to LFX proceeds (Exported is not admin-owned)...
+  assert.equal(shouldSkipSync('Exported', 'Posted to LFX', false), false);
+  // ...but a card an admin already moved forward is left alone (no regress).
+  assert.equal(shouldSkipSync('LFX Approved', 'Posted to LFX', false), true);
+  assert.equal(shouldSkipSync('Mentors added', 'Posted to LFX', false), true);
+  // Re-running while already Posted to LFX is a no-op skip.
+  assert.equal(shouldSkipSync('Posted to LFX', 'Posted to LFX', false), true);
 });
 
 test('shouldSkipExport: skips admin-owned cards or any read failure', () => {

--- a/programs/lfx-mentorship/automation/test/csv.test.js
+++ b/programs/lfx-mentorship/automation/test/csv.test.js
@@ -106,3 +106,9 @@ test('renderTrackingCsv: header, input order, blank LFX URL, 4 mentor slots', ()
   assert.deepEqual(r2.slice(5, 9), ['Al Pha', 'alpha', 'al@example.com', 'alpha']);
   assert.deepEqual(r2.slice(9, 21), ['', '', '', '', '', '', '', '', '', '', '', '']);
 });
+
+test('renderTrackingCsv: a recorded lfx_url fills the LFX URL column', () => {
+  const withUrl = [{ ...CSV_PROGRAMS[0], lfx_url: 'https://mentorship.lfx.linuxfoundation.org/p/1' }];
+  const r1 = parseCsvLine(renderTrackingCsv(withUrl).split('\n')[1]);
+  assert.equal(r1[1], 'https://mentorship.lfx.linuxfoundation.org/p/1');
+});

--- a/programs/lfx-mentorship/automation/test/csv.test.js
+++ b/programs/lfx-mentorship/automation/test/csv.test.js
@@ -108,7 +108,8 @@ test('renderTrackingCsv: header, input order, blank LFX URL, 4 mentor slots', ()
 });
 
 test('renderTrackingCsv: a recorded lfx_url fills the LFX URL column', () => {
-  const withUrl = [{ ...CSV_PROGRAMS[0], lfx_url: 'https://mentorship.lfx.linuxfoundation.org/p/1' }];
+  const url = 'https://mentorship.lfx.linuxfoundation.org/project/005db8db-7efe-4433-9605-91d14174c72c';
+  const withUrl = [{ ...CSV_PROGRAMS[0], lfx_url: url }];
   const r1 = parseCsvLine(renderTrackingCsv(withUrl).split('\n')[1]);
-  assert.equal(r1[1], 'https://mentorship.lfx.linuxfoundation.org/p/1');
+  assert.equal(r1[1], url);
 });

--- a/programs/lfx-mentorship/automation/test/csv.test.js
+++ b/programs/lfx-mentorship/automation/test/csv.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { parseCsvLine, csvEscape } = require('../lib/csv');
+const { parseCsvLine, csvEscape, renderTrackingCsv } = require('../lib/csv');
 
 // Columns: Maturity, Project, Name, Company, GitHub, OWNERS (handle = cols[4]).
 
@@ -47,4 +47,62 @@ test('csvEscape: coerces null/undefined to empty and numbers to strings', () => 
   assert.equal(csvEscape(undefined), '');
   assert.equal(csvEscape(5), '5');
   assert.equal(csvEscape(0), '0');
+});
+
+// ── renderTrackingCsv: the export tracking sheet ──
+// Characterizes the CSV assembly extracted from lfx-export.yml. Rows keep the
+// input program order (unlike the README body, which sorts). LFX URL column is
+// blank at export time (populated later by /lfx-url, §4.3.5).
+
+const CSV_PROGRAMS = [
+  {
+    program_name_full: 'CNCF - Backstage: Alpha Program (2026 Term 3)',
+    upstream_issue_url: 'https://github.com/cncf/mentoring/issues/1883',
+    mentors: [
+      { name: 'Jane Doe', github_handle: 'janedoe', email: 'jane@example.com', lfid: 'janedoe' },
+      { name: 'Sam Lee', github_handle: 'samlee', email: 'sam@example.com', lfid: 'samlee' },
+    ],
+  },
+  {
+    program_name_full: 'CNCF - Argo: Beta Program (2026 Term 3)',
+    upstream_issue_url: 'https://github.com/argoproj/argo/issues/1',
+    mentors: [
+      { name: 'Al Pha', github_handle: 'alpha', email: 'al@example.com', lfid: 'alpha' },
+    ],
+  },
+];
+
+const CSV_HEADER = 'PROJECT,LFX URL,Upstream issue,,mentor count,'
+  + 'Mentor 1,Mentor 1 GitHub,Mentor 1 email address,Mentor 1 LFID,'
+  + 'Mentor 2,Mentor 2 GitHub,Mentor 2 email address,Mentor 2 LFID,'
+  + 'Mentor 3,Mentor 3 GitHub,Mentor 3 email address,Mentor 3 LFID,'
+  + 'Mentor 4,Mentor 4 GitHub,Mentor 4 email address,Mentor 4 LFID';
+
+test('renderTrackingCsv: header, input order, blank LFX URL, 4 mentor slots', () => {
+  const out = renderTrackingCsv(CSV_PROGRAMS);
+  const lines = out.split('\n');
+  assert.equal(out.endsWith('\n'), true);
+  assert.equal(lines[lines.length - 1], '');            // trailing newline
+  const rows = lines.slice(0, -1);
+  assert.equal(rows.length, 3);                          // header + 2 programs
+  assert.equal(rows[0], CSV_HEADER);
+
+  // Row 1 = first input program (Backstage), 2 mentors, blank LFX URL.
+  const r1 = parseCsvLine(rows[1]);
+  assert.equal(r1.length, 21);
+  assert.equal(r1[0], 'CNCF - Backstage: Alpha Program (2026 Term 3)');
+  assert.equal(r1[1], '');                               // LFX URL blank
+  assert.equal(r1[2], 'https://github.com/cncf/mentoring/issues/1883');
+  assert.equal(r1[3], '');                               // spacer
+  assert.equal(r1[4], '2');                              // mentor count
+  assert.deepEqual(r1.slice(5, 9), ['Jane Doe', 'janedoe', 'jane@example.com', 'janedoe']);
+  assert.deepEqual(r1.slice(9, 13), ['Sam Lee', 'samlee', 'sam@example.com', 'samlee']);
+  assert.deepEqual(r1.slice(13, 21), ['', '', '', '', '', '', '', '']); // mentors 3 & 4 empty
+
+  // Row 2 = second input program (Argo), 1 mentor.
+  const r2 = parseCsvLine(rows[2]);
+  assert.equal(r2[0], 'CNCF - Argo: Beta Program (2026 Term 3)');
+  assert.equal(r2[4], '1');
+  assert.deepEqual(r2.slice(5, 9), ['Al Pha', 'alpha', 'al@example.com', 'alpha']);
+  assert.deepEqual(r2.slice(9, 21), ['', '', '', '', '', '', '', '', '', '', '', '']);
 });

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { recordedLfxUrlComment, parseRecordedLfxUrl } = require('../lib/lfx-url');
+const { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision } = require('../lib/lfx-url');
 
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
 const user = (login, body) => ({ user: { login }, body });
@@ -48,4 +48,66 @@ test('parseRecordedLfxUrl: empty / none → empty string', () => {
   assert.equal(parseRecordedLfxUrl([]), '');
   assert.equal(parseRecordedLfxUrl(null), '');
   assert.equal(parseRecordedLfxUrl([bot('no url here')]), '');
+});
+
+// ── lfxUrlDecision: the /lfx-url gate (§4.3.5) ──
+// Same admin allowlist as /cncf-approve; requires the Exported label; validates
+// the URL and flags a non-LFX host as a warning (not a block).
+const admins = ['natedoubleu', 'dkrook'];
+const LFX = 'https://mentorship.lfx.linuxfoundation.org/program/abc';
+
+test('lfxUrlDecision: non-admin is rejected', () => {
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'randomuser', admins, currentLabels: ['Exported'], arg: LFX }),
+    { ok: false, reason: 'not-admin' });
+});
+
+test('lfxUrlDecision: admin match is case-insensitive', () => {
+  const d = lfxUrlDecision({ commenter: 'NateDoubleU', admins, currentLabels: ['Exported'], arg: LFX });
+  assert.equal(d.ok, true);
+});
+
+test('lfxUrlDecision: requires the Exported label', () => {
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['CNCF Approved'], arg: LFX }),
+    { ok: false, reason: 'not-exported' });
+});
+
+test('lfxUrlDecision: missing URL argument', () => {
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: '' }),
+    { ok: false, reason: 'missing-url' });
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: '   ' }),
+    { ok: false, reason: 'missing-url' });
+});
+
+test('lfxUrlDecision: a non-URL argument is rejected', () => {
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: 'not a url' }),
+    { ok: false, reason: 'invalid-url' });
+});
+
+test('lfxUrlDecision: a non-http(s) scheme is rejected', () => {
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: 'javascript:alert(1)' }),
+    { ok: false, reason: 'invalid-url' });
+});
+
+test('lfxUrlDecision: a valid LFX URL passes with no host warning', () => {
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: LFX }),
+    { ok: true, url: LFX, hostWarning: false });
+});
+
+test('lfxUrlDecision: a valid non-LFX URL passes but warns on the host', () => {
+  const other = 'https://example.com/whatever';
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: other }),
+    { ok: true, url: other, hostWarning: true });
+});
+
+test('lfxUrlDecision: trims surrounding whitespace and records the URL as given', () => {
+  const d = lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: `  ${LFX}  ` });
+  assert.deepEqual(d, { ok: true, url: LFX, hostWarning: false });
 });

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -77,6 +77,24 @@ test('lfxUrlDecision: requires the Exported label', () => {
     { ok: false, reason: 'not-exported' });
 });
 
+test('lfxUrlDecision: a closed issue is rejected (reopen first)', () => {
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: LFX, closed: true }),
+    { ok: false, reason: 'issue-closed' });
+});
+
+test('lfxUrlDecision: auth is checked before the closed state', () => {
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'randomuser', admins, currentLabels: ['Exported'], arg: LFX, closed: true }),
+    { ok: false, reason: 'not-admin' });
+});
+
+test('lfxUrlDecision: closed is reported before not-exported', () => {
+  assert.deepEqual(
+    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: [], arg: LFX, closed: true }),
+    { ok: false, reason: 'issue-closed' });
+});
+
 test('lfxUrlDecision: missing URL argument', () => {
   assert.deepEqual(
     lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: '' }),

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -7,36 +7,38 @@ const { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision } = require('
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
 const user = (login, body) => ({ user: { login }, body });
 
+// Realistic LFX Mentorship program URLs — the exact shape /lfx-url enforces.
+const LFX = 'https://mentorship.lfx.linuxfoundation.org/project/005db8db-7efe-4433-9605-91d14174c72c';
+const LFX2 = 'https://mentorship.lfx.linuxfoundation.org/project/0071e2ff-f538-4817-978b-07b267cfcd6a';
+
 test('recordedLfxUrlComment: canonical phrasing the parser reads back', () => {
   assert.equal(
-    recordedLfxUrlComment('nate-double-u', 'https://mentorship.lfx.linuxfoundation.org/program/abc'),
-    'LFX URL recorded from @nate-double-u: https://mentorship.lfx.linuxfoundation.org/program/abc'
+    recordedLfxUrlComment('nate-double-u', LFX),
+    `LFX URL recorded from @nate-double-u: ${LFX}`
   );
   // A leading @ on the user is normalized away.
   assert.equal(
-    recordedLfxUrlComment('@nate', 'https://x/y'),
-    'LFX URL recorded from @nate: https://x/y'
+    recordedLfxUrlComment('@nate', LFX2),
+    `LFX URL recorded from @nate: ${LFX2}`
   );
 });
 
 test('parseRecordedLfxUrl: round-trips a recorded comment', () => {
-  const url = 'https://mentorship.lfx.linuxfoundation.org/program/abc';
-  const comments = [bot(recordedLfxUrlComment('nate', url))];
-  assert.equal(parseRecordedLfxUrl(comments), url);
+  const comments = [bot(recordedLfxUrlComment('nate', LFX))];
+  assert.equal(parseRecordedLfxUrl(comments), LFX);
 });
 
 test('parseRecordedLfxUrl: matches even with a leading emoji/prefix', () => {
-  const url = 'https://mentorship.lfx.linuxfoundation.org/p/1';
-  assert.equal(parseRecordedLfxUrl([bot('✅ ' + recordedLfxUrlComment('nate', url))]), url);
+  assert.equal(parseRecordedLfxUrl([bot('✅ ' + recordedLfxUrlComment('nate', LFX))]), LFX);
 });
 
 test('parseRecordedLfxUrl: latest recorded URL wins (a correction supersedes)', () => {
   const comments = [
-    bot(recordedLfxUrlComment('nate', 'https://mentorship.lfx.linuxfoundation.org/old')),
+    bot(recordedLfxUrlComment('nate', LFX)),
     user('someone', 'chatter'),
-    bot(recordedLfxUrlComment('nate', 'https://mentorship.lfx.linuxfoundation.org/new')),
+    bot(recordedLfxUrlComment('nate', LFX2)),
   ];
-  assert.equal(parseRecordedLfxUrl(comments), 'https://mentorship.lfx.linuxfoundation.org/new');
+  assert.equal(parseRecordedLfxUrl(comments), LFX2);
 });
 
 test('parseRecordedLfxUrl: ignores non-bot comments (anti-spoof)', () => {
@@ -57,7 +59,6 @@ test('parseRecordedLfxUrl: empty / none → empty string', () => {
 // other lfx.linuxfoundation.org products, the bare host, a bad id — is rejected,
 // so the board only advances on a real program URL.
 const admins = ['natedoubleu', 'dkrook'];
-const LFX = 'https://mentorship.lfx.linuxfoundation.org/project/005db8db-7efe-4433-9605-91d14174c72c';
 
 test('lfxUrlDecision: non-admin is rejected', () => {
   assert.deepEqual(

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, findExportedProgram } = require('../lib/lfx-url');
+const { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, findExportedProgram, exportTermLabel } = require('../lib/lfx-url');
 
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
 const user = (login, body) => ({ user: { login }, body });
@@ -161,4 +161,27 @@ test('findExportedProgram: null when the export data is missing or malformed', (
   assert.equal(findExportedProgram(undefined, 115), null);
   assert.equal(findExportedProgram({}, 115), null);
   assert.equal(findExportedProgram({ programs: 'nope' }, 115), null);
+});
+
+// ── exportTermLabel: the term string used in /lfx-url PR metadata ──
+test('exportTermLabel: prefers the canonical _term from the merged export', () => {
+  assert.equal(
+    exportTermLabel({ _term: '2026 Term 3 (Sep-Nov)' }, '2026 Term 3 (Sep-Nov)\ninjected'),
+    '2026 Term 3 (Sep-Nov)');
+});
+
+test('exportTermLabel: falls back to the issue term when _term is absent', () => {
+  assert.equal(exportTermLabel({}, '2026 Term 3 (Sep-Nov)'), '2026 Term 3 (Sep-Nov)');
+  assert.equal(exportTermLabel(null, '2026 Term 3 (Sep-Nov)'), '2026 Term 3 (Sep-Nov)');
+});
+
+test('exportTermLabel: collapses whitespace/newlines to a single line', () => {
+  // Guards the peter-evans PR title / commit subject against a multi-line term.
+  assert.equal(exportTermLabel({ _term: '  2026   Term 3\n\n(Sep-Nov)  ' }, ''), '2026 Term 3 (Sep-Nov)');
+  assert.equal(exportTermLabel(null, 'line1\r\nline2'), 'line1 line2');
+});
+
+test('exportTermLabel: empty when neither source has a term', () => {
+  assert.equal(exportTermLabel(null, ''), '');
+  assert.equal(exportTermLabel({}, undefined), '');
 });

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision } = require('../lib/lfx-url');
+const { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, findExportedProgram } = require('../lib/lfx-url');
 
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
 const user = (login, body) => ({ user: { login }, body });
@@ -142,4 +142,23 @@ test('lfxUrlDecision: anything that is not an exact LFX program URL is rejected'
       lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg }),
       { ok: false, reason: 'invalid-url' }, arg);
   }
+});
+
+// ── findExportedProgram: the "export merged to main" guard (§4.3.5, option C) ──
+test('findExportedProgram: returns the matching program by issue number', () => {
+  const data = { programs: [{ issue_number: 114, cncf_project: 'A' }, { issue_number: 115, cncf_project: 'B' }] };
+  assert.equal(findExportedProgram(data, 115).cncf_project, 'B');
+});
+
+test('findExportedProgram: null when the program is not in the export', () => {
+  const data = { programs: [{ issue_number: 114 }] };
+  assert.equal(findExportedProgram(data, 115), null);
+});
+
+test('findExportedProgram: null when the export data is missing or malformed', () => {
+  // Models lfx-export.json not being on main yet (export PR unmerged).
+  assert.equal(findExportedProgram(null, 115), null);
+  assert.equal(findExportedProgram(undefined, 115), null);
+  assert.equal(findExportedProgram({}, 115), null);
+  assert.equal(findExportedProgram({ programs: 'nope' }, 115), null);
 });

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { recordedLfxUrlComment, parseRecordedLfxUrl } = require('../lib/lfx-url');
+
+const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
+const user = (login, body) => ({ user: { login }, body });
+
+test('recordedLfxUrlComment: canonical phrasing the parser reads back', () => {
+  assert.equal(
+    recordedLfxUrlComment('nate-double-u', 'https://mentorship.lfx.linuxfoundation.org/program/abc'),
+    'LFX URL recorded from @nate-double-u: https://mentorship.lfx.linuxfoundation.org/program/abc'
+  );
+  // A leading @ on the user is normalized away.
+  assert.equal(
+    recordedLfxUrlComment('@nate', 'https://x/y'),
+    'LFX URL recorded from @nate: https://x/y'
+  );
+});
+
+test('parseRecordedLfxUrl: round-trips a recorded comment', () => {
+  const url = 'https://mentorship.lfx.linuxfoundation.org/program/abc';
+  const comments = [bot(recordedLfxUrlComment('nate', url))];
+  assert.equal(parseRecordedLfxUrl(comments), url);
+});
+
+test('parseRecordedLfxUrl: matches even with a leading emoji/prefix', () => {
+  const url = 'https://mentorship.lfx.linuxfoundation.org/p/1';
+  assert.equal(parseRecordedLfxUrl([bot('✅ ' + recordedLfxUrlComment('nate', url))]), url);
+});
+
+test('parseRecordedLfxUrl: latest recorded URL wins (a correction supersedes)', () => {
+  const comments = [
+    bot(recordedLfxUrlComment('nate', 'https://mentorship.lfx.linuxfoundation.org/old')),
+    user('someone', 'chatter'),
+    bot(recordedLfxUrlComment('nate', 'https://mentorship.lfx.linuxfoundation.org/new')),
+  ];
+  assert.equal(parseRecordedLfxUrl(comments), 'https://mentorship.lfx.linuxfoundation.org/new');
+});
+
+test('parseRecordedLfxUrl: ignores non-bot comments (anti-spoof)', () => {
+  const spoof = user('imposter', recordedLfxUrlComment('imposter', 'https://evil.example/x'));
+  assert.equal(parseRecordedLfxUrl([spoof]), '');
+});
+
+test('parseRecordedLfxUrl: empty / none → empty string', () => {
+  assert.equal(parseRecordedLfxUrl([]), '');
+  assert.equal(parseRecordedLfxUrl(null), '');
+  assert.equal(parseRecordedLfxUrl([bot('no url here')]), '');
+});

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -51,10 +51,13 @@ test('parseRecordedLfxUrl: empty / none → empty string', () => {
 });
 
 // ── lfxUrlDecision: the /lfx-url gate (§4.3.5) ──
-// Same admin allowlist as /cncf-approve; requires the Exported label; validates
-// the URL and flags a non-LFX host as a warning (not a block).
+// Same admin allowlist as /cncf-approve; requires the Exported label; and the
+// argument must be an exact LFX Mentorship program URL
+// (https://mentorship.lfx.linuxfoundation.org/project/<uuid>). Anything else —
+// other lfx.linuxfoundation.org products, the bare host, a bad id — is rejected,
+// so the board only advances on a real program URL.
 const admins = ['natedoubleu', 'dkrook'];
-const LFX = 'https://mentorship.lfx.linuxfoundation.org/program/abc';
+const LFX = 'https://mentorship.lfx.linuxfoundation.org/project/005db8db-7efe-4433-9605-91d14174c72c';
 
 test('lfxUrlDecision: non-admin is rejected', () => {
   assert.deepEqual(
@@ -82,32 +85,42 @@ test('lfxUrlDecision: missing URL argument', () => {
     { ok: false, reason: 'missing-url' });
 });
 
-test('lfxUrlDecision: a non-URL argument is rejected', () => {
-  assert.deepEqual(
-    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: 'not a url' }),
-    { ok: false, reason: 'invalid-url' });
-});
-
-test('lfxUrlDecision: a non-http(s) scheme is rejected', () => {
-  assert.deepEqual(
-    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: 'javascript:alert(1)' }),
-    { ok: false, reason: 'invalid-url' });
-});
-
-test('lfxUrlDecision: a valid LFX URL passes with no host warning', () => {
+test('lfxUrlDecision: a valid LFX program URL passes', () => {
   assert.deepEqual(
     lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: LFX }),
-    { ok: true, url: LFX, hostWarning: false });
+    { ok: true, url: LFX });
 });
 
-test('lfxUrlDecision: a valid non-LFX URL passes but warns on the host', () => {
-  const other = 'https://example.com/whatever';
+test('lfxUrlDecision: an uppercase-hex UUID still passes', () => {
+  const upper = 'https://mentorship.lfx.linuxfoundation.org/project/005DB8DB-7EFE-4433-9605-91D14174C72C';
   assert.deepEqual(
-    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: other }),
-    { ok: true, url: other, hostWarning: true });
+    lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: upper }),
+    { ok: true, url: upper });
 });
 
 test('lfxUrlDecision: trims surrounding whitespace and records the URL as given', () => {
   const d = lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg: `  ${LFX}  ` });
-  assert.deepEqual(d, { ok: true, url: LFX, hostWarning: false });
+  assert.deepEqual(d, { ok: true, url: LFX });
+});
+
+test('lfxUrlDecision: anything that is not an exact LFX program URL is rejected', () => {
+  const bad = [
+    'not a url',
+    'javascript:alert(1)',
+    'http://mentorship.lfx.linuxfoundation.org/project/005db8db-7efe-4433-9605-91d14174c72c', // http, not https
+    'https://mentorship.lfx.linuxfoundation.org',                                              // bare host, no program
+    'https://mentorship.lfx.linuxfoundation.org/project/not-a-uuid',                           // malformed id
+    'https://mentorship.lfx.linuxfoundation.org/program/005db8db-7efe-4433-9605-91d14174c72c', // wrong path segment
+    'https://crowdfunding.lfx.linuxfoundation.org/projects/005db8db-7efe-4433-9605-91d14174c72c', // different LFX product
+    'https://example.com/whatever',
+    `${LFX}/`,       // trailing slash
+    `${LFX}?x=1`,    // query string
+    `${LFX}#frag`,   // fragment
+    `${LFX}extra`,   // trailing junk
+  ];
+  for (const arg of bad) {
+    assert.deepEqual(
+      lfxUrlDecision({ commenter: 'natedoubleu', admins, currentLabels: ['Exported'], arg }),
+      { ok: false, reason: 'invalid-url' }, arg);
+  }
 });

--- a/programs/lfx-mentorship/automation/test/readme.test.js
+++ b/programs/lfx-mentorship/automation/test/readme.test.js
@@ -175,3 +175,22 @@ test('renderAcceptedProgramsBody: a recorded lfx_url replaces the TBD placeholde
 test('renderAcceptedProgramsBody: no lfx_url still renders TBD', () => {
   assert.match(renderAcceptedProgramsBody(RENDER_PROGRAMS).join('\n'), /- LFX URL: TBD/);
 });
+
+test('renderAcceptedProgramsBody: a __proto__ project name neither pollutes nor crashes', () => {
+  // cncf_project is untrusted issue-form input used as a grouping key; a
+  // prototype-polluting name like __proto__ must not throw or mutate Object.
+  const evil = [{
+    cncf_project: '__proto__',
+    program_name_short: 'Evil Program',
+    program_name_full: 'CNCF - __proto__: Evil Program (2026 Term 3)',
+    description: 'desc',
+    skills: 'Go',
+    technologies: 'Go',
+    mentors: [{ name: 'A B', github_handle: 'ab', email: 'a@example.com', lfid: 'ab' }],
+    upstream_issue_url: 'https://github.com/cncf/mentoring/issues/1',
+  }];
+  let body;
+  assert.doesNotThrow(() => { body = renderAcceptedProgramsBody(evil).join('\n'); });
+  assert.match(body, /### __proto__/);
+  assert.equal({}.polluted, undefined);
+});

--- a/programs/lfx-mentorship/automation/test/readme.test.js
+++ b/programs/lfx-mentorship/automation/test/readme.test.js
@@ -2,8 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { buildReadme } = require('../lib/readme');
-
+const { buildReadme, renderAcceptedProgramsBody } = require('../lib/readme');
 const TITLE = 'Term 03 - 2026 September - November';
 
 const stub = `# Term 03 - 2026 September - November
@@ -72,4 +71,96 @@ test('buildReadme: no existing README falls back to a minimal header', () => {
   const out = buildReadme(null, body, TITLE);
   assert.ok(out.startsWith(`# ${TITLE}`));
   assert.match(out, /## Accepted Projects/);
+});
+
+// ── renderAcceptedProgramsBody: the TOC + Accepted Projects body ──
+// Characterizes the body assembly extracted from lfx-export.yml. Programs are
+// grouped by CNCF project and the projects sorted case-insensitively; the CSV
+// (see csv.test.js) keeps input order, but this body sorts.
+
+const RENDER_PROGRAMS = [
+  {
+    cncf_project: 'Backstage',
+    program_name_short: 'Alpha Program',
+    program_name_full: 'CNCF - Backstage: Alpha Program (2026 Term 3)',
+    description: 'Line one.\nLine two.',
+    skills: 'Go, Kubernetes',
+    technologies: 'Go, Kubernetes',
+    mentors: [
+      { name: 'Jane Doe', github_handle: 'janedoe', email: 'jane@example.com', lfid: 'janedoe' },
+      { name: 'Sam Lee', github_handle: 'samlee', email: 'sam@example.com', lfid: 'samlee' },
+    ],
+    upstream_issue_url: 'https://github.com/cncf/mentoring/issues/1883',
+  },
+  {
+    cncf_project: 'Argo',
+    program_name_short: 'Beta Program',
+    program_name_full: 'CNCF - Argo: Beta Program (2026 Term 3)',
+    description: 'Solo desc.',
+    skills: 'Rust',
+    technologies: 'Rust',
+    mentors: [
+      { name: 'Al Pha', github_handle: 'alpha', email: 'al@example.com', lfid: 'alpha' },
+    ],
+    upstream_issue_url: 'https://github.com/argoproj/argo/issues/1',
+  },
+];
+
+const EXPECTED_BODY = [
+  '## Table of Contents',
+  '',
+  '- [Argo](#argo)',
+  '  - [Beta Program](#beta-program)',
+  '- [Backstage](#backstage)',
+  '  - [Alpha Program](#alpha-program)',
+  '',
+  '## Accepted Projects',
+  '',
+  '### Argo',
+  '',
+  '#### Beta Program',
+  '',
+  'CNCF - Argo: Beta Program (2026 Term 3)',
+  '',
+  '- Description:',
+  '',
+  '  > Solo desc.',
+  '',
+  '- Recommended Skills: Rust',
+  '- Technologies: Rust',
+  '- Mentor(s):',
+  '  - Al Pha (@alpha, al@example.com)',
+  '- Upstream Issue: https://github.com/argoproj/argo/issues/1',
+  '- LFX URL: TBD',
+  '',
+  '### Backstage',
+  '',
+  '#### Alpha Program',
+  '',
+  'CNCF - Backstage: Alpha Program (2026 Term 3)',
+  '',
+  '- Description:',
+  '',
+  '  > Line one.',
+  '  > Line two.',
+  '',
+  '- Recommended Skills: Go, Kubernetes',
+  '- Technologies: Go, Kubernetes',
+  '- Mentor(s):',
+  '  - Jane Doe (@janedoe, jane@example.com)',
+  '  - Sam Lee (@samlee, sam@example.com)',
+  '- Upstream Issue: https://github.com/cncf/mentoring/issues/1883',
+  '- LFX URL: TBD',
+  '',
+];
+
+test('renderAcceptedProgramsBody: sorts projects, nests programs, renders full detail', () => {
+  assert.deepEqual(renderAcceptedProgramsBody(RENDER_PROGRAMS), EXPECTED_BODY);
+});
+
+test('renderAcceptedProgramsBody: output feeds buildReadme cleanly', () => {
+  const out = buildReadme(null, renderAcceptedProgramsBody(RENDER_PROGRAMS), TITLE);
+  assert.match(out, /## Table of Contents/);
+  assert.match(out, /#### Beta Program/);
+  assert.match(out, /- LFX URL: TBD/);
 });

--- a/programs/lfx-mentorship/automation/test/readme.test.js
+++ b/programs/lfx-mentorship/automation/test/readme.test.js
@@ -164,3 +164,14 @@ test('renderAcceptedProgramsBody: output feeds buildReadme cleanly', () => {
   assert.match(out, /#### Beta Program/);
   assert.match(out, /- LFX URL: TBD/);
 });
+
+test('renderAcceptedProgramsBody: a recorded lfx_url replaces the TBD placeholder', () => {
+  const withUrl = [{ ...RENDER_PROGRAMS[1], lfx_url: 'https://mentorship.lfx.linuxfoundation.org/p/1' }];
+  const body = renderAcceptedProgramsBody(withUrl).join('\n');
+  assert.match(body, /- LFX URL: https:\/\/mentorship\.lfx\.linuxfoundation\.org\/p\/1/);
+  assert.doesNotMatch(body, /- LFX URL: TBD/);
+});
+
+test('renderAcceptedProgramsBody: no lfx_url still renders TBD', () => {
+  assert.match(renderAcceptedProgramsBody(RENDER_PROGRAMS).join('\n'), /- LFX URL: TBD/);
+});

--- a/programs/lfx-mentorship/automation/test/readme.test.js
+++ b/programs/lfx-mentorship/automation/test/readme.test.js
@@ -166,9 +166,10 @@ test('renderAcceptedProgramsBody: output feeds buildReadme cleanly', () => {
 });
 
 test('renderAcceptedProgramsBody: a recorded lfx_url replaces the TBD placeholder', () => {
-  const withUrl = [{ ...RENDER_PROGRAMS[1], lfx_url: 'https://mentorship.lfx.linuxfoundation.org/p/1' }];
+  const url = 'https://mentorship.lfx.linuxfoundation.org/project/005db8db-7efe-4433-9605-91d14174c72c';
+  const withUrl = [{ ...RENDER_PROGRAMS[1], lfx_url: url }];
   const body = renderAcceptedProgramsBody(withUrl).join('\n');
-  assert.match(body, /- LFX URL: https:\/\/mentorship\.lfx\.linuxfoundation\.org\/p\/1/);
+  assert.match(body, new RegExp(`- LFX URL: ${url.replace(/[.\/]/g, '\\$&')}`));
   assert.doesNotMatch(body, /- LFX URL: TBD/);
 });
 

--- a/programs/lfx-mentorship/automation/test/term-paths.test.js
+++ b/programs/lfx-mentorship/automation/test/term-paths.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { termPaths } = require('../lib/term-paths');
+
+test('termPaths: standard term string', () => {
+  assert.deepEqual(termPaths('2026 Term 3 (Sep-Nov)'), {
+    year: '2026',
+    termNum: '03',
+    months: 'Sep-Nov',
+    termDir: '03-Sep-Nov',
+    outDir: 'programs/lfx-mentorship/2026/03-Sep-Nov',
+  });
+});
+
+test('termPaths: normalizes en/em dashes in the months to hyphens', () => {
+  assert.equal(termPaths('2026 Term 2 (Jun\u2013Aug)').termDir, '02-Jun-Aug');
+  assert.equal(termPaths('2026 Term 2 (Jun\u2014Aug)').months, 'Jun-Aug');
+});
+
+test('termPaths: malformed term falls back to safe placeholders', () => {
+  assert.deepEqual(termPaths('garbage'), {
+    year: 'unknown',
+    termNum: '00',
+    months: 'unknown',
+    termDir: '00-unknown',
+    outDir: 'programs/lfx-mentorship/unknown/00-unknown',
+  });
+});

--- a/programs/lfx-mentorship/automation/test/term-paths.test.js
+++ b/programs/lfx-mentorship/automation/test/term-paths.test.js
@@ -11,12 +11,18 @@ test('termPaths: standard term string', () => {
     months: 'Sep-Nov',
     termDir: '03-Sep-Nov',
     outDir: 'programs/lfx-mentorship/2026/03-Sep-Nov',
+    readmeTitle: 'Term 03 - 2026 September - November',
   });
 });
 
 test('termPaths: normalizes en/em dashes in the months to hyphens', () => {
   assert.equal(termPaths('2026 Term 2 (Jun\u2013Aug)').termDir, '02-Jun-Aug');
   assert.equal(termPaths('2026 Term 2 (Jun\u2014Aug)').months, 'Jun-Aug');
+});
+
+test('termPaths: derives the README title with expanded month names', () => {
+  assert.equal(termPaths('2026 Term 1 (Mar-May)').readmeTitle, 'Term 01 - 2026 March - May');
+  assert.equal(termPaths('2026 Term 2 (Jun\u2013Aug)').readmeTitle, 'Term 02 - 2026 June - August');
 });
 
 test('termPaths: malformed term falls back to safe placeholders', () => {
@@ -26,5 +32,6 @@ test('termPaths: malformed term falls back to safe placeholders', () => {
     months: 'unknown',
     termDir: '00-unknown',
     outDir: 'programs/lfx-mentorship/unknown/00-unknown',
+    readmeTitle: 'Term 00 - unknown unknown',
   });
 });

--- a/programs/lfx-mentorship/automation/test/term-paths.test.js
+++ b/programs/lfx-mentorship/automation/test/term-paths.test.js
@@ -35,3 +35,19 @@ test('termPaths: malformed term falls back to safe placeholders', () => {
     readmeTitle: 'Term 00 - unknown unknown',
   });
 });
+
+test('termPaths: rejects path-traversal characters in the untrusted months', () => {
+  // The Term field is untrusted issue-form input that feeds outDir, so months
+  // outside a safe charset must not reach the filesystem path.
+  for (const t of [
+    '2026 Term 3 (x/../../../etc)',
+    '2026 Term 3 (../evil)',
+    '2026 Term 3 (a.b)',
+    '2026 Term 3 (Sep Nov)',
+  ]) {
+    const p = termPaths(t);
+    assert.equal(p.months, 'unknown', t);
+    assert.equal(p.termDir, '03-unknown', t);
+    assert.equal(p.outDir, 'programs/lfx-mentorship/2026/03-unknown', t);
+  }
+});

--- a/programs/lfx-mentorship/automation/test/term-paths.test.js
+++ b/programs/lfx-mentorship/automation/test/term-paths.test.js
@@ -20,6 +20,11 @@ test('termPaths: normalizes en/em dashes in the months to hyphens', () => {
   assert.equal(termPaths('2026 Term 2 (Jun\u2014Aug)').months, 'Jun-Aug');
 });
 
+test('termPaths: trims surrounding whitespace in the months before validating', () => {
+  assert.equal(termPaths('2026 Term 3 (Sep-Nov )').termDir, '03-Sep-Nov');
+  assert.equal(termPaths('2026 Term 3 ( Sep-Nov)').months, 'Sep-Nov');
+});
+
 test('termPaths: derives the README title with expanded month names', () => {
   assert.equal(termPaths('2026 Term 1 (Mar-May)').readmeTitle, 'Term 01 - 2026 March - May');
   assert.equal(termPaths('2026 Term 2 (Jun\u2013Aug)').readmeTitle, 'Term 02 - 2026 June - August');


### PR DESCRIPTION
Adds `/lfx-url <url>`, the last automated step of the LFX Mentorship proposal intake (§4.3.5 / §4.5 of #1883).

After a term's export PR is merged, a CNCF admin comments `/lfx-url <url>` on an exported proposal issue. The bot:
- records the URL on the issue (the durable source of truth the export reads back),
- fills it into that term's `lfx-export.json`, `README.md`, and `lfx-tracking.csv` via an accumulating per-term "LFX URLs — <term>" PR, and
- advances the board card to "Posted to LFX".

Guards: restricted to global approvers (same allowlist as `/cncf-approve`); the URL must be an exact program URL (`https://mentorship.lfx.linuxfoundation.org/project/<uuid>`); the issue must be open and its export merged to `main`, else it's rejected atomically with the exact command to re-run; a closed issue is rejected; and the board advance never overrides a manual placement.

Also refactors the export's README/CSV/term-path rendering into shared, unit-tested libs so the export and `/lfx-url` stay in lockstep.

Built and validated end-to-end on the dev fork (nate-double-u/mentoring): full command matrix + the merge-order and no-regress edge cases. 304 unit tests pass.

