### PR TITLE
Note the auto-counted proposer when all mentors are confirmed

### DIFF
--- a/programs/lfx-mentorship/automation/lib/next-steps.js
+++ b/programs/lfx-mentorship/automation/lib/next-steps.js
@@ -45,9 +45,10 @@ function nextSteps({
 
   // 2. Mentor confirmation
   if (mentorsConfirmed) {
-    lines.push(`2. **Mentor confirmation** — ✅ all ${total} confirmed.`);
+    const auto = proposerIsMentor ? `; ${at(proposer)} auto-counted as proposer` : '';
+    lines.push(`2. **Mentor confirmation** — ✅ all ${total} confirmed${auto}.`);
   } else {
-    const auto = proposerIsMentor ? ` (${at(proposer)} auto-counted as proposer)` : '';
+    const auto = proposerIsMentor ? `; ${at(proposer)} auto-counted as proposer` : '';
     lines.push(`2. **Mentor confirmation** — ⏳ ${count} of ${total} confirmed${auto}. Awaiting \`/confirm\` from ${remaining.map(at).join(', ')}.`);
   }
 

--- a/programs/lfx-mentorship/automation/lib/next-steps.js
+++ b/programs/lfx-mentorship/automation/lib/next-steps.js
@@ -44,11 +44,10 @@ function nextSteps({
   }
 
   // 2. Mentor confirmation
+  const auto = proposerIsMentor ? `; ${at(proposer)} auto-counted as proposer` : '';
   if (mentorsConfirmed) {
-    const auto = proposerIsMentor ? `; ${at(proposer)} auto-counted as proposer` : '';
     lines.push(`2. **Mentor confirmation** — ✅ all ${total} confirmed${auto}.`);
   } else {
-    const auto = proposerIsMentor ? `; ${at(proposer)} auto-counted as proposer` : '';
     lines.push(`2. **Mentor confirmation** — ⏳ ${count} of ${total} confirmed${auto}. Awaiting \`/confirm\` from ${remaining.map(at).join(', ')}.`);
   }
 

--- a/programs/lfx-mentorship/automation/test/next-steps.test.js
+++ b/programs/lfx-mentorship/automation/test/next-steps.test.js
@@ -55,10 +55,22 @@ test('proposer who is maintainer and sole mentor sees both gates satisfied but i
     proposerIsMentor: true,
   });
   assert.match(out, /project maintainer/);
-  assert.match(out, /all 1 confirmed/);
+  assert.match(out, /all 1 confirmed; @carlesarnal auto-counted as proposer/);
   assert.match(out, /`\/cncf-approve`/);
   assert.doesNotMatch(out, /Awaiting `\/confirm`/);
   assert.doesNotMatch(out, /Nothing more/i);
+});
+
+// ── All mentors confirmed, but the proposer is NOT one of them → no note ──
+test('all mentors confirmed with a proposer who is not a mentor shows no auto-count note', () => {
+  const out = render({
+    proposer: 'outsider',
+    maintainerApproved: true, maintainerAutoApproved: false,
+    confirm: { count: 2, total: 2, remaining: [] },
+    proposerIsMentor: false,
+  });
+  assert.match(out, /all 2 confirmed\./);
+  assert.doesNotMatch(out, /auto-counted/);
 });
 
 // ── Proposer is NOT a mentor → no auto-count note ──


### PR DESCRIPTION
The "all N confirmed" next-steps line omitted the "auto-counted as proposer" note that the partial-tally and maintainer lines carry, so a lone proposer-mentor was not told why their slot was satisfied. Add the note to the all-confirmed branch and normalize both mentor branches to the maintainer line's "; ..." style (no parentheses). Pure lib change, fully unit-tested (455/455); no workflow wiring change.