### PR TITLE
Harden /lfx-url: locate export by content, warn on Term mismatch

### DIFF
--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -46,7 +46,7 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
-            const { lfxUrlDecision, recordedLfxUrlComment, readExports, locateExportedProgram, exportTermLabel } = _lib('lfx-url.js');
+            const { lfxUrlDecision, recordedLfxUrlComment, readExports, locateExportedProgram, exportTermLabel, termMismatchWarning } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
@@ -431,7 +431,14 @@ jobs:
               // Record the URL on the issue — the durable source of truth the
               // export reads back (§4.5) — then fill the term's files and advance
               // the board. The guard above guarantees this completes fully.
-              await reply('✅', recordedLfxUrlComment(commenter, decision.url));
+              // If the issue's editable Term no longer matches the term its
+              // export lives under, append a ⚠️ to this same comment: the scan
+              // already used the exported term; a human should reconcile the
+              // stale field (#1938). We warn, we don't block.
+              const mismatch = termMismatchWarning(fields['Term'], term);
+              await reply('✅',
+                recordedLfxUrlComment(commenter, decision.url) +
+                (mismatch ? `\n\n${mismatch}` : ''));
               core.exportVariable('LFX_URL_POSTED', 'true');
 
               if (prog.lfx_url === decision.url) {

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -470,7 +470,7 @@ jobs:
 
             Recorded via /lfx-url on issue #${{ github.event.issue.number }}.
           branch: automation/lfx-urls-${{ env.LFX_URL_YEAR }}-${{ env.LFX_URL_TERM_DIR }}
-          title: "LFX URLs — ${{ env.LFX_URL_TERM }}"
+          title: "LFX URLs: ${{ env.LFX_URL_TERM }}"
           body: |
             Accumulating LFX program URLs recorded via `/lfx-url` for **${{ env.LFX_URL_TERM }}**.
 

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -46,7 +46,7 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
-            const { lfxUrlDecision, recordedLfxUrlComment, findExportedProgram, exportTermLabel } = _lib('lfx-url.js');
+            const { lfxUrlDecision, recordedLfxUrlComment, readExports, locateExportedProgram, exportTermLabel } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
@@ -408,30 +408,25 @@ jobs:
                 return;
               }
 
-              // Guard (§4.3.5, option C): the term's export must be merged to
-              // `main` and contain this program before we touch anything. If the
-              // export PR is still open, the files live only on its branch, so
-              // recording now would move the board and leave the files unsynced.
-              // Reject atomically instead — nothing recorded, no board move — and
-              // hand back the exact command to re-run after the export PR merges.
-              // decision.url already passed the strict format gate, so it is safe
-              // to echo here.
-              const lfxTerm = (parseIssueForm(issueBody)['Term'] || '').trim();
-              const { outDir, year, termDir, readmeTitle } = termPaths(lfxTerm);
-              const jsonPath = `${outDir}/lfx-export.json`;
-              let data = null;
-              try {
-                data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
-              } catch {
-                // Missing/unreadable on main → treated as not-yet-merged below.
-              }
-              const prog = findExportedProgram(data, issue_number);
-              if (!prog) {
+              // Guard (§4.3.5, option C + #1938): locate this issue's export by
+              // CONTENT, not the editable issue Term. Scan every
+              // programs/lfx-mentorship/<year>/<termDir>/lfx-export.json on `main`
+              // for the one whose programs[] contains this issue, so a wrong or
+              // edited Term can't misdirect the guard. If none is found, the
+              // export PR isn't merged yet: reject atomically — nothing recorded,
+              // no board move — and hand back the exact command to re-run after
+              // merging. decision.url already passed the strict format gate, so
+              // it is safe to echo.
+              const located = locateExportedProgram(readExports(fs, 'programs/lfx-mentorship'), issue_number);
+              if (!located) {
                 await reply('❌',
-                  `This term's export isn't on \`main\` yet (with this program). ` +
-                  `Merge its export PR (\`${outDir}/\`), then re-run: \`/lfx-url ${decision.url}\``);
+                  'Cannot `/lfx-url` — no exported program for this issue is on `main` yet. ' +
+                  `Merge the term's export PR, then re-run: \`/lfx-url ${decision.url}\``);
                 return;
               }
+              const { dir, year, termDir, term, data, prog } = located;
+              const { readmeTitle } = termPaths(term);
+              const jsonPath = `${dir}/lfx-export.json`;
 
               // Record the URL on the issue — the durable source of truth the
               // export reads back (§4.5) — then fill the term's files and advance
@@ -444,15 +439,15 @@ jobs:
               } else {
                 prog.lfx_url = decision.url;
                 fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2) + '\n');
-                const readmePath = `${outDir}/README.md`;
+                const readmePath = `${dir}/README.md`;
                 const existingReadme = fs.existsSync(readmePath) ? fs.readFileSync(readmePath, 'utf8') : null;
                 fs.writeFileSync(readmePath, buildReadme(existingReadme, renderAcceptedProgramsBody(data.programs), readmeTitle));
-                fs.writeFileSync(`${outDir}/lfx-tracking.csv`, renderTrackingCsv(data.programs));
+                fs.writeFileSync(`${dir}/lfx-tracking.csv`, renderTrackingCsv(data.programs));
                 core.exportVariable('LFX_URL_FILES_CHANGED', 'true');
-                core.exportVariable('LFX_URL_TERM', exportTermLabel(data, lfxTerm));
+                core.exportVariable('LFX_URL_TERM', exportTermLabel(data, term));
                 core.exportVariable('LFX_URL_YEAR', year);
                 core.exportVariable('LFX_URL_TERM_DIR', termDir);
-                console.log(`Updated export files in ${outDir}`);
+                console.log(`Updated export files in ${dir}`);
               }
               return;
             }

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -135,7 +135,7 @@ the existing branch if the previous PR wasn't merged).
 4. **After you create each program on LFX:** comment `/lfx-url <url>` on that
    program's proposal issue. The bot records the URL on the issue, fills it into
    the term's `lfx-export.json`, `README.md`, and `lfx-tracking.csv` (landing the
-   change in a per-term `LFX URLs — <term>` PR), and advances the card to
+   change in a per-term `LFX URLs: <term>` PR), and advances the card to
    `Posted to LFX`. Restricted to global approvers; the issue must already be
    `Exported` and open. The URL must be a full LFX Mentorship program URL
    (`https://mentorship.lfx.linuxfoundation.org/project/<id>`); anything else is

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -159,8 +159,8 @@ function termMismatchWarning(declaredTerm, exportedTerm) {
   const d = norm(declaredTerm);
   const e = norm(exportedTerm);
   if (!d || !e || d.toLowerCase() === e.toLowerCase()) return '';
-  return `⚠️ This issue's **Term** field (*${d}*) doesn't match the term it ` +
-    `was exported under (*${e}*). Recorded under *${e}*. ` +
+  return `⚠️ This issue's **Term** field (\`${d}\`) doesn't match the term it ` +
+    `was exported under (\`${e}\`). Recorded under \`${e}\`. ` +
     `Fix whichever is wrong: the Term field or the export.`;
 }
 

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -157,8 +157,10 @@ function locateExportedProgram(exports, issueNumber) {
 function termMismatchWarning(declaredTerm, exportedTerm) {
   // Strip backticks (the only char that can break an inline code span) before
   // wrapping the values below, so an edited Term can't escape and render an
-  // @mention/Markdown. Then collapse whitespace and trim.
-  const norm = (s) => String(s || '').replace(/`/g, '').replace(/\s+/g, ' ').trim();
+  // @mention/Markdown. Fold en/em dashes to a hyphen to match termPaths()
+  // (term-paths.js), so a Term differing only by dash style in the months range
+  // isn't flagged as a mismatch. Then collapse whitespace and trim.
+  const norm = (s) => String(s || '').replace(/`/g, '').replace(/[\u2013\u2014]/g, '-').replace(/\s+/g, ' ').trim();
   const d = norm(declaredTerm);
   const e = norm(exportedTerm);
   if (!d || !e || d.toLowerCase() === e.toLowerCase()) return '';

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -97,7 +97,58 @@ function exportTermLabel(exportData, fallbackTerm) {
   return String(raw).replace(/\s+/g, ' ').trim();
 }
 
+// Read every term export on disk: programs/lfx-mentorship/<year>/<termDir>/
+// lfx-export.json. Returns [{ dir, data }] (data = the parsed JSON). Entries
+// that aren't directories (e.g. README.md), term dirs without an export, and
+// files that don't parse are all skipped. `fs` is injected (node's fs in the
+// workflow) so the two-level walk is unit-testable; only readdirSync and
+// readFileSync are used. Backs /lfx-url's content-based export lookup (#1938).
+function readExports(fs, root) {
+  const out = [];
+  let years;
+  try { years = fs.readdirSync(root); } catch { return out; }
+  for (const year of years) {
+    let termDirs;
+    try { termDirs = fs.readdirSync(`${root}/${year}`); } catch { continue; }
+    for (const termDir of termDirs) {
+      const dir = `${root}/${year}/${termDir}`;
+      let raw;
+      try { raw = fs.readFileSync(`${dir}/lfx-export.json`, 'utf8'); } catch { continue; }
+      let data;
+      try { data = JSON.parse(raw); } catch { continue; }
+      out.push({ dir, data });
+    }
+  }
+  return out;
+}
+
+// Find the export that actually contains this issue's program by scanning
+// content, rather than deriving the path from the (editable, untrusted) issue
+// Term (#1938). `exports` is readExports() output. Returns
+// { dir, year, termDir, term, data, prog } for the first matching export — an
+// issue is exported to exactly one term — or null when no on-disk export
+// contains it. dir/year/termDir come from the file's real location; term is the
+// export's canonical _term (used for PR metadata and the README title).
+function locateExportedProgram(exports, issueNumber) {
+  for (const entry of exports || []) {
+    const prog = findExportedProgram(entry && entry.data, issueNumber);
+    if (prog) {
+      const parts = String(entry.dir).split('/');
+      return {
+        dir: entry.dir,
+        year: parts[parts.length - 2],
+        termDir: parts[parts.length - 1],
+        term: (entry.data && entry.data._term) || '',
+        data: entry.data,
+        prog,
+      };
+    }
+  }
+  return null;
+}
+
 module.exports = {
   recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision,
-  findExportedProgram, exportTermLabel, LFX_PROGRAM_URL_RE,
+  findExportedProgram, exportTermLabel, readExports, locateExportedProgram,
+  LFX_PROGRAM_URL_RE,
 };

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -155,7 +155,10 @@ function locateExportedProgram(exports, issueNumber) {
 // (whitespace- and case-insensitively), or '' when they match or either is
 // unknown.
 function termMismatchWarning(declaredTerm, exportedTerm) {
-  const norm = (s) => String(s || '').replace(/\s+/g, ' ').trim();
+  // Strip backticks (the only char that can break an inline code span) before
+  // wrapping the values below, so an edited Term can't escape and render an
+  // @mention/Markdown. Then collapse whitespace and trim.
+  const norm = (s) => String(s || '').replace(/`/g, '').replace(/\s+/g, ' ').trim();
   const d = norm(declaredTerm);
   const e = norm(exportedTerm);
   if (!d || !e || d.toLowerCase() === e.toLowerCase()) return '';

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -147,8 +147,26 @@ function locateExportedProgram(exports, issueNumber) {
   return null;
 }
 
+// Warn when the issue's declared Term disagrees with the term its export
+// actually lives under. /lfx-url trusts the export (content wins, #1938), but a
+// mismatch means the editable Term field is stale or wrong, so we surface it for
+// a human to reconcile rather than correcting silently. Returns the ⚠️ note
+// (appended to the recorded-URL comment) when both terms are present and differ
+// (whitespace- and case-insensitively), or '' when they match or either is
+// unknown.
+function termMismatchWarning(declaredTerm, exportedTerm) {
+  const norm = (s) => String(s || '').replace(/\s+/g, ' ').trim();
+  const d = norm(declaredTerm);
+  const e = norm(exportedTerm);
+  if (!d || !e || d.toLowerCase() === e.toLowerCase()) return '';
+  return `⚠️ This issue's **Term** field (*${d}*) doesn't match the term it ` +
+    `was exported under (*${e}*). Recorded under *${e}*. ` +
+    `Fix whichever is wrong: the Term field or the export.`;
+}
+
 module.exports = {
   recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision,
   findExportedProgram, exportTermLabel, readExports, locateExportedProgram,
+  termMismatchWarning,
   LFX_PROGRAM_URL_RE,
 };

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -331,3 +331,11 @@ test('termMismatchWarning: strips backticks so an edited Term cannot break out o
   assert.ok(w.includes('`2026 @acme/team Term`'), 'internal backticks removed; value stays inside its span');
   assert.equal((w.match(/`/g) || []).length, 6, 'only the three span wrappers remain; no stray backticks');
 });
+
+test('termMismatchWarning: folds en/em dashes to a hyphen so a cosmetic dash difference is not a mismatch', () => {
+  // termPaths() folds en/em dashes to '-' when resolving the directory, so a
+  // Term differing only by dash style resolves to the same term and must not
+  // warn. Keeps the warning consistent with the rest of the automation.
+  assert.equal(termMismatchWarning('2026 Term 3 (Sep\u2013Nov)', '2026 Term 3 (Sep-Nov)'), '', 'en-dash equals hyphen');
+  assert.equal(termMismatchWarning('2026 Term 3 (Sep\u2014Nov)', '2026 Term 3 (Sep-Nov)'), '', 'em-dash equals hyphen');
+});

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -2,7 +2,10 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, findExportedProgram, exportTermLabel } = require('../lib/lfx-url');
+const {
+  recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, findExportedProgram,
+  exportTermLabel, readExports, locateExportedProgram,
+} = require('../lib/lfx-url');
 
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
 const user = (login, body) => ({ user: { login }, body });
@@ -161,6 +164,108 @@ test('findExportedProgram: null when the export data is missing or malformed', (
   assert.equal(findExportedProgram(undefined, 115), null);
   assert.equal(findExportedProgram({}, 115), null);
   assert.equal(findExportedProgram({ programs: 'nope' }, 115), null);
+});
+
+// ── readExports / locateExportedProgram: content discovery across terms (#1938) ──
+// Fake fs: `dirs` maps a directory path to its entry names; `files` maps a file
+// path to its contents. readdirSync throws for anything that isn't a listed
+// directory (models a plain file like README.md); readFileSync throws for a
+// missing file. Only these two calls are used by readExports.
+const makeFs = (dirs, files) => ({
+  readdirSync(p) {
+    if (!Object.prototype.hasOwnProperty.call(dirs, p)) throw new Error(`ENOTDIR: ${p}`);
+    return dirs[p];
+  },
+  readFileSync(p) {
+    if (!Object.prototype.hasOwnProperty.call(files, p)) throw new Error(`ENOENT: ${p}`);
+    return files[p];
+  },
+});
+
+const ROOT = 'programs/lfx-mentorship';
+
+test('readExports: reads every lfx-export.json under root/<year>/<termDir>', () => {
+  const dirs = {
+    [ROOT]: ['2025', '2026', 'automation', 'README.md'],
+    [`${ROOT}/2025`]: ['03-Sep-Nov'],
+    [`${ROOT}/2026`]: ['02-Jun-Aug', '03-Sep-Nov'],
+    [`${ROOT}/automation`]: ['lib', 'test'], // no lfx-export.json inside → skipped
+  };
+  const files = {
+    [`${ROOT}/2025/03-Sep-Nov/lfx-export.json`]: JSON.stringify({ _term: '2025 Term 3 (Sep-Nov)', programs: [{ issue_number: 90 }] }),
+    [`${ROOT}/2026/02-Jun-Aug/lfx-export.json`]: JSON.stringify({ _term: '2026 Term 2 (Jun-Aug)', programs: [{ issue_number: 100 }] }),
+    [`${ROOT}/2026/03-Sep-Nov/lfx-export.json`]: JSON.stringify({ _term: '2026 Term 3 (Sep-Nov)', programs: [{ issue_number: 115 }] }),
+  };
+  const got = readExports(makeFs(dirs, files), ROOT);
+  assert.deepEqual(got.map(e => e.dir).sort(), [
+    `${ROOT}/2025/03-Sep-Nov`,
+    `${ROOT}/2026/02-Jun-Aug`,
+    `${ROOT}/2026/03-Sep-Nov`,
+  ]);
+  assert.equal(got.find(e => e.dir === `${ROOT}/2026/03-Sep-Nov`).data._term, '2026 Term 3 (Sep-Nov)');
+});
+
+test('readExports: skips term dirs without an export and malformed JSON', () => {
+  const dirs = {
+    [ROOT]: ['2026'],
+    [`${ROOT}/2026`]: ['01-Mar-May', '02-Jun-Aug', '03-Sep-Nov'],
+  };
+  const files = {
+    [`${ROOT}/2026/01-Mar-May/lfx-export.json`]: '{ not valid json',
+    // 02-Jun-Aug has no lfx-export.json
+    [`${ROOT}/2026/03-Sep-Nov/lfx-export.json`]: JSON.stringify({ _term: 'x', programs: [] }),
+  };
+  const got = readExports(makeFs(dirs, files), ROOT);
+  assert.deepEqual(got.map(e => e.dir), [`${ROOT}/2026/03-Sep-Nov`]);
+});
+
+test('readExports: returns [] when the root cannot be read', () => {
+  assert.deepEqual(readExports(makeFs({}, {}), ROOT), []);
+});
+
+test('locateExportedProgram: finds the program and returns its real location', () => {
+  const exportsList = [
+    { dir: `${ROOT}/2026/02-Jun-Aug`, data: { _term: '2026 Term 2 (Jun-Aug)', programs: [{ issue_number: 100 }] } },
+    { dir: `${ROOT}/2026/03-Sep-Nov`, data: { _term: '2026 Term 3 (Sep-Nov)', programs: [{ issue_number: 114 }, { issue_number: 115, cncf_project: 'B' }] } },
+  ];
+  const got = locateExportedProgram(exportsList, 115);
+  assert.equal(got.dir, `${ROOT}/2026/03-Sep-Nov`);
+  assert.equal(got.year, '2026');
+  assert.equal(got.termDir, '03-Sep-Nov');
+  assert.equal(got.term, '2026 Term 3 (Sep-Nov)');
+  assert.equal(got.prog.cncf_project, 'B');
+  assert.equal(got.data, exportsList[1].data);
+});
+
+test('locateExportedProgram: picks the right term among several exports', () => {
+  const exportsList = [
+    { dir: `${ROOT}/2025/03-Sep-Nov`, data: { _term: '2025 Term 3 (Sep-Nov)', programs: [{ issue_number: 90 }] } },
+    { dir: `${ROOT}/2026/02-Jun-Aug`, data: { _term: '2026 Term 2 (Jun-Aug)', programs: [{ issue_number: 100 }] } },
+    { dir: `${ROOT}/2026/03-Sep-Nov`, data: { _term: '2026 Term 3 (Sep-Nov)', programs: [{ issue_number: 115 }] } },
+  ];
+  const got = locateExportedProgram(exportsList, 100);
+  assert.equal(got.dir, `${ROOT}/2026/02-Jun-Aug`);
+  assert.equal(got.termDir, '02-Jun-Aug');
+  assert.equal(got.year, '2026');
+});
+
+test('locateExportedProgram: null when no export contains the issue', () => {
+  const exportsList = [
+    { dir: `${ROOT}/2026/03-Sep-Nov`, data: { _term: 'x', programs: [{ issue_number: 114 }] } },
+  ];
+  assert.equal(locateExportedProgram(exportsList, 115), null);
+  assert.equal(locateExportedProgram([], 115), null);
+  assert.equal(locateExportedProgram(null, 115), null);
+});
+
+test('locateExportedProgram: skips malformed entries; missing _term → empty term', () => {
+  const exportsList = [
+    { dir: 'ignored', data: null },
+    { dir: `${ROOT}/2026/03-Sep-Nov`, data: { programs: [{ issue_number: 115 }] } }, // no _term
+  ];
+  const got = locateExportedProgram(exportsList, 115);
+  assert.equal(got.dir, `${ROOT}/2026/03-Sep-Nov`);
+  assert.equal(got.term, '');
 });
 
 // ── exportTermLabel: the term string used in /lfx-url PR metadata ──

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -311,6 +311,14 @@ test('termMismatchWarning: empty when either term is missing (nothing to compare
 test('termMismatchWarning: warns and names both terms when they differ', () => {
   const w = termMismatchWarning('2026 Term 1 (Mar-May)', '2026 Term 3 (Sep-Nov)');
   assert.ok(w.startsWith('⚠️'), 'starts with the warning glyph');
-  assert.ok(w.includes('2026 Term 1 (Mar-May)'), 'names the declared (issue) term');
-  assert.ok(w.includes('2026 Term 3 (Sep-Nov)'), 'names the exported term');
+  // User-controlled term values are wrapped in inline code, matching how the
+  // validate workflow echoes user input — neutralizes stray @mentions/Markdown.
+  assert.ok(w.includes('`2026 Term 1 (Mar-May)`'), 'names the declared (issue) term in code');
+  assert.ok(w.includes('`2026 Term 3 (Sep-Nov)`'), 'names the exported term in code');
+});
+
+test('termMismatchWarning: neutralizes an @mention in an edited Term field', () => {
+  const w = termMismatchWarning('@acme/team', '2026 Term 3 (Sep-Nov)');
+  assert.ok(w.includes('`@acme/team`'), 'wraps the raw value in inline code so it cannot ping');
+  assert.ok(!/(^|[^`])@acme\/team/.test(w), 'no bare @mention escapes the code span');
 });

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -322,3 +322,12 @@ test('termMismatchWarning: neutralizes an @mention in an edited Term field', () 
   assert.ok(w.includes('`@acme/team`'), 'wraps the raw value in inline code so it cannot ping');
   assert.ok(!/(^|[^`])@acme\/team/.test(w), 'no bare @mention escapes the code span');
 });
+
+test('termMismatchWarning: strips backticks so an edited Term cannot break out of the code span', () => {
+  // A backtick is the only character that can terminate an inline code span, so
+  // removing it fully neutralizes any embedded Markdown/@mention (no need for a
+  // CommonMark variable-length fence). A Term never legitimately contains one.
+  const w = termMismatchWarning('2026 `@acme/team` Term', '2026 Term 3 (Sep-Nov)');
+  assert.ok(w.includes('`2026 @acme/team Term`'), 'internal backticks removed; value stays inside its span');
+  assert.equal((w.match(/`/g) || []).length, 6, 'only the three span wrappers remain; no stray backticks');
+});

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -4,7 +4,7 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const {
   recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, findExportedProgram,
-  exportTermLabel, readExports, locateExportedProgram,
+  exportTermLabel, readExports, locateExportedProgram, termMismatchWarning,
 } = require('../lib/lfx-url');
 
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
@@ -289,4 +289,28 @@ test('exportTermLabel: collapses whitespace/newlines to a single line', () => {
 test('exportTermLabel: empty when neither source has a term', () => {
   assert.equal(exportTermLabel(null, ''), '');
   assert.equal(exportTermLabel({}, undefined), '');
+});
+
+// ── termMismatchWarning: surface a stale/edited Term vs the exported term ──
+// (#1938) /lfx-url trusts the export (content wins), but a Term-field mismatch
+// means a human should reconcile it, so we warn instead of correcting silently.
+test('termMismatchWarning: empty when the declared term matches the export', () => {
+  assert.equal(termMismatchWarning('2026 Term 3 (Sep-Nov)', '2026 Term 3 (Sep-Nov)'), '');
+});
+
+test('termMismatchWarning: empty when they match after normalizing space/case', () => {
+  assert.equal(termMismatchWarning('  2026   Term 3\n(sep-nov) ', '2026 Term 3 (Sep-Nov)'), '');
+});
+
+test('termMismatchWarning: empty when either term is missing (nothing to compare)', () => {
+  assert.equal(termMismatchWarning('', '2026 Term 3 (Sep-Nov)'), '');
+  assert.equal(termMismatchWarning('2026 Term 1 (Mar-May)', ''), '');
+  assert.equal(termMismatchWarning(null, undefined), '');
+});
+
+test('termMismatchWarning: warns and names both terms when they differ', () => {
+  const w = termMismatchWarning('2026 Term 1 (Mar-May)', '2026 Term 3 (Sep-Nov)');
+  assert.ok(w.startsWith('⚠️'), 'starts with the warning glyph');
+  assert.ok(w.includes('2026 Term 1 (Mar-May)'), 'names the declared (issue) term');
+  assert.ok(w.includes('2026 Term 3 (Sep-Nov)'), 'names the exported term');
 });


### PR DESCRIPTION
Harden `/lfx-url` to find a proposal's export by scanning export-file content for the issue number, instead of deriving the term directory from the issue's editable **Term** field. 

Fixes #1938

## Why

The Term field can be edited after export. When it stops matching the term the proposal was exported under, the old code looked in the wrong directory and false-rejected a valid `/lfx-url`.

## What changed

- **Locate the export by content.** `lib/lfx-url.js` gains two pure helpers: `readExports(fs, root)` walks `<year>/<termDir>/lfx-export.json`, and `locateExportedProgram(exports, issueNumber)` returns the export whose `programs[]` contains the issue. Directory comes from the file's real location; term from the canonical `_term`. The `/lfx-url` handler in `lfx-proposal-approvals.yml` resolves the term directory from that scan (was: from the Term field); peter-evans env vars are unchanged in name, re-sourced from the located result.
- **Warn on a Term mismatch.** When the located export's term differs from the issue's Term field, `termMismatchWarning()` appends a ⚠️ to the recorded-URL comment naming both terms. The scan already used the exported term; this surfaces the stale field for a human to reconcile. Warns, never blocks.
- **Safe rendering.** The warning wraps both term values in inline code (matching how the validate workflow echoes user input) and strips backticks first, so an edited Term can't break out of the code span to render a stray `@mention` or Markdown.
- **Drop the em-dash from the PR title.** The per-term PR is now `LFX URLs: <term>` (was an em-dash). peter-evans matches its PR by branch, not title, so retitling is safe. Matching `ADMIN_GUIDE` reference updated.

## Testing

- TDD throughout; full suite 317/317 (from 311).
- e2e on [the dev fork](https://github.com/nate-double-u/mentoring): a proposal exported under Term 3, Term field then edited to Term 1 (mismatch). `/lfx-url` succeeded and opened a per-term PR titled `LFX URLs: 2026 Term 3 (Sep-Nov)` targeting `2026/03-Sep-Nov` (not Term 1), with the ⚠️ mismatch warning on the issue. The old code would have false-rejected.
