### PR TITLE
feat(lfx): warn on duplicate upstream issue across proposals

### DIFF
--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -372,7 +372,7 @@ jobs:
                     number: iss.number,
                     url: parseIssueForm(iss.body || '')['Upstream Issue URL'] || '',
                   }));
-                  const dupUpstream = findDuplicateUpstreamIssues(get('Upstream Issue URL'), others);
+                  const dupUpstream = findDuplicateUpstreamIssues(upstreamUrl, others);
                   if (dupUpstream.length) {
                     warnings.push(
                       `**Duplicate upstream issue:** the same Upstream Issue URL is listed on ` +

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -364,18 +364,23 @@ jobs:
                 // Non-blocking warning when another open proposal for the same
                 // project + term lists the same Upstream Issue URL: likely the
                 // same effort proposed twice, which an admin should reconcile.
-                const others = sameProjectTerm.map(iss => ({
-                  number: iss.number,
-                  url: parseIssueForm(iss.body || '')['Upstream Issue URL'] || '',
-                }));
-                const dupUpstream = findDuplicateUpstreamIssues(get('Upstream Issue URL'), others);
-                if (dupUpstream.length) {
-                  warnings.push(
-                    `**Duplicate upstream issue:** the same Upstream Issue URL is listed on ` +
-                    `other open ${project} proposal(s) for ${term}: ${dupUpstream.map(n => `#${n}`).join(', ')}. ` +
-                    `If that's unintentional, please update it; if the proposals are related, the CNCF ` +
-                    `Mentorship Admins can help sort out next steps.`
-                  );
+                // Only when this proposal's URL is itself valid (upstreamErr
+                // null): a malformed/empty URL has a hard error to fix first, and
+                // gating avoids a confusing dup warning stacked on that error.
+                if (upstreamErr === null) {
+                  const others = sameProjectTerm.map(iss => ({
+                    number: iss.number,
+                    url: parseIssueForm(iss.body || '')['Upstream Issue URL'] || '',
+                  }));
+                  const dupUpstream = findDuplicateUpstreamIssues(get('Upstream Issue URL'), others);
+                  if (dupUpstream.length) {
+                    warnings.push(
+                      `**Duplicate upstream issue:** the same Upstream Issue URL is listed on ` +
+                      `other open ${project} proposal(s) for ${term}: ${dupUpstream.map(n => `#${n}`).join(', ')}. ` +
+                      `If that's unintentional, please update it; if the proposals are related, the CNCF ` +
+                      `Mentorship Admins can help sort out next steps.`
+                    );
+                  }
                 }
               }
             }

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -73,7 +73,7 @@ jobs:
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
             const { parseIssueForm, parseMentors, parseCheckboxes, formFieldsChanged } = _lib('parse.js');
-            const { validateMentors, validateUpstreamUrl, mentorCountWarning, validateCustomPrerequisite, CUSTOM_PREREQ_NAME_MAX, CUSTOM_PREREQ_DESC_MAX } = _lib('validate.js');
+            const { validateMentors, validateUpstreamUrl, mentorCountWarning, validateCustomPrerequisite, CUSTOM_PREREQ_NAME_MAX, CUSTOM_PREREQ_DESC_MAX, findDuplicateUpstreamIssues } = _lib('validate.js');
             const { lookupProject } = _lib('projects.js');
             const { isProposalTitle, looksLikeProposalForm } = _lib('labels.js');
             const { resolveProjectMaintainer } = _lib('authorize.js');
@@ -288,68 +288,95 @@ jobs:
               passed.push(`Custom Prerequisite: name ${customName.trim().length}/${CUSTOM_PREREQ_NAME_MAX} chars, description ${customDesc.trim().length}/${CUSTOM_PREREQ_DESC_MAX} chars`);
             }
 
-            // ── 10. Quota check ──
+            // ── 10. Same project + term scan (shared) ──
+            // One listForRepo call feeds both the quota check and the duplicate
+            // upstream-issue check below. sameProjectTerm stays null if the scan
+            // fails, so neither check runs on incomplete data.
             if (project && term) {
+              let sameProjectTerm = null;
               try {
-                const quotaRaw = fs.readFileSync('programs/lfx-mentorship/automation/quotas.yml', 'utf8');
-                // Simple YAML parse for our known format — no js-yaml needed
-                const defaultMatch = quotaRaw.match(/default_per_project_per_term:\s*(\d+)/);
-                const defaultQ = defaultMatch ? parseInt(defaultMatch[1]) : 5;
-                const overrides = {};
-                const overrideSection = quotaRaw.split(/^overrides:\s*$/m)[1];
-                if (overrideSection) {
-                  for (const m of overrideSection.matchAll(/^\s+([^:]+):\s*(\d+)/gm)) {
-                    overrides[m[1].trim().toLowerCase()] = parseInt(m[2]);
-                  }
-                }
-                // Build candidate keys: normalized NAME, GitHub org, and projects.yml
-                // slug. quotas.yml may key a project by any of these; first match wins.
-                const projectKeys = [project.toLowerCase().replace(/\s+/g, '-')];
-                try {
-                  const projYaml = fs.readFileSync('programs/lfx-mentorship/automation/projects.yml', 'utf8');
-                  // GitHub org before projects.yml slug, to match the candidate
-                  // ordering in lfx-proposal-approvals.yml (org preferred over slug).
-                  const info = lookupProject(projYaml, project);
-                  if (info) {
-                    if (info.org) projectKeys.push(info.org.toLowerCase());
-                    if (info.slug) projectKeys.push(info.slug);
-                  }
-                } catch (e) {
-                  console.log(`projects.yml key lookup failed: ${e.message}`);
-                }
-                const quotaKeys = projectKeys.filter((v, i, a) => v && a.indexOf(v) === i);
-                let quota = defaultQ;
-                for (const key of quotaKeys) {
-                  if (overrides[key] !== undefined) { quota = overrides[key]; break; }
-                }
-
-                // Count open proposals for same project + term
                 const issues = await github.paginate(github.rest.issues.listForRepo, {
                   owner, repo, state: 'open', labels: `lfx mentorship,Proposal`,
                   per_page: 100,
                 });
-
-                const sameProjectTerm = issues.filter(iss => {
+                sameProjectTerm = issues.filter(iss => {
                   if (iss.number === issue_number) return false;
                   const b = iss.body || '';
                   return b.includes(`### CNCF Project\n\n${project}`)
                     && b.includes(`### Term\n\n${term}`);
                 });
-
-                const count = sameProjectTerm.length + 1; // include this one
-                if (count > quota) {
-                  warnings.push(
-                    `**Over quota:** ${project} has ${count} proposals for ${term} ` +
-                    `(guideline: ${quota}). Existing proposals: ` +
-                    sameProjectTerm.map(i => `#${i.number}`).join(', ') +
-                    `. Going over may be acceptable; please reach out to the CNCF ` +
-                    `Mentorship Admins to discuss, and prioritize proposals within your project.`
-                  );
-                } else {
-                  passed.push(`Quota: ${count}/${quota} proposals for ${project} in ${term}`);
-                }
               } catch (e) {
-                warnings.push(`Could not check quota: ${e.message}`);
+                warnings.push(`Could not check other ${project} proposals for ${term}: ${e.message}`);
+              }
+
+              if (sameProjectTerm) {
+                // ── 10a. Quota check ──
+                try {
+                  const quotaRaw = fs.readFileSync('programs/lfx-mentorship/automation/quotas.yml', 'utf8');
+                  // Simple YAML parse for our known format (no js-yaml needed)
+                  const defaultMatch = quotaRaw.match(/default_per_project_per_term:\s*(\d+)/);
+                  const defaultQ = defaultMatch ? parseInt(defaultMatch[1]) : 5;
+                  const overrides = {};
+                  const overrideSection = quotaRaw.split(/^overrides:\s*$/m)[1];
+                  if (overrideSection) {
+                    for (const m of overrideSection.matchAll(/^\s+([^:]+):\s*(\d+)/gm)) {
+                      overrides[m[1].trim().toLowerCase()] = parseInt(m[2]);
+                    }
+                  }
+                  // Build candidate keys: normalized NAME, GitHub org, and projects.yml
+                  // slug. quotas.yml may key a project by any of these; first match wins.
+                  const projectKeys = [project.toLowerCase().replace(/\s+/g, '-')];
+                  try {
+                    const projYaml = fs.readFileSync('programs/lfx-mentorship/automation/projects.yml', 'utf8');
+                    // GitHub org before projects.yml slug, to match the candidate
+                    // ordering in lfx-proposal-approvals.yml (org preferred over slug).
+                    const info = lookupProject(projYaml, project);
+                    if (info) {
+                      if (info.org) projectKeys.push(info.org.toLowerCase());
+                      if (info.slug) projectKeys.push(info.slug);
+                    }
+                  } catch (e) {
+                    console.log(`projects.yml key lookup failed: ${e.message}`);
+                  }
+                  const quotaKeys = projectKeys.filter((v, i, a) => v && a.indexOf(v) === i);
+                  let quota = defaultQ;
+                  for (const key of quotaKeys) {
+                    if (overrides[key] !== undefined) { quota = overrides[key]; break; }
+                  }
+
+                  const count = sameProjectTerm.length + 1; // include this one
+                  if (count > quota) {
+                    warnings.push(
+                      `**Over quota:** ${project} has ${count} proposals for ${term} ` +
+                      `(guideline: ${quota}). Existing proposals: ` +
+                      sameProjectTerm.map(i => `#${i.number}`).join(', ') +
+                      `. Going over may be acceptable; please reach out to the CNCF ` +
+                      `Mentorship Admins to discuss, and prioritize proposals within your project.`
+                    );
+                  } else {
+                    passed.push(`Quota: ${count}/${quota} proposals for ${project} in ${term}`);
+                  }
+                } catch (e) {
+                  warnings.push(`Could not check quota: ${e.message}`);
+                }
+
+                // ── 10b. Duplicate upstream-issue check ──
+                // Non-blocking warning when another open proposal for the same
+                // project + term lists the same Upstream Issue URL: likely the
+                // same effort proposed twice, which an admin should reconcile.
+                const others = sameProjectTerm.map(iss => ({
+                  number: iss.number,
+                  url: parseIssueForm(iss.body || '')['Upstream Issue URL'] || '',
+                }));
+                const dupUpstream = findDuplicateUpstreamIssues(get('Upstream Issue URL'), others);
+                if (dupUpstream.length) {
+                  warnings.push(
+                    `**Duplicate upstream issue:** the same Upstream Issue URL is listed on ` +
+                    `other open ${project} proposal(s) for ${term}: ${dupUpstream.map(n => `#${n}`).join(', ')}. ` +
+                    `If that's unintentional, please update it; if the proposals are related, the CNCF ` +
+                    `Mentorship Admins can help sort out next steps.`
+                  );
+                }
               }
             }
 

--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -80,12 +80,13 @@ function validateUpstreamUrl(raw) {
 
 // Canonical form of an upstream-issue URL for cross-proposal comparison. Drops
 // the protocol, a leading "www.", the #fragment, and any trailing slash on the
-// path, then lowercases the result so the same target in different casing
-// compares equal. The ?query string is PRESERVED: an upstream "issue" is often a
-// filtered issues list whose identity lives entirely in the query (e.g. a
-// kubernetes/kubernetes/issues?q=...label:area/foo link, cncf/mentoring#1960),
-// so dropping it would collapse distinct upstreams to the same /issues path and
-// raise false duplicates. Blank in, blank out.
+// path, then lowercases the host and path so the same target in different
+// casing compares equal. The ?query string is PRESERVED verbatim (case and all):
+// an upstream "issue" is often a filtered issues list whose identity lives
+// entirely in the query (e.g. a kubernetes/kubernetes/issues?q=...label:area/foo
+// link, cncf/mentoring#1960), so dropping it would collapse distinct upstreams
+// to the same /issues path, and case-folding it could merge case-sensitive query
+// values; both raise false duplicates. Blank in, blank out.
 function normalizeUpstreamUrl(url) {
   const s = String(url == null ? '' : url).trim();
   if (!s) return '';
@@ -93,8 +94,8 @@ function normalizeUpstreamUrl(url) {
   rest = rest.split('#')[0];                       // drop fragment (page anchor)
   const qIdx = rest.indexOf('?');
   const path = (qIdx === -1 ? rest : rest.slice(0, qIdx)).replace(/\/+$/, '');
-  const query = qIdx === -1 ? '' : rest.slice(qIdx); // preserved (leading '?')
-  return (path + query).toLowerCase();
+  const query = qIdx === -1 ? '' : rest.slice(qIdx); // preserved verbatim
+  return path.toLowerCase() + query;
 }
 
 // Given the current proposal's upstream URL and other proposals

--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -78,6 +78,34 @@ function validateUpstreamUrl(raw) {
   return null;
 }
 
+// Canonical form of an upstream-issue URL for cross-proposal comparison. Drops
+// the protocol, a leading "www.", the #fragment, and any trailing slash, and
+// lowercases host AND path so the same issue in different casing (e.g.
+// github.com/Org/Repo vs .../org/repo) compares equal. Blank in, blank out.
+// Tuned to minimize false negatives (a missed duplicate); false positives are
+// implausible for issue URLs, where the numeric id disambiguates.
+function normalizeUpstreamUrl(url) {
+  const s = String(url == null ? '' : url).trim();
+  if (!s) return '';
+  let rest = s.replace(/^https?:\/\//i, '').replace(/^www\./i, '');
+  rest = rest.split('#')[0];       // drop fragment
+  rest = rest.replace(/\/+$/, ''); // drop trailing slash(es)
+  return rest.toLowerCase();
+}
+
+// Given the current proposal's upstream URL and other proposals
+// ({ number, url }), return the numbers whose upstream URL matches after
+// normalization. A blank current URL matches nothing (so proposals that both
+// omit the URL are not flagged as duplicates of each other). Input order is
+// preserved.
+function findDuplicateUpstreamIssues(url, others) {
+  const target = normalizeUpstreamUrl(url);
+  if (!target) return [];
+  return (others || [])
+    .filter((o) => o && normalizeUpstreamUrl(o.url) === target)
+    .map((o) => o.number);
+}
+
 // LFX programs are encouraged — not required — to have at least two mentors, so
 // the load is shared and a co-mentor can cover absences. This is a soft
 // preference the reviewers have long applied by hand (see PRs #1321, #1323,
@@ -160,4 +188,6 @@ module.exports = {
   validateCustomPrerequisite,
   CUSTOM_PREREQ_NAME_MAX,
   CUSTOM_PREREQ_DESC_MAX,
+  normalizeUpstreamUrl,
+  findDuplicateUpstreamIssues,
 };

--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -79,18 +79,22 @@ function validateUpstreamUrl(raw) {
 }
 
 // Canonical form of an upstream-issue URL for cross-proposal comparison. Drops
-// the protocol, a leading "www.", the #fragment, and any trailing slash, and
-// lowercases host AND path so the same issue in different casing (e.g.
-// github.com/Org/Repo vs .../org/repo) compares equal. Blank in, blank out.
-// Tuned to minimize false negatives (a missed duplicate); false positives are
-// implausible for issue URLs, where the numeric id disambiguates.
+// the protocol, a leading "www.", the #fragment, and any trailing slash on the
+// path, then lowercases the result so the same target in different casing
+// compares equal. The ?query string is PRESERVED: an upstream "issue" is often a
+// filtered issues list whose identity lives entirely in the query (e.g. a
+// kubernetes/kubernetes/issues?q=...label:area/foo link, cncf/mentoring#1960),
+// so dropping it would collapse distinct upstreams to the same /issues path and
+// raise false duplicates. Blank in, blank out.
 function normalizeUpstreamUrl(url) {
   const s = String(url == null ? '' : url).trim();
   if (!s) return '';
   let rest = s.replace(/^https?:\/\//i, '').replace(/^www\./i, '');
-  rest = rest.split('#')[0];       // drop fragment
-  rest = rest.replace(/\/+$/, ''); // drop trailing slash(es)
-  return rest.toLowerCase();
+  rest = rest.split('#')[0];                       // drop fragment (page anchor)
+  const qIdx = rest.indexOf('?');
+  const path = (qIdx === -1 ? rest : rest.slice(0, qIdx)).replace(/\/+$/, '');
+  const query = qIdx === -1 ? '' : rest.slice(qIdx); // preserved (leading '?')
+  return (path + query).toLowerCase();
 }
 
 // Given the current proposal's upstream URL and other proposals

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -267,19 +267,24 @@ test('normalizeUpstreamUrl: protocol, www, fragment, and trailing slash are igno
   assert.equal(normalizeUpstreamUrl('  https://github.com/cncf/mentoring/issues/5  '), canon);
 });
 
-test('normalizeUpstreamUrl: the query string is PRESERVED (filtered issues list, cncf/mentoring#1960)', () => {
+test('normalizeUpstreamUrl: the query string is PRESERVED verbatim (filtered issues list, cncf/mentoring#1960)', () => {
   // A valid upstream link can be a filtered issues list whose identity is the
   // query, not the path. Dropping it would collapse distinct filters to the
-  // same /issues path and raise false duplicates.
-  const filtered = 'https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+label%3Aarea%2Fapi';
+  // same /issues path and raise false duplicates. Host+path are lowercased, but
+  // the query is preserved as-is (query values can be case-sensitive).
   assert.equal(
-    normalizeUpstreamUrl(filtered),
-    'github.com/kubernetes/kubernetes/issues?q=is%3aissue+label%3aarea%2fapi',
+    normalizeUpstreamUrl('https://github.com/Kubernetes/Kubernetes/issues?q=is%3Aissue+label%3AArea%2FAPI'),
+    'github.com/kubernetes/kubernetes/issues?q=is%3Aissue+label%3AArea%2FAPI',
   );
   // Same list, different filter → distinct (must NOT be flagged as duplicates).
   assert.notEqual(
     normalizeUpstreamUrl('https://github.com/kubernetes/kubernetes/issues?q=label%3Aarea%2Fapi'),
     normalizeUpstreamUrl('https://github.com/kubernetes/kubernetes/issues?q=label%3Aarea%2Fnet'),
+  );
+  // Queries differing ONLY by case stay distinct (no false-positive merge).
+  assert.notEqual(
+    normalizeUpstreamUrl('https://example.com/x?token=AbC'),
+    normalizeUpstreamUrl('https://example.com/x?token=abc'),
   );
   // Trailing slash on the path before the query does not change identity.
   assert.equal(

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -267,6 +267,27 @@ test('normalizeUpstreamUrl: protocol, www, fragment, and trailing slash are igno
   assert.equal(normalizeUpstreamUrl('  https://github.com/cncf/mentoring/issues/5  '), canon);
 });
 
+test('normalizeUpstreamUrl: the query string is PRESERVED (filtered issues list, cncf/mentoring#1960)', () => {
+  // A valid upstream link can be a filtered issues list whose identity is the
+  // query, not the path. Dropping it would collapse distinct filters to the
+  // same /issues path and raise false duplicates.
+  const filtered = 'https://github.com/kubernetes/kubernetes/issues?q=is%3Aissue+label%3Aarea%2Fapi';
+  assert.equal(
+    normalizeUpstreamUrl(filtered),
+    'github.com/kubernetes/kubernetes/issues?q=is%3aissue+label%3aarea%2fapi',
+  );
+  // Same list, different filter → distinct (must NOT be flagged as duplicates).
+  assert.notEqual(
+    normalizeUpstreamUrl('https://github.com/kubernetes/kubernetes/issues?q=label%3Aarea%2Fapi'),
+    normalizeUpstreamUrl('https://github.com/kubernetes/kubernetes/issues?q=label%3Aarea%2Fnet'),
+  );
+  // Trailing slash on the path before the query does not change identity.
+  assert.equal(
+    normalizeUpstreamUrl('https://github.com/kubernetes/kubernetes/issues/?q=x'),
+    normalizeUpstreamUrl('https://github.com/kubernetes/kubernetes/issues?q=x'),
+  );
+});
+
 test('normalizeUpstreamUrl: host and path are lowercased (same issue, different casing)', () => {
   assert.equal(
     normalizeUpstreamUrl('https://GitHub.com/CNCF/Mentoring/issues/5'),
@@ -295,6 +316,18 @@ test('findDuplicateUpstreamIssues: flags others sharing the URL despite formatti
   assert.deepEqual(
     findDuplicateUpstreamIssues('https://github.com/cncf/mentoring/issues/5', others),
     [12, 56],
+  );
+});
+
+test('findDuplicateUpstreamIssues: filtered issues lists match by query, not just path', () => {
+  const base = 'https://github.com/kubernetes/kubernetes/issues';
+  const others = [
+    { number: 12, url: `${base}?q=label%3Aarea%2Fapi` },  // same filter → dup
+    { number: 34, url: `${base}?q=label%3Aarea%2Fnet` },  // different filter → not
+  ];
+  assert.deepEqual(
+    findDuplicateUpstreamIssues(`${base}?q=label%3Aarea%2Fapi`, others),
+    [12],
   );
 });
 

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -8,6 +8,7 @@ const {
   mentorCountWarning, MIN_PREFERRED_MENTORS,
   validateCustomPrerequisite,
   CUSTOM_PREREQ_NAME_MAX, CUSTOM_PREREQ_DESC_MAX,
+  normalizeUpstreamUrl, findDuplicateUpstreamIssues,
 } = require('../lib/validate');
 
 const codes = (result) => result.errors.map(e => e.code);
@@ -240,4 +241,86 @@ test('validateCustomPrerequisite: length is measured after trimming (matches the
 test('validateCustomPrerequisite: exposes the LFX limits as constants', () => {
   assert.equal(CUSTOM_PREREQ_NAME_MAX, 20);
   assert.equal(CUSTOM_PREREQ_DESC_MAX, 500);
+});
+
+// ── normalizeUpstreamUrl ─────────────────────────────────────────────
+// Canonical form for comparing upstream-issue URLs across proposals, chosen to
+// avoid false negatives (missing a real duplicate). Drops protocol, a leading
+// "www.", the #fragment, and any trailing slash; lowercases host AND path so
+// github.com/Org/Repo/issues/5 and .../org/repo/issues/5 (the same issue)
+// compare equal. Blank in, blank out.
+
+test('normalizeUpstreamUrl: blank / nullish normalizes to empty string', () => {
+  assert.equal(normalizeUpstreamUrl(''), '');
+  assert.equal(normalizeUpstreamUrl('   '), '');
+  assert.equal(normalizeUpstreamUrl(null), '');
+  assert.equal(normalizeUpstreamUrl(undefined), '');
+});
+
+test('normalizeUpstreamUrl: protocol, www, fragment, and trailing slash are ignored', () => {
+  const canon = 'github.com/cncf/mentoring/issues/5';
+  assert.equal(normalizeUpstreamUrl('https://github.com/cncf/mentoring/issues/5'), canon);
+  assert.equal(normalizeUpstreamUrl('http://github.com/cncf/mentoring/issues/5'), canon);
+  assert.equal(normalizeUpstreamUrl('https://www.github.com/cncf/mentoring/issues/5'), canon);
+  assert.equal(normalizeUpstreamUrl('https://github.com/cncf/mentoring/issues/5/'), canon);
+  assert.equal(normalizeUpstreamUrl('https://github.com/cncf/mentoring/issues/5#issuecomment-9'), canon);
+  assert.equal(normalizeUpstreamUrl('  https://github.com/cncf/mentoring/issues/5  '), canon);
+});
+
+test('normalizeUpstreamUrl: host and path are lowercased (same issue, different casing)', () => {
+  assert.equal(
+    normalizeUpstreamUrl('https://GitHub.com/CNCF/Mentoring/issues/5'),
+    'github.com/cncf/mentoring/issues/5',
+  );
+});
+
+test('normalizeUpstreamUrl: distinct issues stay distinct', () => {
+  assert.notEqual(
+    normalizeUpstreamUrl('https://github.com/cncf/mentoring/issues/5'),
+    normalizeUpstreamUrl('https://github.com/cncf/mentoring/issues/6'),
+  );
+});
+
+// ── findDuplicateUpstreamIssues ──────────────────────────────────────
+// Given the current proposal's URL and other proposals ({ number, url }),
+// return the numbers whose upstream URL matches (after normalization). Blank
+// URLs never match (so two proposals that both omit the URL are not flagged).
+
+test('findDuplicateUpstreamIssues: flags others sharing the URL despite formatting differences', () => {
+  const others = [
+    { number: 12, url: 'http://www.github.com/cncf/mentoring/issues/5/' },
+    { number: 34, url: 'https://github.com/cncf/mentoring/issues/6' },
+    { number: 56, url: 'https://github.com/CNCF/Mentoring/issues/5#note' },
+  ];
+  assert.deepEqual(
+    findDuplicateUpstreamIssues('https://github.com/cncf/mentoring/issues/5', others),
+    [12, 56],
+  );
+});
+
+test('findDuplicateUpstreamIssues: no matches returns empty', () => {
+  const others = [{ number: 34, url: 'https://github.com/cncf/mentoring/issues/6' }];
+  assert.deepEqual(findDuplicateUpstreamIssues('https://github.com/cncf/mentoring/issues/5', others), []);
+});
+
+test('findDuplicateUpstreamIssues: a blank current URL matches nothing', () => {
+  const others = [{ number: 34, url: '' }, { number: 35, url: 'https://github.com/a/b/issues/1' }];
+  assert.deepEqual(findDuplicateUpstreamIssues('', others), []);
+  assert.deepEqual(findDuplicateUpstreamIssues('   ', others), []);
+});
+
+test('findDuplicateUpstreamIssues: others with blank URLs are skipped', () => {
+  const others = [{ number: 34, url: '' }, { number: 35, url: '_No response_' }];
+  // '_No response_' is not a URL; normalized it should not equal a real URL.
+  assert.deepEqual(findDuplicateUpstreamIssues('https://github.com/a/b/issues/1', others), []);
+});
+
+test('findDuplicateUpstreamIssues: preserves input order and handles missing/empty others', () => {
+  assert.deepEqual(findDuplicateUpstreamIssues('https://github.com/a/b/issues/1', []), []);
+  assert.deepEqual(findDuplicateUpstreamIssues('https://github.com/a/b/issues/1'), []);
+  const others = [
+    { number: 9, url: 'https://github.com/a/b/issues/1' },
+    { number: 3, url: 'https://github.com/a/b/issues/1' },
+  ];
+  assert.deepEqual(findDuplicateUpstreamIssues('https://github.com/a/b/issues/1', others), [9, 3]);
 });


### PR DESCRIPTION
## What

Add a non-blocking validation warning when two open proposals for the same
project and term list the same Upstream Issue URL.

## Why

One upstream tracking issue reused across multiple proposals in a term usually
means the same effort was proposed twice, which an admin should reconcile.
Surfaced as a warning (like Over Quota), not a hard block.

## Changes

- `lib/validate.js`: `normalizeUpstreamUrl` and `findDuplicateUpstreamIssues`,
  both pure and unit-tested. Normalization drops protocol, a leading `www.`, the
  `#fragment`, and any trailing slash, and lowercases host and path so the same
  issue in different casing compares equal. Blank URLs never match.
- `lfx-proposal-validate.yml`: hoist the same-project-and-term scan out of the
  quota check so both checks share one `listForRepo` call; add the comment-only
  duplicate warning. If the scan fails, both checks skip rather than run on
  incomplete data.

## Validation

498 unit tests (9 new). Workflow YAML and every embedded `github-script` block
pass `node --check`. The decision logic is unit-tested; the shared scan is the
quota check's existing filter (unchanged), and the `Upstream Issue URL` field key
is the same one the current-issue upstream check already relies on, so no
end-to-end run is needed.
