### PR TITLE
feat(lfx): pin the LFX program link into the proposal issue body

### DIFF
--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -51,7 +51,7 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
-            const { lfxUrlDecision, recordedLfxUrlComment, readExports, locateExportedProgram, exportTermLabel, termMismatchWarning, renderRecordedIssues, recordedUrlNextSteps, changedRecordedPrograms, programCountLabel, populateRecordedUrls } = _lib('lfx-url.js');
+            const { lfxUrlDecision, recordedLfxUrlComment, readExports, locateExportedProgram, exportTermLabel, termMismatchWarning, renderRecordedIssues, recordedUrlNextSteps, changedRecordedPrograms, programCountLabel, populateRecordedUrls, upsertLfxUrlBlock } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
@@ -429,7 +429,7 @@ jobs:
                   `Merge the term's export PR, then re-run: \`/lfx-url ${decision.url}\``);
                 return;
               }
-              const { dir, year, termDir, term, data } = located;
+              const { dir, year, termDir, term, data, prog } = located;
               const { readmeTitle } = termPaths(term);
               const jsonPath = `${dir}/lfx-export.json`;
 
@@ -446,6 +446,27 @@ jobs:
                 (mismatch ? `\n\n${mismatch}` : '') +
                 `\n\n${recordedUrlNextSteps()}`);
               core.exportVariable('LFX_URL_POSTED', 'true');
+
+              // Also pin the LFX program link into the issue body. The recorded
+              // comment above folds in a long thread, but the OP body never
+              // does, so the admin can always find the URL at the top of the
+              // issue. A human-facing convenience only; the comment stays the
+              // export's source of truth. The edit runs on GITHUB_TOKEN, so it
+              // does not re-trigger validation (no-cascade), and the block is not
+              // a form field, so it never resets approvals. Best-effort: a
+              // failure here must not fail an otherwise-successful command.
+              try {
+                const current = await github.rest.issues.get({ owner, repo, issue_number });
+                const newBody = upsertLfxUrlBlock(current.data.body || '', {
+                  title: prog && prog.program_name_full,
+                  url: decision.url,
+                });
+                if (newBody !== (current.data.body || '')) {
+                  await github.rest.issues.update({ owner, repo, issue_number, body: newBody });
+                }
+              } catch (e) {
+                console.log(`Could not pin the LFX URL into the issue body: ${e.message}`);
+              }
 
               // Rebuild the term's files from the durable source of truth: fill
               // every program's URL from its issue's recorded-URL comment, not

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -451,11 +451,12 @@ jobs:
               // comment above folds in a long thread, but the OP body never
               // does, so the admin can always find the URL at the bottom of the
               // issue (under a horizontal rule). A human-facing convenience only;
-              // the comment stays the
-              // export's source of truth. The edit runs on GITHUB_TOKEN, so it
-              // does not re-trigger validation (no-cascade), and the block is not
-              // a form field, so it never resets approvals. Best-effort: a
-              // failure here must not fail an otherwise-successful command.
+              // the comment stays the export's source of truth. Safe against the
+              // approval-reset path: parseIssueForm strips this marker-delimited
+              // block (lib/parse.js), so it is never seen as a form field or a
+              // material edit; and the edit runs on GITHUB_TOKEN, which does not
+              // re-trigger validation (no-cascade) anyway. Best-effort: a failure
+              // here must not fail an otherwise-successful command.
               try {
                 const current = await github.rest.issues.get({ owner, repo, issue_number });
                 const newBody = upsertLfxUrlBlock(current.data.body || '', {

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -449,8 +449,9 @@ jobs:
 
               // Also pin the LFX program link into the issue body. The recorded
               // comment above folds in a long thread, but the OP body never
-              // does, so the admin can always find the URL at the top of the
-              // issue. A human-facing convenience only; the comment stays the
+              // does, so the admin can always find the URL at the bottom of the
+              // issue (under a horizontal rule). A human-facing convenience only;
+              // the comment stays the
               // export's source of truth. The edit runs on GITHUB_TOKEN, so it
               // does not re-trigger validation (no-cascade), and the block is not
               // a form field, so it never resets approvals. Best-effort: a

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -253,11 +253,61 @@ async function populateRecordedUrls(programs, { currentIssue, currentUrl, fetchC
   return programs;
 }
 
+// ── Pin the LFX program link into the issue body ────────────────────────────
+// The recorded-URL comment above is the export's durable source of truth, but
+// it folds in a long thread; the OP body never folds. So /lfx-url also splices
+// this machine-delimited block at the bottom of the issue, under a horizontal
+// rule (mirroring the validation comment's separator). The markers make it
+// idempotent: re-running replaces the block in place instead of stacking copies.
+const LFX_URL_BLOCK_START = '<!-- lfx-url:start -->';
+const LFX_URL_BLOCK_END = '<!-- lfx-url:end -->';
+const LFX_URL_BLOCK_RE = /<!-- lfx-url:start -->[\s\S]*?<!-- lfx-url:end -->/;
+
+// Make an untrusted program title safe as Markdown link text on GitHub. The
+// Program Name is free-text (the @/backtick injection noted on #136), and this
+// now lands in the prominent issue body, so: HTML-escape (&<>), backslash-escape
+// the characters that would break the [label](url) structure (\ ` [ ]), and
+// neutralize @/# so a crafted name can't inject a mention or issue ref. The '#'
+// pass runs before '@' so the '#' inside the generated '&#64;' entity is left
+// alone. URLs are validated upstream (LFX_PROGRAM_URL_RE), so only the label
+// needs escaping.
+function escapeLinkLabel(s) {
+  return String(s == null ? '' : s)
+    .replace(/\s+/g, ' ').trim()
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/([\\`\[\]])/g, '\\$1')
+    .replace(/#/g, '&#35;')
+    .replace(/@/g, '&#64;');
+}
+
+// The body block for a program title + URL, under a horizontal rule so it is
+// visually separated from the proposal above. Falls back to a generic label
+// when the title is empty so the link is never rendered as an empty [](url).
+function lfxUrlBlock({ title, url } = {}) {
+  const label = escapeLinkLabel(title) || 'LFX program';
+  return `${LFX_URL_BLOCK_START}\n\n---\n**LFX program:** [${label}](${url})\n${LFX_URL_BLOCK_END}`;
+}
+
+// Insert or update the LFX-URL block in an issue body. Idempotent: if the block
+// is already present it is replaced in place (position preserved); otherwise it
+// is appended at the bottom, under a horizontal rule, so the link sits at the
+// end of the issue where the OP body never folds. Trailing whitespace is
+// trimmed first so the separator spacing is stable across re-runs.
+function upsertLfxUrlBlock(body, { title, url } = {}) {
+  const b = String(body == null ? '' : body);
+  const block = lfxUrlBlock({ title, url });
+  if (LFX_URL_BLOCK_RE.test(b)) return b.replace(LFX_URL_BLOCK_RE, block);
+  const trimmed = b.replace(/\s+$/, '');
+  return trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;
+}
+
 module.exports = {
   recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision,
   findExportedProgram, exportTermLabel, readExports, locateExportedProgram,
   termMismatchWarning, recordedPrograms, renderRecordedIssues, recordedUrlNextSteps,
   changedRecordedPrograms, programCountLabel,
-  populateRecordedUrls,
+  populateRecordedUrls, upsertLfxUrlBlock,
   LFX_PROGRAM_URL_RE,
 };

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -303,11 +303,20 @@ function upsertLfxUrlBlock(body, { title, url } = {}) {
   return trimmed ? `${trimmed}\n\n${block}\n` : `${block}\n`;
 }
 
+// Remove the LFX-URL block (and the blank line separating it from the content
+// above) from an issue body. parseIssueForm calls this so the appended block
+// never leaks into the last form field, and so gaining the block never reads as
+// a material edit. Leaves a body with no block untouched.
+function stripLfxUrlBlock(body) {
+  return String(body == null ? '' : body)
+    .replace(/\s*<!-- lfx-url:start -->[\s\S]*?<!-- lfx-url:end -->/, '');
+}
+
 module.exports = {
   recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision,
   findExportedProgram, exportTermLabel, readExports, locateExportedProgram,
   termMismatchWarning, recordedPrograms, renderRecordedIssues, recordedUrlNextSteps,
   changedRecordedPrograms, programCountLabel,
-  populateRecordedUrls, upsertLfxUrlBlock,
+  populateRecordedUrls, upsertLfxUrlBlock, stripLfxUrlBlock,
   LFX_PROGRAM_URL_RE,
 };

--- a/programs/lfx-mentorship/automation/lib/parse.js
+++ b/programs/lfx-mentorship/automation/lib/parse.js
@@ -9,11 +9,17 @@
 //   - parseCheckboxes: lfx-export.yml
 //   - parseMentors:    lfx-export.yml
 
+// The /lfx-url bot appends a marker-delimited "LFX program" block to the issue
+// body (lib/lfx-url.js). Strip it before parsing so it never leaks into the last
+// form field or reads as a material edit. lfx-url.js requires nothing, so this
+// leaf-to-leaf dependency introduces no cycle.
+const { stripLfxUrlBlock } = require('./lfx-url');
+
 // Split a GitHub issue-form body into a { label: value } map. Sections are
 // delimited by "### <label>" headings; "_No response_" is normalised to ''.
 function parseIssueForm(body) {
   const fields = {};
-  for (const section of body.split(/^### +/m).slice(1)) {
+  for (const section of stripLfxUrlBlock(body).split(/^### +/m).slice(1)) {
     const nl = section.indexOf('\n');
     if (nl === -1) continue;
     const label = section.slice(0, nl).trim();

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -6,7 +6,7 @@ const {
   recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, findExportedProgram,
   exportTermLabel, readExports, locateExportedProgram, termMismatchWarning,
   recordedPrograms, renderRecordedIssues, recordedUrlNextSteps, populateRecordedUrls,
-  changedRecordedPrograms, programCountLabel,
+  changedRecordedPrograms, programCountLabel, upsertLfxUrlBlock,
 } = require('../lib/lfx-url');
 
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
@@ -545,4 +545,58 @@ test('populateRecordedUrls: skips entries without a numeric issue_number (no fet
   });
   assert.equal(programs[2].lfx_url, `${PROJ}/aaaaaaaa-0000-4000-8000-000000000007`);
   assert.deepEqual(fetched, [], 'no fetch for malformed entries; current issue set directly');
+});
+
+// ── upsertLfxUrlBlock: pin the LFX program link into the issue body ──────────
+// The recorded-URL comment folds in a long thread; the OP body never does. This
+// splices an idempotent, machine-delimited block carrying a linked program
+// title. The recorded-URL comment stays the export's source of truth; this is a
+// human-facing convenience.
+
+test('upsertLfxUrlBlock: adds a rule-separated linked-title block to an empty body', () => {
+  const out = upsertLfxUrlBlock('', { title: 'CNCF - kubernetes: Foo (2026 Term 3)', url: LFX });
+  assert.equal(
+    out,
+    `<!-- lfx-url:start -->\n\n---\n**LFX program:** [CNCF - kubernetes: Foo (2026 Term 3)](${LFX})\n<!-- lfx-url:end -->\n`
+  );
+});
+
+test('upsertLfxUrlBlock: appends the block below existing body content, rule-separated', () => {
+  const body = '### CNCF Project\n\nkubernetes\n\n### Term\n\n2026 Term 3 (Sep-Nov)';
+  const out = upsertLfxUrlBlock(body, { title: 'T', url: LFX });
+  assert.ok(out.startsWith(`${body}\n\n`), 'original body preserved verbatim at the top');
+  assert.ok(
+    out.endsWith(`<!-- lfx-url:start -->\n\n---\n**LFX program:** [T](${LFX})\n<!-- lfx-url:end -->\n`),
+    'block appended at the bottom under a rule'
+  );
+});
+
+test('upsertLfxUrlBlock: is idempotent — same URL does not duplicate', () => {
+  const once = upsertLfxUrlBlock('proposal text', { title: 'T', url: LFX });
+  const twice = upsertLfxUrlBlock(once, { title: 'T', url: LFX });
+  assert.equal(twice, once);
+  assert.equal((twice.match(/<!-- lfx-url:start -->/g) || []).length, 1);
+});
+
+test('upsertLfxUrlBlock: updates the URL/title in place, no move, no duplicate', () => {
+  const first = upsertLfxUrlBlock('proposal text', { title: 'T', url: LFX });
+  const updated = upsertLfxUrlBlock(first, { title: 'T2', url: LFX2 });
+  assert.equal((updated.match(/<!-- lfx-url:start -->/g) || []).length, 1);
+  assert.ok(updated.includes(`**LFX program:** [T2](${LFX2})`));
+  assert.ok(!updated.includes(LFX), 'old URL removed');
+  assert.ok(updated.startsWith('proposal text'), 'body preserved at the top');
+});
+
+test('upsertLfxUrlBlock: escapes/neutralizes untrusted title characters', () => {
+  const mk = (title) => upsertLfxUrlBlock('', { title, url: LFX });
+  assert.ok(mk('A [b] c').includes('[A \\[b\\] c]('), 'square brackets escaped');
+  assert.ok(mk('a\\b').includes('[a\\\\b]('), 'backslash escaped');
+  assert.ok(mk('a`b`c').includes('[a\\`b\\`c]('), 'backtick escaped');
+  assert.ok(mk('x<y>&z').includes('[x&lt;y&gt;&amp;z]('), 'HTML escaped');
+  assert.ok(mk('@foo #12').includes('[&#64;foo &#35;12]('), 'mention/ref neutralized');
+});
+
+test('upsertLfxUrlBlock: collapses whitespace and falls back when title is empty', () => {
+  assert.ok(upsertLfxUrlBlock('', { title: 'a\n b\t c', url: LFX }).includes('[a b c]('));
+  assert.ok(upsertLfxUrlBlock('body', { title: '', url: LFX }).includes(`**LFX program:** [LFX program](${LFX})`));
 });

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -6,7 +6,7 @@ const {
   recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision, findExportedProgram,
   exportTermLabel, readExports, locateExportedProgram, termMismatchWarning,
   recordedPrograms, renderRecordedIssues, recordedUrlNextSteps, populateRecordedUrls,
-  changedRecordedPrograms, programCountLabel, upsertLfxUrlBlock,
+  changedRecordedPrograms, programCountLabel, upsertLfxUrlBlock, stripLfxUrlBlock,
 } = require('../lib/lfx-url');
 
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
@@ -599,4 +599,16 @@ test('upsertLfxUrlBlock: escapes/neutralizes untrusted title characters', () => 
 test('upsertLfxUrlBlock: collapses whitespace and falls back when title is empty', () => {
   assert.ok(upsertLfxUrlBlock('', { title: 'a\n b\t c', url: LFX }).includes('[a b c]('));
   assert.ok(upsertLfxUrlBlock('body', { title: '', url: LFX }).includes(`**LFX program:** [LFX program](${LFX})`));
+});
+
+test('stripLfxUrlBlock: removes the block and its separating whitespace', () => {
+  const body = '### CNCF Project\n\nkubernetes';
+  const withBlock = upsertLfxUrlBlock(body, { title: 'T', url: LFX });
+  assert.equal(stripLfxUrlBlock(withBlock).trimEnd(), body);
+});
+
+test('stripLfxUrlBlock: is a no-op when there is no block', () => {
+  const body = '### CNCF Project\n\nkubernetes';
+  assert.equal(stripLfxUrlBlock(body), body);
+  assert.equal(stripLfxUrlBlock(''), '');
 });

--- a/programs/lfx-mentorship/automation/test/parse.test.js
+++ b/programs/lfx-mentorship/automation/test/parse.test.js
@@ -127,3 +127,22 @@ test('formFieldsChanged: internal whitespace reflow/indent is not material', () 
   const v2 = bodyV1.replace('Do cool things.', 'Do    cool\n   things.');
   assert.equal(formFieldsChanged(bodyV1, v2), false);
 });
+
+// The /lfx-url bot appends a marker-delimited "LFX program" block to the issue
+// body (lib/lfx-url.js). parseIssueForm must ignore it so it never leaks into
+// the last form field, and so a body that gains the block is not seen as a
+// material edit (which would otherwise reset approvals).
+const { upsertLfxUrlBlock } = require('../lib/lfx-url');
+const A_LFX_URL = 'https://mentorship.lfx.linuxfoundation.org/project/005db8db-7efe-4433-9605-91d14174c72c';
+
+test('parseIssueForm: ignores an appended /lfx-url block (last field not polluted)', () => {
+  const body = '### CNCF Project\n\nKubernetes\n\n### Upstream Issue URL\n\nhttps://example.test/1';
+  const withBlock = upsertLfxUrlBlock(body, { title: 'CNCF - Kubernetes: X (2026 Term 3)', url: A_LFX_URL });
+  assert.equal(parseIssueForm(withBlock)['Upstream Issue URL'], 'https://example.test/1');
+});
+
+test('formFieldsChanged: adding the /lfx-url block is not a material edit', () => {
+  const body = '### CNCF Project\n\nKubernetes\n\n### Upstream Issue URL\n\nhttps://example.test/1';
+  const withBlock = upsertLfxUrlBlock(body, { title: 'CNCF - Kubernetes: X (2026 Term 3)', url: A_LFX_URL });
+  assert.equal(formFieldsChanged(body, withBlock), false);
+});


### PR DESCRIPTION
When `/lfx-url` records a program URL, also pin it into the proposal issue body so it stays visible: comments fold in a long thread, but the OP body never does.

- `upsertLfxUrlBlock` (`lib/lfx-url.js`): an idempotent, marker-delimited block appended at the bottom under a horizontal rule, carrying the program title as a safe Markdown link (HTML-escaped; link-breaking chars and `@`/`#` neutralized). Replaced in place on re-run.
- Wired into the `/lfx-url` handler: best-effort body update on `GITHUB_TOKEN`, behind a body-changed guard. The recorded-URL comment stays the export's source of truth.
- `parseIssueForm` strips the block (`lib/parse.js`), so it never leaks into a form field or reads as a material edit.

Tests: 465/465 (TDD). Dev e2e passed: the block lands at the bottom under the rule with the linked title, original content preserved, and a second `/lfx-url` updates it in place.