### PR TITLE
Validate the custom application prerequisite (LFX limits + unchecked-copy)

### DIFF
--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -260,13 +260,13 @@ jobs:
             for (const e of customPrereq.errors) {
               switch (e.code) {
                 case 'name-missing':
-                  errors.push('Custom Prerequisite is checked but Custom Prerequisite Name is empty. Add a name (max 20 chars), or uncheck Custom Prerequisite.');
+                  errors.push(`Custom Prerequisite is checked but Custom Prerequisite Name is empty. Add a name (max ${CUSTOM_PREREQ_NAME_MAX} chars), or uncheck Custom Prerequisite.`);
                   break;
                 case 'name-too-long':
                   errors.push(`Custom Prerequisite Name is ${e.length} chars (LFX limit is ${e.max}). Please trim ${e.length - e.max} chars.`);
                   break;
                 case 'description-missing':
-                  errors.push('Custom Prerequisite is checked but Custom Prerequisite Description is empty. Add a description (max 500 chars), or uncheck Custom Prerequisite.');
+                  errors.push(`Custom Prerequisite is checked but Custom Prerequisite Description is empty. Add a description (max ${CUSTOM_PREREQ_DESC_MAX} chars), or uncheck Custom Prerequisite.`);
                   break;
                 case 'description-too-long':
                   errors.push(`Custom Prerequisite Description is ${e.length} chars (LFX limit is ${e.max}). Please trim ${e.length - e.max} chars.`);

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -263,7 +263,11 @@ jobs:
             for (const e of customPrereq.errors) {
               switch (e.code) {
                 case 'unchecked-with-copy':
-                  errors.push('Custom Prerequisite details are filled in, but the Custom Prerequisite box (under Application Prerequisites) is not checked, so they will not be sent to LFX. Check the box to include this prerequisite, or clear the name and description if you do not want one.');
+                  errors.push(
+                    'Custom Prerequisite Name/Description are filled in, but the ' +
+                    'Custom Prerequisite box is not checked, so they will not be sent ' +
+                    'to LFX. Check the box to include them, or clear the fields.'
+                  );
                   break;
                 case 'name-missing':
                   errors.push(`Custom Prerequisite Name is empty. Add a name (max ${CUSTOM_PREREQ_NAME_MAX} chars).`);

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -72,8 +72,8 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
-            const { parseIssueForm, parseMentors, formFieldsChanged } = _lib('parse.js');
-            const { validateMentors, validateUpstreamUrl, mentorCountWarning } = _lib('validate.js');
+            const { parseIssueForm, parseMentors, parseCheckboxes, formFieldsChanged } = _lib('parse.js');
+            const { validateMentors, validateUpstreamUrl, mentorCountWarning, validateCustomPrerequisite, CUSTOM_PREREQ_NAME_MAX, CUSTOM_PREREQ_DESC_MAX } = _lib('validate.js');
             const { lookupProject } = _lib('projects.js');
             const { isProposalTitle, looksLikeProposalForm } = _lib('labels.js');
             const { resolveProjectMaintainer } = _lib('authorize.js');
@@ -245,7 +245,39 @@ jobs:
               passed.push(`Upstream Issue URL: ${upstreamUrl}`);
             }
 
-            // ── 9. Quota check ──
+            // ── 9. Custom application prerequisite (name/description limits) ──
+            // LFX only receives the custom prerequisite when the "Custom
+            // Prerequisite" box is checked (same gate as lfx-export.yml), and
+            // LFX caps the name at 20 chars and the description at 500. Decision
+            // in lib/validate.js; prose stays here.
+            const customPrereqChecked = parseCheckboxes(get('Application Prerequisites'))
+              .includes('Custom Prerequisite (fill in details below)');
+            const customName = get('Custom Prerequisite Name');
+            const customDesc = get('Custom Prerequisite Description');
+            const customPrereq = validateCustomPrerequisite({
+              checked: customPrereqChecked, name: customName, description: customDesc,
+            });
+            for (const e of customPrereq.errors) {
+              switch (e.code) {
+                case 'name-missing':
+                  errors.push('Custom Prerequisite is checked but Custom Prerequisite Name is empty. Add a name (max 20 chars), or uncheck Custom Prerequisite.');
+                  break;
+                case 'name-too-long':
+                  errors.push(`Custom Prerequisite Name is ${e.length} chars (LFX limit is ${e.max}). Please trim ${e.length - e.max} chars.`);
+                  break;
+                case 'description-missing':
+                  errors.push('Custom Prerequisite is checked but Custom Prerequisite Description is empty. Add a description (max 500 chars), or uncheck Custom Prerequisite.');
+                  break;
+                case 'description-too-long':
+                  errors.push(`Custom Prerequisite Description is ${e.length} chars (LFX limit is ${e.max}). Please trim ${e.length - e.max} chars.`);
+                  break;
+              }
+            }
+            if (customPrereqChecked && customPrereq.ok) {
+              passed.push(`Custom Prerequisite: name ${customName.trim().length}/${CUSTOM_PREREQ_NAME_MAX} chars, description ${customDesc.trim().length}/${CUSTOM_PREREQ_DESC_MAX} chars`);
+            }
+
+            // ── 10. Quota check ──
             if (project && term) {
               try {
                 const quotaRaw = fs.readFileSync('programs/lfx-mentorship/automation/quotas.yml', 'utf8');
@@ -309,7 +341,7 @@ jobs:
               }
             }
 
-            // ── 10. LFX verification stub ──
+            // ── 11. LFX verification stub ──
             warnings.push(
               'LFX LFID/email verification is not yet automated. ' +
               'Please manually confirm mentor emails are registered on ' +

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -264,9 +264,9 @@ jobs:
               switch (e.code) {
                 case 'unchecked-with-copy':
                   errors.push(
-                    'Custom Prerequisite Name/Description are filled in, but the ' +
-                    'Custom Prerequisite box is not checked, so they will not be sent ' +
-                    'to LFX. Check the box to include them, or clear the fields.'
+                    'A Custom Prerequisite name or description is filled in, but the ' +
+                    'Custom Prerequisite box is not checked, so it will not be sent ' +
+                    'to LFX. Check the box to include it, or clear the fields.'
                   );
                   break;
                 case 'name-missing':

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -246,10 +246,13 @@ jobs:
             }
 
             // ── 9. Custom application prerequisite (name/description limits) ──
-            // LFX only receives the custom prerequisite when the "Custom
-            // Prerequisite" box is checked (same gate as lfx-export.yml), and
-            // LFX caps the name at 20 chars and the description at 500. Decision
-            // in lib/validate.js; prose stays here.
+            // There is a custom prerequisite to validate when the box is checked
+            // or any copy is present (a fully empty, unchecked one is skipped).
+            // Name and description are required and must fit LFX's limits. The
+            // export sends it to LFX only when the box is checked (same gate as
+            // lfx-export.yml), so copy left with the box unchecked is flagged
+            // too, and every problem is reported together. Decision in
+            // lib/validate.js; prose stays here.
             const customPrereqChecked = parseCheckboxes(get('Application Prerequisites'))
               .includes('Custom Prerequisite (fill in details below)');
             const customName = get('Custom Prerequisite Name');
@@ -259,14 +262,17 @@ jobs:
             });
             for (const e of customPrereq.errors) {
               switch (e.code) {
+                case 'unchecked-with-copy':
+                  errors.push('Custom Prerequisite details are filled in, but the Custom Prerequisite box (under Application Prerequisites) is not checked, so they will not be sent to LFX. Check the box to include this prerequisite, or clear the name and description if you do not want one.');
+                  break;
                 case 'name-missing':
-                  errors.push(`Custom Prerequisite is checked but Custom Prerequisite Name is empty. Add a name (max ${CUSTOM_PREREQ_NAME_MAX} chars), or uncheck Custom Prerequisite.`);
+                  errors.push(`Custom Prerequisite Name is empty. Add a name (max ${CUSTOM_PREREQ_NAME_MAX} chars).`);
                   break;
                 case 'name-too-long':
                   errors.push(`Custom Prerequisite Name is ${e.length} chars (LFX limit is ${e.max}). Please trim ${e.length - e.max} chars.`);
                   break;
                 case 'description-missing':
-                  errors.push(`Custom Prerequisite is checked but Custom Prerequisite Description is empty. Add a description (max ${CUSTOM_PREREQ_DESC_MAX} chars), or uncheck Custom Prerequisite.`);
+                  errors.push(`Custom Prerequisite Description is empty. Add a description (max ${CUSTOM_PREREQ_DESC_MAX} chars).`);
                   break;
                 case 'description-too-long':
                   errors.push(`Custom Prerequisite Description is ${e.length} chars (LFX limit is ${e.max}). Please trim ${e.length - e.max} chars.`);

--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -106,21 +106,32 @@ function mentorCountWarning(result) {
 const CUSTOM_PREREQ_NAME_MAX = 20;
 const CUSTOM_PREREQ_DESC_MAX = 500;
 
-// Validate the custom application prerequisite. The export only sends it to LFX
-// when the "Custom Prerequisite" box is checked (lfx-export.yml keys the export
-// off that box), so the check is gated on `checked`: when checked, the name and
-// description are required and must fit the LFX limits; when unchecked, the
-// fields are ignored by the export and nothing is enforced. name/description are
+// Validate the custom application prerequisite. There is a custom prerequisite
+// to validate when the "Custom Prerequisite" box is checked OR any copy is
+// present; only a fully empty, unchecked prerequisite is skipped. The name and
+// description are required and must fit the LFX limits (name <= 20, description
+// <= 500). Because the export sends the prerequisite to LFX only when the box
+// is checked (lfx-export.yml keys off that box), copy left with the box
+// unchecked would be silently dropped, so that is flagged too. All problems are
+// returned together so the proposer sees every needed edit at once. Fields are
 // trimmed before measuring, matching the trimmed value the export sends.
-// Returns { ok, errors } with codes 'name-missing', 'name-too-long',
-// 'description-missing', 'description-too-long'; the too-long codes carry
-// { length, max }. Prose stays in the workflow, mirroring validateMentors.
+// Returns { ok, errors } with codes 'unchecked-with-copy', 'name-missing',
+// 'name-too-long', 'description-missing', 'description-too-long'; the too-long
+// codes carry { length, max }. Prose stays in the workflow, mirroring
+// validateMentors.
 function validateCustomPrerequisite({ checked, name, description } = {}) {
   const errors = [];
-  if (!checked) return { ok: true, errors };
-
   const n = (name || '').trim();
   const d = (description || '').trim();
+  const hasCopy = n !== '' || d !== '';
+
+  // A fully empty, unchecked prerequisite: nothing to validate.
+  if (!checked && !hasCopy) return { ok: true, errors };
+
+  // Copy filled in but the box unchecked: the export keys off the box, so the
+  // details would be silently dropped. Flag it, then still run the field checks
+  // below so every needed edit is reported in one pass.
+  if (!checked) errors.push({ code: 'unchecked-with-copy' });
 
   if (!n) {
     errors.push({ code: 'name-missing' });

--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -99,6 +99,44 @@ function mentorCountWarning(result) {
   return null;
 }
 
+// LFX caps a custom application prerequisite's name at 20 characters and its
+// description at 500. The proposal form documents these limits but nothing
+// enforced them, so an over-long custom prereq passed validation and only
+// failed later on the LFX platform (see #1954).
+const CUSTOM_PREREQ_NAME_MAX = 20;
+const CUSTOM_PREREQ_DESC_MAX = 500;
+
+// Validate the custom application prerequisite. The export only sends it to LFX
+// when the "Custom Prerequisite" box is checked (lfx-export.yml keys the export
+// off that box), so the check is gated on `checked`: when checked, the name and
+// description are required and must fit the LFX limits; when unchecked, the
+// fields are ignored by the export and nothing is enforced. name/description are
+// trimmed before measuring, matching the trimmed value the export sends.
+// Returns { ok, errors } with codes 'name-missing', 'name-too-long',
+// 'description-missing', 'description-too-long'; the too-long codes carry
+// { length, max }. Prose stays in the workflow, mirroring validateMentors.
+function validateCustomPrerequisite({ checked, name, description } = {}) {
+  const errors = [];
+  if (!checked) return { ok: true, errors };
+
+  const n = (name || '').trim();
+  const d = (description || '').trim();
+
+  if (!n) {
+    errors.push({ code: 'name-missing' });
+  } else if (n.length > CUSTOM_PREREQ_NAME_MAX) {
+    errors.push({ code: 'name-too-long', length: n.length, max: CUSTOM_PREREQ_NAME_MAX });
+  }
+
+  if (!d) {
+    errors.push({ code: 'description-missing' });
+  } else if (d.length > CUSTOM_PREREQ_DESC_MAX) {
+    errors.push({ code: 'description-too-long', length: d.length, max: CUSTOM_PREREQ_DESC_MAX });
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
 module.exports = {
   emailRe,
   urlRe,
@@ -108,4 +146,7 @@ module.exports = {
   validateUpstreamUrl,
   mentorCountWarning,
   MIN_PREFERRED_MENTORS,
+  validateCustomPrerequisite,
+  CUSTOM_PREREQ_NAME_MAX,
+  CUSTOM_PREREQ_DESC_MAX,
 };

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -158,22 +158,35 @@ test('emailRe / ghHandleRe / urlRe: basic accept and reject', () => {
 });
 
 // ── validateCustomPrerequisite ───────────────────────────────────────
-// LFX only receives the custom application prerequisite when the "Custom
-// Prerequisite" box is checked (lfx-export.yml keys the export off that box),
-// and LFX caps the name at 20 chars and the description at 500. So the check is
-// gated on `checked`: when checked, name and description are required and must
-// fit; when unchecked, the fields are ignored by the export and nothing is
-// enforced. Codes: 'name-missing', 'name-too-long', 'description-missing',
-// 'description-too-long'.
+// There is a custom prerequisite to validate when the "Custom Prerequisite"
+// box is checked OR any copy is present; a fully empty, unchecked prerequisite
+// is skipped. Name and description are required and must fit LFX's limits
+// (name <= 20, description <= 500). The export sends the prerequisite only when
+// the box is checked, so copy left with the box unchecked would be silently
+// dropped and is flagged. All problems come back together so the proposer sees
+// every needed edit at once. Codes: 'unchecked-with-copy', 'name-missing',
+// 'name-too-long', 'description-missing', 'description-too-long'.
 
-test('validateCustomPrerequisite: unchecked is always ok, even with over-limit fields', () => {
+test('validateCustomPrerequisite: unchecked with both fields empty is ok (no custom prerequisite)', () => {
   assert.deepEqual(validateCustomPrerequisite({ checked: false, name: '', description: '' }), { ok: true, errors: [] });
-  const over = validateCustomPrerequisite({
-    checked: false,
-    name: 'x'.repeat(50),
-    description: 'y'.repeat(600),
-  });
-  assert.deepEqual(over, { ok: true, errors: [] });
+  // whitespace-only trims to empty, so still no custom prerequisite
+  assert.deepEqual(validateCustomPrerequisite({ checked: false, name: '   ', description: '  ' }), { ok: true, errors: [] });
+});
+
+test('validateCustomPrerequisite: unchecked but copy present flags unchecked-with-copy (would be silently dropped)', () => {
+  // valid-length copy, box unchecked: the only problem is the unchecked box
+  assert.deepEqual(codes(validateCustomPrerequisite({ checked: false, name: 'Writing Sample', description: 'A short writing sample.' })),
+    ['unchecked-with-copy']);
+  // a single filled field is enough copy to count as intent
+  assert.deepEqual(codes(validateCustomPrerequisite({ checked: false, name: 'Writing Sample', description: '' })),
+    ['unchecked-with-copy', 'description-missing']);
+});
+
+test('validateCustomPrerequisite: unchecked reports the box AND every field problem together', () => {
+  // over-limit name + over-limit description + unchecked: all surfaced at once
+  const r = validateCustomPrerequisite({ checked: false, name: 'x'.repeat(50), description: 'y'.repeat(600) });
+  assert.deepEqual(codes(r), ['unchecked-with-copy', 'name-too-long', 'description-too-long']);
+  assert.equal(r.ok, false);
 });
 
 test('validateCustomPrerequisite: checked with a valid name and description passes', () => {

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -6,6 +6,8 @@ const {
   emailRe, urlRe, ghHandleRe, lfidRe,
   validateMentors, validateUpstreamUrl,
   mentorCountWarning, MIN_PREFERRED_MENTORS,
+  validateCustomPrerequisite,
+  CUSTOM_PREREQ_NAME_MAX, CUSTOM_PREREQ_DESC_MAX,
 } = require('../lib/validate');
 
 const codes = (result) => result.errors.map(e => e.code);
@@ -153,4 +155,76 @@ test('emailRe / ghHandleRe / urlRe: basic accept and reject', () => {
   assert.equal(ghHandleRe.test('jane'), false);
   assert.equal(urlRe.test('https://example.com/x'), true);
   assert.equal(urlRe.test('ftp://example.com'), false);
+});
+
+// ── validateCustomPrerequisite ───────────────────────────────────────
+// LFX only receives the custom application prerequisite when the "Custom
+// Prerequisite" box is checked (lfx-export.yml keys the export off that box),
+// and LFX caps the name at 20 chars and the description at 500. So the check is
+// gated on `checked`: when checked, name and description are required and must
+// fit; when unchecked, the fields are ignored by the export and nothing is
+// enforced. Codes: 'name-missing', 'name-too-long', 'description-missing',
+// 'description-too-long'.
+
+test('validateCustomPrerequisite: unchecked is always ok, even with over-limit fields', () => {
+  assert.deepEqual(validateCustomPrerequisite({ checked: false, name: '', description: '' }), { ok: true, errors: [] });
+  const over = validateCustomPrerequisite({
+    checked: false,
+    name: 'x'.repeat(50),
+    description: 'y'.repeat(600),
+  });
+  assert.deepEqual(over, { ok: true, errors: [] });
+});
+
+test('validateCustomPrerequisite: checked with a valid name and description passes', () => {
+  const r = validateCustomPrerequisite({ checked: true, name: 'Writing Sample', description: 'Please share a short writing sample.' });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.errors, []);
+});
+
+test('validateCustomPrerequisite: checked requires a name and a description', () => {
+  assert.deepEqual(codes(validateCustomPrerequisite({ checked: true, name: '', description: '' })),
+    ['name-missing', 'description-missing']);
+  assert.deepEqual(codes(validateCustomPrerequisite({ checked: true, name: '   ', description: 'ok' })),
+    ['name-missing']);
+  assert.deepEqual(codes(validateCustomPrerequisite({ checked: true, name: 'Name', description: '  ' })),
+    ['description-missing']);
+});
+
+test('validateCustomPrerequisite: name over 20 / description over 500 are flagged with lengths', () => {
+  const r = validateCustomPrerequisite({
+    checked: true,
+    name: 'x'.repeat(21),
+    description: 'y'.repeat(501),
+  });
+  assert.deepEqual(codes(r), ['name-too-long', 'description-too-long']);
+  const nameErr = r.errors.find(e => e.code === 'name-too-long');
+  const descErr = r.errors.find(e => e.code === 'description-too-long');
+  assert.deepEqual({ length: nameErr.length, max: nameErr.max }, { length: 21, max: 20 });
+  assert.deepEqual({ length: descErr.length, max: descErr.max }, { length: 501, max: 500 });
+});
+
+test('validateCustomPrerequisite: the limits are inclusive boundaries (20 / 500 pass)', () => {
+  const r = validateCustomPrerequisite({
+    checked: true,
+    name: 'x'.repeat(20),
+    description: 'y'.repeat(500),
+  });
+  assert.equal(r.ok, true);
+});
+
+test('validateCustomPrerequisite: length is measured after trimming (matches the exported value)', () => {
+  // get() trims the field before export, so surrounding whitespace does not
+  // count toward the limit.
+  const r = validateCustomPrerequisite({
+    checked: true,
+    name: '  ' + 'x'.repeat(20) + '  ',
+    description: '  ' + 'y'.repeat(500) + '  ',
+  });
+  assert.equal(r.ok, true);
+});
+
+test('validateCustomPrerequisite: exposes the LFX limits as constants', () => {
+  assert.equal(CUSTOM_PREREQ_NAME_MAX, 20);
+  assert.equal(CUSTOM_PREREQ_DESC_MAX, 500);
 });


### PR DESCRIPTION
Validate the custom application prerequisite so a proposal fails fast in GitHub instead of later on the LFX platform. Prompted by #1954, where an over-limit custom prerequisite passed validation and only broke on LFX.

## Problem

LFX caps a custom prerequisite's name at 20 characters and its description at 500, and only receives the prerequisite when the "Custom Prerequisite" box is checked. None of this was validated: an over-limit custom prerequisite passed, and a name/description filled in with the box left unchecked was silently dropped on export.

## Changes

- `validateCustomPrerequisite` in `lib/validate.js`: there is a prerequisite to validate whenever the box is checked or any copy is present (a fully empty, unchecked one is skipped). Name and description are required and must fit the limits; values are trimmed before measuring, matching what the export sends. Exposes `CUSTOM_PREREQ_NAME_MAX` / `CUSTOM_PREREQ_DESC_MAX`.
- Copy present but box unchecked is flagged (`unchecked-with-copy`), so the export's silent drop is caught, and it is reported alongside any length/presence problems so every needed edit shows up in one validation pass.
- Wire it into the proposal validation workflow as a new check, with messages that state the count and how many characters to trim (mirroring the Program Name and Description checks).

## Testing

- Unit: full suite 454/454 (from 445), covering checked/unchecked, one or both fields, inclusive boundaries, and trimming.
- End-to-end on the dev fork: an over-limit custom prerequisite (checked, then unchecked) fails with the box and both length problems reported together; trimming within limits passes; a fully empty, unchecked prerequisite passes with no custom-prerequisite output.
