### PR TITLE
feat(lfx): per-project exclusive approvers (Kubernetes: SIG ContribEx only)

### DIFF
--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -49,7 +49,7 @@ jobs:
             const { resolveProjectMaintainer } = _lib('authorize.js');
             const { computeConfirm } = _lib('confirm.js');
             const { lookupProject } = _lib('projects.js');
-            const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams, maintainersCanApprove, projectKeys } = _lib('approvers.js');
+            const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams, maintainersCanApprove, buildProjectKeys } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
             const { lfxUrlDecision, recordedLfxUrlComment, readExports, locateExportedProgram, exportTermLabel, termMismatchWarning, renderRecordedIssues, recordedUrlNextSteps, changedRecordedPrograms, programCountLabel, populateRecordedUrls, upsertLfxUrlBlock } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
@@ -182,7 +182,7 @@ jobs:
               try {
                 approversRaw = fs.readFileSync('programs/lfx-mentorship/automation/approvers.yml', 'utf8');
                 if (project) {
-                  projectSection = getProjectSection(approversRaw, projectKeys({ project, org: ghOrg, slug: projectSlug }));
+                  projectSection = getProjectSection(approversRaw, buildProjectKeys({ project, org: ghOrg, slug: projectSlug }));
                 }
               } catch (e) {
                 console.log(`approvers.yml read failed: ${e.message}`);

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -256,15 +256,25 @@ jobs:
               }
 
               if (!authorized) {
-                const orgNote = ghOrg
-                  ? `- A \`project-maintainers\` team member in [\`${ghOrg}/.project/maintainers.yaml\`](https://github.com/${ghOrg}/.project/blob/main/maintainers.yaml)\n`
-                  : '';
+                let paths;
+                if (maintainersOk) {
+                  const orgNote = ghOrg
+                    ? `- A \`project-maintainers\` team member in [\`${ghOrg}/.project/maintainers.yaml\`](https://github.com/${ghOrg}/.project/blob/main/maintainers.yaml)\n`
+                    : '';
+                  paths =
+                    `Approvers must be:\n` +
+                    orgNote +
+                    `- Listed in [project-maintainers.csv](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)\n` +
+                    `- A fallback approver in \`approvers.yml\``;
+                } else {
+                  paths =
+                    `Approvals for **${project}** are limited to its listed approvers in ` +
+                    `\`approvers.yml\` (plus CNCF global approvers); project maintainers ` +
+                    `can't \`/approve\` here.`;
+                }
                 await reply('❌',
                   `@${commenter} is not authorized to \`/approve\` proposals for **${project}**.\n\n` +
-                  `Approvers must be:\n` +
-                  orgNote +
-                  `- Listed in [project-maintainers.csv](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)\n` +
-                  `- A fallback approver in \`approvers.yml\`\n\n` +
+                  paths + `\n\n` +
                   `If this is an error, contact a CNCF program admin.`);
                 return;
               }

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -49,7 +49,7 @@ jobs:
             const { resolveProjectMaintainer } = _lib('authorize.js');
             const { computeConfirm } = _lib('confirm.js');
             const { lookupProject } = _lib('projects.js');
-            const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams } = _lib('approvers.js');
+            const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams, maintainersCanApprove, projectKeys } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
             const { lfxUrlDecision, recordedLfxUrlComment, readExports, locateExportedProgram, exportTermLabel, termMismatchWarning, renderRecordedIssues, recordedUrlNextSteps, changedRecordedPrograms, programCountLabel, populateRecordedUrls, upsertLfxUrlBlock } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
@@ -171,13 +171,33 @@ jobs:
                 }
               }
 
+              // Read approvers.yml once, up front: it supplies both the tier-3
+              // fallback section below and the project's exclusive-approver flag.
+              // maintainers_can_approve: false makes a project's fallback
+              // handles/teams (plus global_approvers) the ONLY approvers and
+              // skips the maintainer rosters (tiers 1-2) below. Default true
+              // keeps the additive model; a read failure also defaults to true.
+              let approversRaw = '';
+              let projectSection = '';
+              try {
+                approversRaw = fs.readFileSync('programs/lfx-mentorship/automation/approvers.yml', 'utf8');
+                if (project) {
+                  projectSection = getProjectSection(approversRaw, projectKeys({ project, org: ghOrg, slug: projectSlug }));
+                }
+              } catch (e) {
+                console.log(`approvers.yml read failed: ${e.message}`);
+              }
+              const maintainersOk = maintainersCanApprove(projectSection);
+
               // 1-2. Project-maintainer rosters: {org}/.project/maintainers.yaml
               // (when adopted), then cncf/foundation project-maintainers.csv.
               // Extracted to lib/authorize.js so the same "is @handle a project
               // maintainer?" decision also drives proposer-implied approval in
-              // the validation workflow. Tier-3 (approvers.yml) stays inline
-              // below — delegates/global approvers are not project maintainers.
-              if (!authorized) {
+              // the validation workflow. Skipped when maintainers_can_approve is
+              // false (the exclusive-approver projects, e.g. Kubernetes). Tier-3
+              // (approvers.yml) stays inline below; delegates and global
+              // approvers are not project maintainers.
+              if (!authorized && maintainersOk) {
                 const r = await resolveProjectMaintainer({
                   handle: commenter, project, org: ghOrg, hasDotProject,
                   fetchFn: fetch, log: (m) => console.log(m),
@@ -188,47 +208,36 @@ jobs:
                 }
               }
 
-              // 3. Check approvers.yml: per-project fallbacks then global_approvers
+              // 3. Check approvers.yml: per-project fallbacks then global_approvers.
+              // (approvers.yml and the project section were read once, above.)
               if (!authorized) {
                 try {
-                  const raw = fs.readFileSync('programs/lfx-mentorship/automation/approvers.yml', 'utf8');
-
                   // 3a. Per-project fallback handles and teams
-                  if (project) {
-                    // approvers.yml may key a project by its normalized name, its
-                    // GitHub org, or its projects.yml slug; try each, first match wins.
-                    const projectKeys = [
-                      project.toLowerCase().replace(/\s+/g, '-'),
-                      ghOrg.toLowerCase(),
-                      projectSlug,
-                    ].filter((v, i, a) => v && a.indexOf(v) === i);
-                    const section = getProjectSection(raw, projectKeys);
-                    if (section) {
-                      // Check fallback_handles
-                      if (getFallbackHandles(section).includes(commenter.toLowerCase())) {
-                        authorized = true;
-                        authSource = 'approvers.yml (fallback handle)';
-                      }
-                      // Check fallback_teams
-                      if (!authorized) {
-                        for (const team of getFallbackTeams(section)) {
-                          const [org, slug] = team.split('/');
-                          if (!org || !slug) continue;
-                          try {
-                            const { data } = await github.rest.teams.getMembershipForUserInOrg({
-                              org, team_slug: slug, username: commenter,
-                            });
-                            if (data.state === 'active') {
-                              authorized = true;
-                              authSource = `approvers.yml (team ${team})`;
-                              break;
-                            }
-                          } catch (e) {
-                            // Likely a cross-org team: the repo token can't read
-                            // membership outside this org, so the team authorizes
-                            // no one. Use fallback_handles for cross-org approvers.
-                            console.log(`Could not verify team ${team} for ${commenter}: ${e.message}`);
+                  if (projectSection) {
+                    // Check fallback_handles
+                    if (getFallbackHandles(projectSection).includes(commenter.toLowerCase())) {
+                      authorized = true;
+                      authSource = 'approvers.yml (fallback handle)';
+                    }
+                    // Check fallback_teams
+                    if (!authorized) {
+                      for (const team of getFallbackTeams(projectSection)) {
+                        const [org, slug] = team.split('/');
+                        if (!org || !slug) continue;
+                        try {
+                          const { data } = await github.rest.teams.getMembershipForUserInOrg({
+                            org, team_slug: slug, username: commenter,
+                          });
+                          if (data.state === 'active') {
+                            authorized = true;
+                            authSource = `approvers.yml (team ${team})`;
+                            break;
                           }
+                        } catch (e) {
+                          // Likely a cross-org team: the repo token can't read
+                          // membership outside this org, so the team authorizes
+                          // no one. Use fallback_handles for cross-org approvers.
+                          console.log(`Could not verify team ${team} for ${commenter}: ${e.message}`);
                         }
                       }
                     }
@@ -236,7 +245,7 @@ jobs:
 
                   // 3b. Global approvers: can /approve for any project
                   if (!authorized) {
-                    if (getGlobalApprovers(raw).includes(commenter.toLowerCase())) {
+                    if (getGlobalApprovers(approversRaw).includes(commenter.toLowerCase())) {
                       authorized = true;
                       authSource = 'approvers.yml (global approver)';
                     }

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -77,6 +77,7 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { isProposalTitle, looksLikeProposalForm } = _lib('labels.js');
             const { resolveProjectMaintainer } = _lib('authorize.js');
+            const { getProjectSection, maintainersCanApprove, projectKeys } = _lib('approvers.js');
             const { computeConfirm } = _lib('confirm.js');
             const { gateLabelChanges } = _lib('gates.js');
             const { findRecordedApprovers } = _lib('approvals.js');
@@ -408,13 +409,29 @@ jobs:
                 try {
                   const projYaml = fs.readFileSync('programs/lfx-mentorship/automation/projects.yml', 'utf8');
                   const info = lookupProject(projYaml, project) || {};
-                  const r = await resolveProjectMaintainer({
-                    handle: proposer, project, org: info.org, hasDotProject: info.hasDotProject,
-                    fetchFn: fetch, log: (m) => console.log(m),
-                  });
-                  if (r.authorized) {
-                    maintainerApproved = true;
-                    maintainerAutoApproved = true;
+                  // Skip proposer-implied approval when the project restricts
+                  // approvals to its listed approvers (maintainers_can_approve:
+                  // false): a maintainer-proposer must still receive an explicit
+                  // /approve from a listed approver (e.g. Kubernetes routes
+                  // approvals through SIG ContribEx). Default true; a read
+                  // failure keeps the additive behavior.
+                  let maintainersOk = true;
+                  try {
+                    const approversRaw = fs.readFileSync('programs/lfx-mentorship/automation/approvers.yml', 'utf8');
+                    const keys = projectKeys({ project, org: info.org, slug: info.slug });
+                    maintainersOk = maintainersCanApprove(getProjectSection(approversRaw, keys));
+                  } catch (e) {
+                    console.log(`approvers.yml read failed: ${e.message}`);
+                  }
+                  if (maintainersOk) {
+                    const r = await resolveProjectMaintainer({
+                      handle: proposer, project, org: info.org, hasDotProject: info.hasDotProject,
+                      fetchFn: fetch, log: (m) => console.log(m),
+                    });
+                    if (r.authorized) {
+                      maintainerApproved = true;
+                      maintainerAutoApproved = true;
+                    }
                   }
                 } catch (e) {
                   console.log(`proposer maintainer check failed: ${e.message}`);

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -77,7 +77,7 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { isProposalTitle, looksLikeProposalForm } = _lib('labels.js');
             const { resolveProjectMaintainer } = _lib('authorize.js');
-            const { getProjectSection, maintainersCanApprove, projectKeys } = _lib('approvers.js');
+            const { getProjectSection, maintainersCanApprove, buildProjectKeys } = _lib('approvers.js');
             const { computeConfirm } = _lib('confirm.js');
             const { gateLabelChanges } = _lib('gates.js');
             const { findRecordedApprovers } = _lib('approvals.js');
@@ -418,7 +418,7 @@ jobs:
                   let maintainersOk = true;
                   try {
                     const approversRaw = fs.readFileSync('programs/lfx-mentorship/automation/approvers.yml', 'utf8');
-                    const keys = projectKeys({ project, org: info.org, slug: info.slug });
+                    const keys = buildProjectKeys({ project, org: info.org, slug: info.slug });
                     maintainersOk = maintainersCanApprove(getProjectSection(approversRaw, keys));
                   } catch (e) {
                     console.log(`approvers.yml read failed: ${e.message}`);

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -306,8 +306,14 @@ authorization check order is:
 
 1. `{org}/.project/maintainers.yaml` — project-maintainers team membership
 2. `cncf/foundation/project-maintainers.csv` — maintainer CSV lookup
-3. Per-project `fallback_teams` and `fallback_handles` in this file
+3. Per-project `fallback_handles` in this file
 4. `global_approvers` in this file
+
+Tiers 1-2 are the project's **maintainer rosters**; tiers 3-4 are the **listed
+approvers** in this file. By default they are additive. A project can set
+`maintainers_can_approve: false` to skip tiers 1-2, making its listed approvers
+plus `global_approvers` the exclusive set (see [Exclusive
+approvers](#exclusive-approvers)).
 
 **Global approvers** can `/approve` for any project and use `/cncf-approve` and
 `/lfx-url`.
@@ -316,19 +322,29 @@ authorization check order is:
 captured in the maintainers CSV:
 
 ```yaml
-kubernetes:
-  fallback_teams:
-    - kubernetes/sig-contribex
+open-telemetry:
   fallback_handles:
-    - some-delegate
+    - <delegate-handle>
 ```
 
-> **Note:** `fallback_teams` can only be verified for teams in the **cncf**
-> org. The workflow token cannot read team membership in other orgs (for
-> example `kubernetes` or `open-telemetry`), so a cross-org team authorizes no
-> one and fails silently. Use `fallback_handles` for cross-org delegates;
-> maintainers of those projects are still covered by the `.project` and
-> maintainers-CSV tiers above.
+#### Exclusive approvers
+
+By default the tiers are **additive**: a project's maintainers, its listed
+`fallback_handles`, and `global_approvers` can all `/approve`.
+Set `maintainers_can_approve: false` on a project to skip the maintainer rosters
+(tiers 1-2), so that **only** its listed approvers plus `global_approvers` can
+`/approve`. This also stops a maintainer-proposer from being auto-approved for
+filing their own proposal.
+
+```yaml
+kubernetes:
+  maintainers_can_approve: false   # only the approvers below (+ global_approvers)
+  fallback_handles:
+    - <sig-contribex-lead>         # the leads who /approve; see approvers.yml
+```
+
+Kubernetes uses this: mentorship approvals run through SIG Contributor
+Experience, not individual project maintainers.
 
 The key can be the project's **GitHub org** (recommended, e.g. `open-telemetry`),
 its **name** lowercased with spaces replaced by hyphens (e.g. `opentelemetry`), or

--- a/programs/lfx-mentorship/automation/approvers.yml
+++ b/programs/lfx-mentorship/automation/approvers.yml
@@ -14,12 +14,11 @@
 #   <project-key>:                # match by GitHub org (e.g. open-telemetry), the
 #                                 # lowercased/hyphenated name, or the projects.yml
 #                                 # slug; any of the three works.
-#     fallback_teams:             # GitHub teams (org/team) whose members may /approve
-#       - org/team-name           # NOTE: only teams in this repo's org (cncf) can be
-#                                 # verified. The workflow token cannot read team
-#                                 # membership in other orgs, so cross-org teams
-#                                 # silently authorize no one. Use fallback_handles
-#                                 # for cross-org approvers.
+#     fallback_teams:             # DEPRECATED, practically dead (slated for removal):
+#       - org/team-name           # only cncf-org teams resolve (the token can't read
+#                                 # cross-org membership), and there are no CNCF-org
+#                                 # mentor/maintainer teams, so global_approvers already
+#                                 # covers that case. Use fallback_handles instead.
 #     fallback_handles:           # individual GitHub handles (works for any org)
 #       - username
 
@@ -29,19 +28,17 @@ global_approvers:
   - idvoretskyi
   - Swil78
 
-# NOTE: kubernetes/sig-contribex and open-telemetry/governance-committee are
-# cross-org teams. The repo token cannot read their membership, so these
-# fallback_teams entries are effectively inert. Maintainers of these projects
-# are still authorized via tiers 1-2 (.project/maintainers.yaml and the
-# project-maintainers CSV). Add fallback_handles below for a guaranteed
-# per-person override.
 kubernetes:
   # Kubernetes mentorship approvals run through SIG Contributor Experience
   # (SIG ContribEx). The sig-contribex team is cross-org (token can't read it), so
   # current SIG ContribEx leads are listed individually. Source: kubernetes/community
   # sig-contributor-experience leadership.
-  fallback_teams:
-    - kubernetes/sig-contribex
+  #
+  # Exclusive approvers: skip the project-maintainer rosters (the maintainers.yaml
+  # and project-maintainers.csv tiers) so only the handles below plus
+  # global_approvers can /approve. Kubernetes mentorship decisions are steering/
+  # SIG-driven, not per-maintainer.
+  maintainers_can_approve: false
   fallback_handles:
     - kaslin
     - mfahlandt
@@ -57,8 +54,6 @@ open-telemetry:
   # The governance-committee team is cross-org (token can't read it), so GC
   # members are listed individually. Roster (prune as terms end):
   #   https://github.com/open-telemetry/community/blob/main/community-members.md
-  fallback_teams:
-    - open-telemetry/governance-committee
   fallback_handles:
     - alolita
     - austinlparker

--- a/programs/lfx-mentorship/automation/lib/approvers.js
+++ b/programs/lfx-mentorship/automation/lib/approvers.js
@@ -54,10 +54,12 @@ function getFallbackTeams(section) {
 // (plus global_approvers) the EXCLUSIVE approver set, so its individual
 // maintainer rosters are skipped (e.g. Kubernetes routes approvals through SIG
 // ContribEx, not per-maintainer). Only an explicit `false` disables it; a
-// missing, commented, or malformed value keeps the default true.
+// missing, commented, or malformed value keeps the default true. The value must
+// be a bare boolean token (optionally followed by whitespace or a # comment to
+// end of line); trailing junk like `false-positive` is malformed, not false.
 function maintainersCanApprove(section) {
   const m = String(section == null ? '' : section)
-    .match(/^\s*maintainers_can_approve:\s*(true|false)\b/im);
+    .match(/^[ \t]*maintainers_can_approve:[ \t]*(true|false)[ \t]*(#.*)?$/im);
   return m ? m[1].toLowerCase() !== 'false' : true;
 }
 

--- a/programs/lfx-mentorship/automation/lib/approvers.js
+++ b/programs/lfx-mentorship/automation/lib/approvers.js
@@ -46,9 +46,38 @@ function getFallbackTeams(section) {
   return [...block[1].matchAll(/-\s+(\S+)/g)].map((m) => m[1]);
 }
 
+// Whether project maintainers may /approve for a project, read from its
+// approvers.yml section text (as returned by getProjectSection). Defaults to
+// true: the additive model where a project's maintainers, its fallback
+// handles/teams, and global_approvers can all /approve. A project sets
+// `maintainers_can_approve: false` to make its fallback_handles/fallback_teams
+// (plus global_approvers) the EXCLUSIVE approver set, so its individual
+// maintainer rosters are skipped (e.g. Kubernetes routes approvals through SIG
+// ContribEx, not per-maintainer). Only an explicit `false` disables it; a
+// missing, commented, or malformed value keeps the default true.
+function maintainersCanApprove(section) {
+  const m = String(section == null ? '' : section)
+    .match(/^\s*maintainers_can_approve:\s*(true|false)\b/im);
+  return m ? m[1].toLowerCase() !== 'false' : true;
+}
+
+// The approvers.yml/quotas.yml lookup keys for a project, in priority order:
+// its name (lowercased, spaces to hyphens), its GitHub org (lowercased), and
+// its projects.yml slug. Falsy keys dropped, duplicates removed. getProjectSection
+// tries each in turn, so a project section may be keyed by any of the three.
+function projectKeys({ project, org, slug } = {}) {
+  return [
+    String(project == null ? '' : project).toLowerCase().replace(/\s+/g, '-'),
+    String(org == null ? '' : org).toLowerCase(),
+    slug,
+  ].filter((v, i, a) => v && a.indexOf(v) === i);
+}
+
 module.exports = {
   getGlobalApprovers,
   getProjectSection,
   getFallbackHandles,
   getFallbackTeams,
+  maintainersCanApprove,
+  projectKeys,
 };

--- a/programs/lfx-mentorship/automation/lib/approvers.js
+++ b/programs/lfx-mentorship/automation/lib/approvers.js
@@ -62,14 +62,14 @@ function maintainersCanApprove(section) {
 }
 
 // The approvers.yml/quotas.yml lookup keys for a project, in priority order:
-// its name (lowercased, spaces to hyphens), its GitHub org (lowercased), and
-// its projects.yml slug. Falsy keys dropped, duplicates removed. getProjectSection
-// tries each in turn, so a project section may be keyed by any of the three.
+// its name (spaces to hyphens), its GitHub org, and its projects.yml slug, all
+// lowercased. Falsy keys dropped, duplicates removed. getProjectSection tries
+// each in turn, so a project section may be keyed by any of the three.
 function buildProjectKeys({ project, org, slug } = {}) {
   return [
     String(project == null ? '' : project).toLowerCase().replace(/\s+/g, '-'),
     String(org == null ? '' : org).toLowerCase(),
-    slug,
+    String(slug == null ? '' : slug).toLowerCase(),
   ].filter((v, i, a) => v && a.indexOf(v) === i);
 }
 

--- a/programs/lfx-mentorship/automation/lib/approvers.js
+++ b/programs/lfx-mentorship/automation/lib/approvers.js
@@ -65,7 +65,7 @@ function maintainersCanApprove(section) {
 // its name (lowercased, spaces to hyphens), its GitHub org (lowercased), and
 // its projects.yml slug. Falsy keys dropped, duplicates removed. getProjectSection
 // tries each in turn, so a project section may be keyed by any of the three.
-function projectKeys({ project, org, slug } = {}) {
+function buildProjectKeys({ project, org, slug } = {}) {
   return [
     String(project == null ? '' : project).toLowerCase().replace(/\s+/g, '-'),
     String(org == null ? '' : org).toLowerCase(),
@@ -79,5 +79,5 @@ module.exports = {
   getFallbackHandles,
   getFallbackTeams,
   maintainersCanApprove,
-  projectKeys,
+  buildProjectKeys,
 };

--- a/programs/lfx-mentorship/automation/test/approvers.test.js
+++ b/programs/lfx-mentorship/automation/test/approvers.test.js
@@ -141,6 +141,10 @@ test('buildProjectKeys: lowercases and hyphenates the project name', () => {
   assert.deepEqual(buildProjectKeys({ project: 'Cloud Custodian' }), ['cloud-custodian']);
 });
 
+test('buildProjectKeys: lowercases the slug too (uniform with name and org)', () => {
+  assert.deepEqual(buildProjectKeys({ slug: 'OpenTelemetry' }), ['opentelemetry']);
+});
+
 test('buildProjectKeys: drops falsy keys', () => {
   assert.deepEqual(buildProjectKeys({ project: '', org: 'foo', slug: undefined }), ['foo']);
 });

--- a/programs/lfx-mentorship/automation/test/approvers.test.js
+++ b/programs/lfx-mentorship/automation/test/approvers.test.js
@@ -8,7 +8,7 @@ const {
   getFallbackHandles,
   getFallbackTeams,
   maintainersCanApprove,
-  projectKeys,
+  buildProjectKeys,
 } = require('../lib/approvers');
 
 // Fixture mirrors the real approvers.yml shape: a global_approvers list plus
@@ -119,35 +119,35 @@ test('maintainersCanApprove: a commented flag line is ignored (stays default tru
   assert.equal(maintainersCanApprove('  # maintainers_can_approve: false\n  fallback_handles:\n    - a\n'), true);
 });
 
-// ── projectKeys: the approvers.yml/quotas.yml lookup keys for a project ───────
+// ── buildProjectKeys: the approvers.yml/quotas.yml lookup keys for a project ───────
 // A project section may be keyed by its name (lowercased, spaces to hyphens),
 // its GitHub org (lowercased), or its projects.yml slug; the lookup tries each.
 
-test('projectKeys: dedupes name-hyphenated, org, and slug (first-match order)', () => {
+test('buildProjectKeys: dedupes name-hyphenated, org, and slug (first-match order)', () => {
   assert.deepEqual(
-    projectKeys({ project: 'Open Telemetry', org: 'open-telemetry', slug: 'otel' }),
+    buildProjectKeys({ project: 'Open Telemetry', org: 'open-telemetry', slug: 'otel' }),
     ['open-telemetry', 'otel'],
   );
 });
 
-test('projectKeys: collapses to one when name, org, and slug coincide', () => {
+test('buildProjectKeys: collapses to one when name, org, and slug coincide', () => {
   assert.deepEqual(
-    projectKeys({ project: 'Kubernetes', org: 'kubernetes', slug: 'kubernetes' }),
+    buildProjectKeys({ project: 'Kubernetes', org: 'kubernetes', slug: 'kubernetes' }),
     ['kubernetes'],
   );
 });
 
-test('projectKeys: lowercases and hyphenates the project name', () => {
-  assert.deepEqual(projectKeys({ project: 'Cloud Custodian' }), ['cloud-custodian']);
+test('buildProjectKeys: lowercases and hyphenates the project name', () => {
+  assert.deepEqual(buildProjectKeys({ project: 'Cloud Custodian' }), ['cloud-custodian']);
 });
 
-test('projectKeys: drops falsy keys', () => {
-  assert.deepEqual(projectKeys({ project: '', org: 'foo', slug: undefined }), ['foo']);
+test('buildProjectKeys: drops falsy keys', () => {
+  assert.deepEqual(buildProjectKeys({ project: '', org: 'foo', slug: undefined }), ['foo']);
 });
 
-test('projectKeys: empty array when no identity is given', () => {
-  assert.deepEqual(projectKeys({}), []);
-  assert.deepEqual(projectKeys(), []);
+test('buildProjectKeys: empty array when no identity is given', () => {
+  assert.deepEqual(buildProjectKeys({}), []);
+  assert.deepEqual(buildProjectKeys(), []);
 });
 
 // ── Guard: the real approvers.yml resolves to the intended policy per project.
@@ -158,7 +158,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const REAL_APPROVERS = fs.readFileSync(path.join(__dirname, '..', 'approvers.yml'), 'utf8');
 const resolveMaintainersOk = (ids) =>
-  maintainersCanApprove(getProjectSection(REAL_APPROVERS, projectKeys(ids)));
+  maintainersCanApprove(getProjectSection(REAL_APPROVERS, buildProjectKeys(ids)));
 
 test('real approvers.yml: Kubernetes restricts approvals to its listed approvers', () => {
   assert.equal(

--- a/programs/lfx-mentorship/automation/test/approvers.test.js
+++ b/programs/lfx-mentorship/automation/test/approvers.test.js
@@ -7,6 +7,8 @@ const {
   getProjectSection,
   getFallbackHandles,
   getFallbackTeams,
+  maintainersCanApprove,
+  projectKeys,
 } = require('../lib/approvers');
 
 // Fixture mirrors the real approvers.yml shape: a global_approvers list plus
@@ -82,4 +84,99 @@ test('getFallbackTeams: returns raw org/team strings with case preserved', () =>
 
 test('getFallbackTeams: returns [] for a section without fallback_teams', () => {
   assert.deepEqual(getFallbackTeams('fallback_handles:\n    - someone\n'), []);
+});
+
+// ── maintainersCanApprove: the per-project "exclusive approvers" flag ─────────
+// Default true = the additive model (project maintainers + fallbacks + global
+// approvers can /approve). A project sets `maintainers_can_approve: false` to
+// make its fallback_handles/fallback_teams (+ global_approvers) the EXCLUSIVE
+// approver set, so its individual maintainers cannot /approve (e.g. Kubernetes
+// routes approvals through SIG ContribEx, not per-maintainer).
+
+test('maintainersCanApprove: false when the section sets it false', () => {
+  assert.equal(maintainersCanApprove('  maintainers_can_approve: false\n  fallback_handles:\n    - a\n'), false);
+});
+
+test('maintainersCanApprove: true when the section sets it true', () => {
+  assert.equal(maintainersCanApprove('  maintainers_can_approve: true\n'), true);
+});
+
+test('maintainersCanApprove: defaults to true when the key is absent', () => {
+  assert.equal(maintainersCanApprove('  fallback_teams:\n    - a/b\n'), true);
+});
+
+test('maintainersCanApprove: defaults to true for an empty or nullish section', () => {
+  assert.equal(maintainersCanApprove(''), true);
+  assert.equal(maintainersCanApprove(null), true);
+  assert.equal(maintainersCanApprove(undefined), true);
+});
+
+test('maintainersCanApprove: value is case-insensitive', () => {
+  assert.equal(maintainersCanApprove('  maintainers_can_approve: False\n'), false);
+});
+
+test('maintainersCanApprove: a commented flag line is ignored (stays default true)', () => {
+  assert.equal(maintainersCanApprove('  # maintainers_can_approve: false\n  fallback_handles:\n    - a\n'), true);
+});
+
+// ── projectKeys: the approvers.yml/quotas.yml lookup keys for a project ───────
+// A project section may be keyed by its name (lowercased, spaces to hyphens),
+// its GitHub org (lowercased), or its projects.yml slug; the lookup tries each.
+
+test('projectKeys: dedupes name-hyphenated, org, and slug (first-match order)', () => {
+  assert.deepEqual(
+    projectKeys({ project: 'Open Telemetry', org: 'open-telemetry', slug: 'otel' }),
+    ['open-telemetry', 'otel'],
+  );
+});
+
+test('projectKeys: collapses to one when name, org, and slug coincide', () => {
+  assert.deepEqual(
+    projectKeys({ project: 'Kubernetes', org: 'kubernetes', slug: 'kubernetes' }),
+    ['kubernetes'],
+  );
+});
+
+test('projectKeys: lowercases and hyphenates the project name', () => {
+  assert.deepEqual(projectKeys({ project: 'Cloud Custodian' }), ['cloud-custodian']);
+});
+
+test('projectKeys: drops falsy keys', () => {
+  assert.deepEqual(projectKeys({ project: '', org: 'foo', slug: undefined }), ['foo']);
+});
+
+test('projectKeys: empty array when no identity is given', () => {
+  assert.deepEqual(projectKeys({}), []);
+  assert.deepEqual(projectKeys(), []);
+});
+
+// ── Guard: the real approvers.yml resolves to the intended policy per project.
+// Ties the pure helpers to the actual data, so a typo, wrong key, or a dropped
+// kubernetes flag fails here (the exclusive-approver behavior can't be fully
+// exercised in e2e without a non-global maintainer identity).
+const fs = require('node:fs');
+const path = require('node:path');
+const REAL_APPROVERS = fs.readFileSync(path.join(__dirname, '..', 'approvers.yml'), 'utf8');
+const resolveMaintainersOk = (ids) =>
+  maintainersCanApprove(getProjectSection(REAL_APPROVERS, projectKeys(ids)));
+
+test('real approvers.yml: Kubernetes restricts approvals to its listed approvers', () => {
+  assert.equal(
+    resolveMaintainersOk({ project: 'Kubernetes', org: 'kubernetes', slug: 'kubernetes' }),
+    false,
+  );
+});
+
+test('real approvers.yml: OpenTelemetry keeps the additive model', () => {
+  assert.equal(
+    resolveMaintainersOk({ project: 'OpenTelemetry', org: 'open-telemetry', slug: 'open-telemetry' }),
+    true,
+  );
+});
+
+test('real approvers.yml: an unlisted project keeps the additive model (default)', () => {
+  assert.equal(
+    resolveMaintainersOk({ project: 'Some Project', org: 'some-org', slug: 'some-slug' }),
+    true,
+  );
 });

--- a/programs/lfx-mentorship/automation/test/approvers.test.js
+++ b/programs/lfx-mentorship/automation/test/approvers.test.js
@@ -119,6 +119,21 @@ test('maintainersCanApprove: a commented flag line is ignored (stays default tru
   assert.equal(maintainersCanApprove('  # maintainers_can_approve: false\n  fallback_handles:\n    - a\n'), true);
 });
 
+test('maintainersCanApprove: an inline comment after the value is allowed', () => {
+  assert.equal(maintainersCanApprove('  maintainers_can_approve: false   # exclusive\n'), false);
+  assert.equal(maintainersCanApprove('  maintainers_can_approve: true # additive\n'), true);
+});
+
+test('maintainersCanApprove: a malformed value keeps the default true (not a bare boolean)', () => {
+  // The value must be an exact boolean token; trailing junk means malformed,
+  // which must NOT be read as false (a \b-based match wrongly treated
+  // "false-positive" as "false").
+  assert.equal(maintainersCanApprove('  maintainers_can_approve: false-positive\n'), true);
+  assert.equal(maintainersCanApprove('  maintainers_can_approve: falsey\n'), true);
+  assert.equal(maintainersCanApprove('  maintainers_can_approve: false.\n'), true);
+  assert.equal(maintainersCanApprove('  maintainers_can_approve: no\n'), true);
+});
+
 // ── buildProjectKeys: the approvers.yml/quotas.yml lookup keys for a project ───────
 // A project section may be keyed by its name (lowercased, spaces to hyphens),
 // its GitHub org (lowercased), or its projects.yml slug; the lookup tries each.


### PR DESCRIPTION
## What

Add a per-project `maintainers_can_approve` flag to the LFX approvers config.
Setting it `false` limits a project's `/approve` authority to its listed
approvers plus CNCF global approvers, skipping the project-maintainer roster
tiers. Enable it for Kubernetes.

## Why

Kubernetes mentorship approvals are steering and SIG-driven: they run through SIG
Contributor Experience, not individual project maintainers. Before this, any
Kubernetes project maintainer could `/approve` a mentorship proposal. The flag
makes the SIG ContribEx leads (listed in `approvers.yml`) plus CNCF global
approvers the only approvers, and blocks proposer-implied auto-approval on those
projects.

## Changes

- `lib/approvers.js`: `maintainersCanApprove(section)` (flag parser, default
  `true` keeps today's additive model) and `buildProjectKeys(...)` (the lookup-key
  helper both workflows share). New decision logic lives in tested lib code, not
  inline YAML.
- `lfx-proposal-approvals.yml`: `/approve` skips the maintainer-roster tiers when
  the flag is `false`, and tailors the unauthorized reply for exclusive projects.
- `lfx-proposal-validate.yml`: proposer-implied auto-approval honors the same
  flag.
- `approvers.yml`: `maintainers_can_approve: false` on `kubernetes`. Retire the
  inert cross-org `fallback_teams` (flagged `DEPRECATED`; the code path is kept
  for a fast-follow removal).
- `ADMIN_GUIDE.md`: document the flag.

The legacy four-tier authorization orchestration is otherwise unchanged.

## Validation

489 unit tests, including guards that read the real `approvers.yml` (Kubernetes
resolves exclusive, OpenTelemetry additive, an unlisted project defaults to
additive). Workflow YAML and every embedded `github-script` block pass
`node --check`. No dev e2e: the behavior this changes (denying a non-global
Kubernetes maintainer) needs a maintainer identity the dev fork can't provide, so
the unit and guard tests carry it.
