### PR TITLE
fix(lfx): revise over-quota copy to point projects to CNCF admins

### DIFF
--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -340,9 +340,10 @@ jobs:
                 if (count > quota) {
                   warnings.push(
                     `**Over quota:** ${project} has ${count} proposals for ${term} ` +
-                    `(limit: ${quota}). Existing proposals: ` +
+                    `(guideline: ${quota}). Existing proposals: ` +
                     sameProjectTerm.map(i => `#${i.number}`).join(', ') +
-                    `. The project should decide which to keep.`
+                    `. Going over may be acceptable; please reach out to the CNCF ` +
+                    `Mentorship Admins to discuss, and prioritize proposals within your project.`
                   );
                 } else {
                   passed.push(`Quota: ${count}/${quota} proposals for ${project} in ${term}`);


### PR DESCRIPTION
## What

Revise the over-quota warning in the LFX proposal validation comment.

## Why

The message told a project it "should decide which to keep," implying it must
drop its own proposals. Going over the quota is negotiable, not a hard cap
(`quotas.yml` already calls it "a warning, not a hard block"). Projects should
talk to the CNCF Mentorship Admins and set priorities internally, not self-cull.

## Change

One string in `lfx-proposal-validate.yml` ( `{...}` are runtime values;
`{existing}` is the dynamically built list of other same-project, same-term
proposal numbers):

Before:
`**Over quota:** {project} has {count} proposals for {term} (limit: {quota}). Existing proposals: {existing}. The project should decide which to keep.`

After:
`**Over quota:** {project} has {count} proposals for {term} (guideline: {quota}). Existing proposals: {existing}. Going over may be acceptable; please reach out to the CNCF Mentorship Admins to discuss, and prioritize proposals within your project.`

Also softens "limit" to "guideline." No logic change: the `Over Quota` label
and its detection (which keys off the `**Over quota:**` prefix) are unaffected.

## Validation

Workflow YAML and every embedded `github-script` block pass `node --check`.
Copy-only, so there is no behavior to e2e.
