### PR TITLE
fix(lfx): run every slash command in a comment, not just the first

### DIFF
--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -46,6 +46,7 @@ jobs:
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
             const { parseIssueForm, parseMentors } = _lib('parse.js');
+            const { parseCommands } = _lib('commands.js');
             const { resolveProjectMaintainer } = _lib('authorize.js');
             const { computeConfirm } = _lib('confirm.js');
             const { lookupProject } = _lib('projects.js');
@@ -63,18 +64,13 @@ jobs:
             const issueBody = context.payload.issue.body || '';
             const currentLabels = (context.payload.issue.labels || []).map(l => l.name);
 
-            // ── Detect slash command ──
-            // Scan every line; the command may not be the first line (e.g.
-            // someone writes context before their /approve). /lfx-url takes a
-            // URL argument (the rest of the line); the others take none.
-            let command = null;
-            let commandArg = '';
-            for (const line of commentBody.split('\n')) {
-              const m = line.trim().match(/^\/(lfx-url|cncf-approve|approve|confirm)\b\s*(.*)$/);
-              if (m) { command = m[1]; commandArg = (m[2] || '').trim(); break; }
-            }
-            if (!command) return;  // no slash command found
-            console.log(`/${command} from @${commenter}`);
+            // ── Detect slash command(s) ──
+            // A comment may carry more than one command (e.g. /confirm and
+            // /approve together). parseCommands returns them in document order,
+            // deduped by name; each command may lead any line (prose before it
+            // is fine). /lfx-url takes a URL argument; the others take none.
+            const commands = parseCommands(commentBody);
+            if (commands.length === 0) return;  // no slash command found
 
             // ── Reaction: eyes while processing ──
             await github.rest.reactions.createForIssueComment({
@@ -127,6 +123,13 @@ jobs:
                 });
               }
             }
+
+            // Dispatch one slash command. Written as a function so the workflow
+            // can run each command a comment carries in turn; every early
+            // `return` below exits only the current command's handling. The body
+            // keeps its original indentation to keep this diff reviewable.
+            async function handleCommand(command, commandArg) {
+              console.log(`/${command} from @${commenter}`);
 
             // ══════════════════════════════════════════════════
             //  /approve: Maintainer / Contribex Approval
@@ -528,6 +531,10 @@ jobs:
               }
               return;
             }
+            } // end handleCommand
+
+            // Process the command. (A later change loops over every command.)
+            await handleCommand(commands[0].command, commands[0].arg);
 
       - name: Open or update the LFX URL pull request
         if: env.LFX_URL_FILES_CHANGED == 'true'

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -533,8 +533,15 @@ jobs:
             }
             } // end handleCommand
 
-            // Process the command. (A later change loops over every command.)
-            await handleCommand(commands[0].command, commands[0].arg);
+            // Run every command the comment carried, in document order, so a
+            // combined comment (e.g. /confirm and /approve) has each command act
+            // instead of only the first (cncf/mentoring#1977, #1978). Label
+            // state threads through the shared currentLabels array, so a
+            // /confirm + /approve (+ /cncf-approve) sequence cascades correctly
+            // within one run.
+            for (const { command, arg } of commands) {
+              await handleCommand(command, arg);
+            }
 
       - name: Open or update the LFX URL pull request
         if: env.LFX_URL_FILES_CHANGED == 'true'

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -73,9 +73,14 @@ jobs:
             if (commands.length === 0) return;  // no slash command found
 
             // ── Reaction: eyes while processing ──
-            await github.rest.reactions.createForIssueComment({
-              owner, repo, comment_id: comment.id, content: 'eyes',
-            });
+            // Best-effort: a cosmetic reaction must never block command handling.
+            try {
+              await github.rest.reactions.createForIssueComment({
+                owner, repo, comment_id: comment.id, content: 'eyes',
+              });
+            } catch (e) {
+              console.log(`Could not add eyes reaction: ${e.message}`);
+            }
 
             // ── Parse issue form ──
             const fields = parseIssueForm(issueBody);
@@ -100,9 +105,18 @@ jobs:
             // ── Feedback helper ──
             async function reply(emoji, message) {
               const reaction = emoji === '✅' ? '+1' : emoji === '❌' ? '-1' : 'confused';
-              await github.rest.reactions.createForIssueComment({
-                owner, repo, comment_id: comment.id, content: reaction,
-              });
+              // Best-effort reaction: it is cosmetic, so a failure here must never
+              // block the comment (the command's actual acknowledgement) or, in
+              // the multi-command loop, a later command. Adding the same reaction
+              // twice is idempotent (the API returns 200, not an error), so a
+              // repeated +1 across commands is fine; this guards other failures.
+              try {
+                await github.rest.reactions.createForIssueComment({
+                  owner, repo, comment_id: comment.id, content: reaction,
+                });
+              } catch (e) {
+                console.log(`Could not add ${reaction} reaction: ${e.message}`);
+              }
               await github.rest.issues.createComment({
                 owner, repo, issue_number, body: `${emoji} ${message}`,
               });

--- a/programs/lfx-mentorship/automation/lib/commands.js
+++ b/programs/lfx-mentorship/automation/lib/commands.js
@@ -11,10 +11,12 @@
 // at the first match and silently dropped the rest).
 
 // The recognized commands. cncf-approve is listed before approve so the
-// alternation matches the longer command first (both are anchored, and the
-// trailing \b prevents /approved matching /approve, but ordering keeps intent
-// clear).
-const COMMAND_RE = /^\/(lfx-url|cncf-approve|approve|confirm)\b\s*(.*)$/;
+// alternation matches the longer command first (both are anchored). The command
+// must be followed by whitespace or end-of-line, so a hyphenated or longer token
+// (/approve-now, /approved) does not read as the command; a plain \b would treat
+// the hyphen as a boundary and mis-match /approve-now as /approve. The rest of
+// the line is the argument (only /lfx-url uses it).
+const COMMAND_RE = /^\/(lfx-url|cncf-approve|approve|confirm)(?=\s|$)\s*(.*)$/;
 
 // Parse an issue-comment body into an ordered list of { command, arg }.
 // - A command must be the first non-whitespace token on its own line; it may

--- a/programs/lfx-mentorship/automation/lib/commands.js
+++ b/programs/lfx-mentorship/automation/lib/commands.js
@@ -10,12 +10,13 @@
 // (cncf/mentoring#1977, #1978, where the earlier single-command parser stopped
 // at the first match and silently dropped the rest).
 
-// The recognized commands. cncf-approve is listed before approve so the
-// alternation matches the longer command first (both are anchored). The command
-// must be followed by whitespace or end-of-line, so a hyphenated or longer token
-// (/approve-now, /approved) does not read as the command; a plain \b would treat
-// the hyphen as a boundary and mis-match /approve-now as /approve. The rest of
-// the line is the argument (only /lfx-url uses it).
+// The recognized commands. The pattern is anchored at the start of the line
+// (^/) and each command must be followed by whitespace or end-of-line, so a
+// hyphenated or longer token (/approve-now, /approved) does not read as a
+// command; a plain \b would treat the hyphen as a boundary and mis-match
+// /approve-now as /approve. Alternation order does not affect correctness here
+// (no command is a prefix of another at the anchor). The rest of the line is
+// the argument (only /lfx-url uses it).
 const COMMAND_RE = /^\/(lfx-url|cncf-approve|approve|confirm)(?=\s|$)\s*(.*)$/;
 
 // Parse an issue-comment body into an ordered list of { command, arg }.

--- a/programs/lfx-mentorship/automation/lib/commands.js
+++ b/programs/lfx-mentorship/automation/lib/commands.js
@@ -1,0 +1,40 @@
+'use strict';
+
+// Slash-command parsing for the LFX proposal approvals workflow
+// (lfx-proposal-approvals.yml). Extracted so the workflow is thin glue over a
+// unit-tested function.
+//
+// A comment may carry more than one command (e.g. a mentor who is also a
+// maintainer writing `/confirm` and `/approve` together): the workflow executes
+// each in document order, so both act instead of only the first
+// (cncf/mentoring#1977, #1978, where the earlier single-command parser stopped
+// at the first match and silently dropped the rest).
+
+// The recognized commands. cncf-approve is listed before approve so the
+// alternation matches the longer command first (both are anchored, and the
+// trailing \b prevents /approved matching /approve, but ordering keeps intent
+// clear).
+const COMMAND_RE = /^\/(lfx-url|cncf-approve|approve|confirm)\b\s*(.*)$/;
+
+// Parse an issue-comment body into an ordered list of { command, arg }.
+// - A command must be the first non-whitespace token on its own line; it may
+//   appear on any line (prose before it is fine).
+// - arg is the remainder of the line, trimmed (only /lfx-url uses it).
+// - Duplicate commands are removed, keeping the first occurrence (and its arg),
+//   so a comment expresses each intent once.
+// Returns [] when the body is blank or carries no recognized command.
+function parseCommands(body) {
+  const seen = new Set();
+  const commands = [];
+  for (const line of String(body == null ? '' : body).split('\n')) {
+    const m = line.trim().match(COMMAND_RE);
+    if (!m) continue;
+    const command = m[1];
+    if (seen.has(command)) continue;
+    seen.add(command);
+    commands.push({ command, arg: (m[2] || '').trim() });
+  }
+  return commands;
+}
+
+module.exports = { parseCommands, COMMAND_RE };

--- a/programs/lfx-mentorship/automation/test/commands.test.js
+++ b/programs/lfx-mentorship/automation/test/commands.test.js
@@ -71,8 +71,13 @@ test('parseCommands: a slash command mid-sentence does not match (must lead its 
 });
 
 test('parseCommands: a longer word starting with a command name does not match', () => {
-  // /approved must not read as /approve (word boundary after the command).
+  // The command must be followed by whitespace or end-of-line, so neither a
+  // word-char continuation (/approved) nor a hyphenated token (/approve-now)
+  // reads as the command.
   assert.deepEqual(parseCommands('/approved'), []);
+  assert.deepEqual(parseCommands('/approve-now'), []);
+  assert.deepEqual(parseCommands('/confirm-please'), []);
+  assert.deepEqual(parseCommands('/cncf-approve-x'), []);
 });
 
 test('parseCommands: leading whitespace on the line is tolerated', () => {

--- a/programs/lfx-mentorship/automation/test/commands.test.js
+++ b/programs/lfx-mentorship/automation/test/commands.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseCommands } = require('../lib/commands');
+
+// parseCommands scans an issue-comment body for slash commands, one per line,
+// and returns them as ordered { command, arg } objects. It backs the LFX
+// proposal approvals workflow, which executes each command in turn, so a
+// single comment can carry e.g. `/confirm` and `/approve` and have both act
+// (cncf/mentoring#1977, #1978, where only the first was processed).
+
+test('parseCommands: a single command with no argument', () => {
+  assert.deepEqual(parseCommands('/approve'), [{ command: 'approve', arg: '' }]);
+});
+
+test('parseCommands: multiple commands are returned in document order', () => {
+  assert.deepEqual(
+    parseCommands('/confirm\n/approve'),
+    [{ command: 'confirm', arg: '' }, { command: 'approve', arg: '' }],
+  );
+});
+
+test('parseCommands: a command may appear on any line, not just the first', () => {
+  assert.deepEqual(
+    parseCommands('thanks all, looks good\n\n/approve'),
+    [{ command: 'approve', arg: '' }],
+  );
+});
+
+test('parseCommands: /lfx-url keeps its (trimmed) URL argument', () => {
+  assert.deepEqual(
+    parseCommands('/lfx-url   https://mentorship.lfx.linuxfoundation.org/project/abc  '),
+    [{ command: 'lfx-url', arg: 'https://mentorship.lfx.linuxfoundation.org/project/abc' }],
+  );
+});
+
+test('parseCommands: cncf-approve is not misparsed as approve', () => {
+  assert.deepEqual(parseCommands('/cncf-approve'), [{ command: 'cncf-approve', arg: '' }]);
+});
+
+test('parseCommands: duplicate commands are de-duped, keeping the first occurrence', () => {
+  assert.deepEqual(parseCommands('/approve\n/approve'), [{ command: 'approve', arg: '' }]);
+  // First occurrence's argument wins.
+  assert.deepEqual(
+    parseCommands('/lfx-url https://a\n/lfx-url https://b'),
+    [{ command: 'lfx-url', arg: 'https://a' }],
+  );
+});
+
+test('parseCommands: a realistic three-command comment, in order', () => {
+  assert.deepEqual(
+    parseCommands('/confirm\n/approve\n/cncf-approve'),
+    [
+      { command: 'confirm', arg: '' },
+      { command: 'approve', arg: '' },
+      { command: 'cncf-approve', arg: '' },
+    ],
+  );
+});
+
+test('parseCommands: no command yields an empty array', () => {
+  assert.deepEqual(parseCommands('just a normal comment, no commands here'), []);
+  assert.deepEqual(parseCommands(''), []);
+  assert.deepEqual(parseCommands(null), []);
+  assert.deepEqual(parseCommands(undefined), []);
+});
+
+test('parseCommands: a slash command mid-sentence does not match (must lead its line)', () => {
+  assert.deepEqual(parseCommands('please /approve this'), []);
+});
+
+test('parseCommands: a longer word starting with a command name does not match', () => {
+  // /approved must not read as /approve (word boundary after the command).
+  assert.deepEqual(parseCommands('/approved'), []);
+});
+
+test('parseCommands: leading whitespace on the line is tolerated', () => {
+  assert.deepEqual(parseCommands('   /approve'), [{ command: 'approve', arg: '' }]);
+});
+
+test('parseCommands: CRLF line endings are handled', () => {
+  assert.deepEqual(
+    parseCommands('/confirm\r\n/approve\r\n'),
+    [{ command: 'confirm', arg: '' }, { command: 'approve', arg: '' }],
+  );
+});


### PR DESCRIPTION
## What

Make the LFX proposal approvals workflow run **every** slash command in a
comment, in document order, instead of only the first.

## Why

The command parser scanned for one command and stopped, so a combined comment
like:

```
/confirm
/approve
```

ran only `/confirm` and silently dropped `/approve`: no action, and no
acknowledgement that it was ignored. Observed live in #1977 and #1978, where
mentors wrote `/confirm` + `/approve` together and the proposals were left
`Awaiting Maintainer/Contribex Approval` despite the mentors believing they had
approved.

## How

- **`lib/commands.js` (new, unit-tested):** `parseCommands(body)` returns every
  recognized command as ordered `{ command, arg }`, de-duped by name (first
  occurrence wins). The command must lead its line and be followed by whitespace
  or end-of-line, so a hyphenated token like `/approve-now` is not mistaken for
  `/approve`.
- **`lfx-proposal-approvals.yml`:** the four command blocks are wrapped in an
  inner `handleCommand(command, arg)` (behavior-preserving refactor), then the
  workflow loops over every parsed command. Shared `currentLabels` state threads
  between commands, so `/confirm` + `/approve` (+ `/cncf-approve`) in one comment
  cascades to the right gates within a single run. Each command still posts its
  own reply, so every command is both acted on and acknowledged.

## Validation

512 unit tests; workflow YAML and every embedded `github-script` block pass
`node --check`. Verified end-to-end on the dev fork: a single comment carrying
`/confirm` + `/approve` + `/cncf-approve` drove a disposable proposal all the way
to `CNCF Approved` (each command acted and the state cascaded); under the old
parser it stalled at `Awaiting Maintainer/Contribex Approval`.
