### PR TITLE
fix(lfx): soften umbrella-issue guidance to a polite request

### DIFF
--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -241,7 +241,7 @@ jobs:
             } else if (upstreamErr === 'format') {
               errors.push(`Upstream Issue URL \`${upstreamUrl}\` is not a valid URL.`);
             } else if (upstreamErr === 'multiple') {
-              errors.push('Upstream Issue URL should be exactly one URL. If the program spans multiple issues, create an umbrella issue.');
+              errors.push('Upstream Issue URL should be a single URL. If the program spans multiple issues, please consider creating an umbrella issue in your project to group them, and link that here.');
             } else {
               passed.push(`Upstream Issue URL: ${upstreamUrl}`);
             }


### PR DESCRIPTION
## What

Soften the upstream-URL "multiple issues" validation error from a command into a
more polite request.

## Why

When the automation asks a maintainer or mentor to do work in their own project,
it should ask courteously, not command. The prior copy said "create an umbrella
issue."

## Change

One string in `lfx-proposal-validate.yml` (the `upstreamErr === 'multiple'` case):

Before:
`Upstream Issue URL should be exactly one URL. If the program spans multiple issues, create an umbrella issue.`

After:
`Upstream Issue URL should be a single URL. If the program spans multiple issues, please consider creating an umbrella issue in your project to group them, and link that here.`

No logic change.

## Validation

Workflow YAML and every embedded `github-script` block pass `node --check`.
Copy-only, so there is no behavior to e2e.
