### PR TITLE
Recognize the "Mentors listed" board column as admin-owned

### DIFF
--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -191,7 +191,8 @@ the existing branch if the previous PR wasn't merged).
    recorded on a rejection, so re-running after the merge is safe.
 5. **Continue tracking** by dragging cards through the remaining columns by
    hand as each step completes on the LFX platform (`LFX Approved` →
-   `Mentors added` → `Open for Applications` → `Applications Closed`)
+   `Mentors added` → `Mentors listed` → `Open for Applications` →
+   `Applications Closed`)
 
 ---
 
@@ -286,8 +287,12 @@ advances the card. Everything after `Posted to LFX` is **yours to move by
 hand**. As you work with the LFX platform team, drag each card through the
 remaining columns:
 
-`LFX Approved` → `Mentors added` → `Open for Applications`
-→ `Applications Closed`
+`LFX Approved` → `Mentors added` → `Mentors listed` →
+`Open for Applications` → `Applications Closed`
+
+`Mentors added` means the mentors have been invited on LFX (an invitation
+email goes out). `Mentors listed` means they have accepted (or, for returning
+mentors, are auto-listed) and now appear on the program page.
 
 Automation never moves a card once it sits in one of these post-export
 columns (other than the `/lfx-url` advance above), so your manual placement is
@@ -381,7 +386,8 @@ from the board at run time. This means:
   match** the lifecycle stages in the board table above (`Inbox`,
   `Awaiting approvals/confirmations`, `Approved/confirmed`, `CNCF Approved`,
   `Exported`, `Posted to LFX`, `LFX Approved`, `Mentors added`,
-  `Open for Applications`, `Applications Closed`, `Closed`).
+  `Mentors listed`, `Open for Applications`, `Applications Closed`,
+  `Closed`).
 
 If a repo is not listed in `board.json` (or its `projectId` is still a
 `REPLACE_...` placeholder), board sync is skipped with a warning instead of

--- a/programs/lfx-mentorship/automation/lib/board.js
+++ b/programs/lfx-mentorship/automation/lib/board.js
@@ -12,6 +12,7 @@ const ADMIN_OWNED = new Set([
   'Posted to LFX',
   'LFX Approved',
   'Mentors added',
+  'Mentors listed',
   'Open for Applications',
   'Applications Closed',
 ]);

--- a/programs/lfx-mentorship/automation/test/board.test.js
+++ b/programs/lfx-mentorship/automation/test/board.test.js
@@ -95,7 +95,7 @@ test('shouldSkipExport: skips admin-owned cards or any read failure', () => {
   assert.equal(shouldSkipExport('Exported', true), true);
 });
 
-test("both guards protect the 'Mentors listed' admin column", () => {
+test('both guards protect the Mentors listed admin column', () => {
   // 'Mentors listed' is a hand-managed post-export column, so neither a
   // re-export nor a label-driven board-sync may pull a card out of it...
   assert.equal(shouldSkipExport('Mentors listed', false), true);

--- a/programs/lfx-mentorship/automation/test/board.test.js
+++ b/programs/lfx-mentorship/automation/test/board.test.js
@@ -95,6 +95,16 @@ test('shouldSkipExport: skips admin-owned cards or any read failure', () => {
   assert.equal(shouldSkipExport('Exported', true), true);
 });
 
+test("both guards protect the 'Mentors listed' admin column", () => {
+  // 'Mentors listed' is a hand-managed post-export column, so neither a
+  // re-export nor a label-driven board-sync may pull a card out of it...
+  assert.equal(shouldSkipExport('Mentors listed', false), true);
+  assert.equal(shouldSkipSync('Mentors listed', 'Exported', false), true);
+  assert.equal(shouldSkipSync('Mentors listed', 'Posted to LFX', false), true);
+  // ...except that closing the issue still sends the card to Closed.
+  assert.equal(shouldSkipSync('Mentors listed', 'Closed', false), false);
+});
+
 const node = (name) => ({ node: { fieldValueByName: name === null ? null : { name } } });
 const noSleep = { sleep: async () => {} };
 


### PR DESCRIPTION
Recognize the new hand-managed board column **`Mentors listed`** as admin-owned, so automation never pulls a card out of it. Supports a new post-export lifecycle stage on the proposal board.

## Why

`Mentors added` means the mentors were invited on LFX (an invitation email goes out); `Mentors listed` means they have accepted (or, for returning mentors, are auto-listed) and now appear on the program page. The column sits between `Mentors added` and `Open for Applications`.

The board guards protect a card from automation only if its column is in `ADMIN_OWNED`. Without this change, a card an admin moved to `Mentors listed` would be dragged back to `Exported` on the next re-export (the export board loop targets `Exported` for every exported proposal) or on any label-driven board sync.

## Changes

- Add `Mentors listed` to `ADMIN_OWNED` in `lib/board.js`, so both `shouldSkipSync` and `shouldSkipExport` leave the column alone (close still sends a card to `Closed`).
- `board.test.js`: assert both guards protect the new column.
- `ADMIN_GUIDE.md`: add the column to the lifecycle chains and the exact-match column list, and document the invited-vs-listed distinction.

No workflow wiring changes; the guards already consume `ADMIN_OWNED`.

## Testing

- Unit: full suite 445/445 (+1 new).
- End-to-end on the dev fork: exported a proposal, moved its card to `Mentors listed`, then confirmed a re-export and a label-driven board sync both leave the card in place while a second proposal advances to `Exported` normally.

## Board

The `Mentors listed` column (and the `Mentors added` description change to "Mentors invited to LFX") are already added to both the dev and prod boards, with names matching this code exactly.
