### PR TITLE
feat(lfx): split export PR list into newly-added vs updated

### DIFF
--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -40,8 +40,8 @@ jobs:
             const { standardPrerequisites } = _lib('prerequisites.js');
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
-            const { serializeExport, changedExportPrograms } = _lib('export-json.js');
-            const { parseRecordedLfxUrl, renderRecordedIssues, programCountLabel } = _lib('lfx-url.js');
+            const { serializeExport, partitionExportChanges } = _lib('export-json.js');
+            const { parseRecordedLfxUrl, exportChangeLabel, renderExportChangeBody } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
             const { lookupProject } = _lib('projects.js');
             const { lfxTitle } = _lib('title.js');
@@ -178,7 +178,7 @@ jobs:
             if (existingExport != null) {
               try { baselineExport = JSON.parse(existingExport); } catch { baselineExport = null; }
             }
-            const changedPrograms = changedExportPrograms(baselineExport, exportData);
+            const { added, updated } = partitionExportChanges(baselineExport, exportData);
 
             // ── Generate README.md ──
             // The body (Table of Contents + Accepted Projects) is rendered by
@@ -209,21 +209,20 @@ jobs:
             core.exportVariable('EXPORT_TERM_DIR', termDir);
             core.exportVariable('EXPORT_YEAR', year);
             // The Exported label and board sync act on the full exported set
-            // (state, idempotent/guarded); the PR summary and the notification
-            // comment act only on the changed set, so a re-export never re-lists
-            // or re-notifies already-exported programs.
+            // (state, idempotent/guarded). The PR summary splits the changed set
+            // into newly-added vs updated (#1992); the notification comment goes
+            // ONLY to newly-added programs, so a re-export never re-lists the full
+            // term nor re-pings a program whose data merely refreshed (e.g. a
+            // project maturity change).
             core.exportVariable('EXPORTED_ISSUES', programs.map(p => p.issue_number).join(','));
-            core.exportVariable('CHANGED_ISSUES', changedPrograms.map(p => p.issue_number).join(','));
-            core.exportVariable('EXPORT_PROGRAM_LABEL', programCountLabel(changedPrograms.length));
+            core.exportVariable('NOTIFY_ISSUES', added.map(p => p.issue_number).join(','));
+            core.exportVariable('EXPORT_PROGRAM_LABEL', exportChangeLabel(added.length, updated.length));
 
-            // PR body lists only what this run adds or changes (renderRecordedIssues
-            // is shared with the /lfx-url PR for a consistent format). changedPrograms
-            // can be empty while the run still opens a PR (a program was removed, or
-            // only regenerated files changed), so fall back to an explicit line
-            // rather than leave a blank "Added or updated" section.
-            const changedList = renderRecordedIssues(changedPrograms);
-            core.exportVariable('PR_BODY_ISSUES',
-              changedList || '_No programs added or updated in this run (removals or regenerated files only)._');
+            // PR body: a "Newly added" section and/or an "Updated" section, each
+            // shown only when non-empty, with a fallback line when neither is
+            // present (removals or regenerated files only). Rendering + the
+            // empty-section handling live in the tested lib helper.
+            core.exportVariable('PR_BODY_ISSUES', renderExportChangeBody(added, updated));
 
       - name: Check for changes
         id: check
@@ -254,7 +253,6 @@ jobs:
             Auto-generated export of the CNCF-approved LFX Mentorship programs
             for **${{ env.EXPORT_TERM }}**.
 
-            **Added or updated in this PR:**
             ${{ env.PR_BODY_ISSUES }}
 
             **Export files:**
@@ -274,7 +272,7 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const issues = process.env.EXPORTED_ISSUES.split(',').filter(Boolean);
-            const changed = new Set((process.env.CHANGED_ISSUES || '').split(',').filter(Boolean).map(Number));
+            const notify = new Set((process.env.NOTIFY_ISSUES || '').split(',').filter(Boolean).map(Number));
             const term = process.env.EXPORT_TERM;
             const year = process.env.EXPORT_YEAR;
             const termDir = process.env.EXPORT_TERM_DIR;
@@ -288,11 +286,12 @@ jobs:
                 labels: ['Exported'],
               });
 
-              // Only comment on issues this run actually added or changed, so a
-              // re-export doesn't re-post "included in export" on proposals that
-              // were already exported in a prior run.
-              if (!changed.has(issue_number)) {
-                console.log(`#${issue_number} unchanged in this export; no comment`);
+              // Comment only on programs NEWLY added to the export this run, so a
+              // re-export never re-posts "included in export" on an already-exported
+              // proposal -- including one that only appears in this run because its
+              // data was updated (e.g. a project maturity refresh).
+              if (!notify.has(issue_number)) {
+                console.log(`#${issue_number} not newly added in this export; no comment`);
                 continue;
               }
 

--- a/programs/lfx-mentorship/automation/lib/export-json.js
+++ b/programs/lfx-mentorship/automation/lib/export-json.js
@@ -38,15 +38,37 @@ function serializeExport(data, existingText) {
 // when absent from the baseline or serialized differently. A null/malformed
 // baseline yields every program (a safe fallback to the pre-change "list all"
 // behavior, e.g. a term's first export). Insertion order of afterData is kept.
-function changedExportPrograms(beforeData, afterData) {
+function collectExportChanges(beforeData, afterData) {
   const before = new Map();
   const baseline = beforeData && Array.isArray(beforeData.programs) ? beforeData.programs : [];
   for (const p of baseline) {
     if (p && Number.isInteger(p.issue_number)) before.set(p.issue_number, JSON.stringify(p));
   }
   const after = afterData && Array.isArray(afterData.programs) ? afterData.programs : [];
-  return after.filter((p) => p && Number.isInteger(p.issue_number)
-    && before.get(p.issue_number) !== JSON.stringify(p));
+  const changed = [];
+  const added = [];
+  const updated = [];
+  for (const p of after) {
+    if (!p || !Number.isInteger(p.issue_number)) continue;
+    const serialized = JSON.stringify(p);
+    if (!before.has(p.issue_number)) {
+      changed.push(p);
+      added.push(p);
+    } else if (before.get(p.issue_number) !== serialized) {
+      changed.push(p);
+      updated.push(p);
+    }
+  }
+  return { changed, added, updated };
 }
 
-module.exports = { serializeExport, ignoreGenerated, changedExportPrograms };
+function changedExportPrograms(beforeData, afterData) {
+  return collectExportChanges(beforeData, afterData).changed;
+}
+
+function partitionExportChanges(beforeData, afterData) {
+  const { added, updated } = collectExportChanges(beforeData, afterData);
+  return { added, updated };
+}
+
+module.exports = { serializeExport, ignoreGenerated, changedExportPrograms, partitionExportChanges };

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -312,11 +312,40 @@ function stripLfxUrlBlock(body) {
     .replace(/\s*<!-- lfx-url:start -->[\s\S]*?<!-- lfx-url:end -->/, '');
 }
 
+// The adaptive program-change count in the export PR title. Names only the
+// buckets present: "5 new, 1 updated" when both, "5 new" or "1 updated" when
+// only one, and "no program changes" when neither (a removal-only or
+// regenerated-files-only re-export still opens a PR). "new"/"updated" are
+// adjectives, so no pluralization is needed. (cncf/mentoring#1992)
+function exportChangeLabel(addedCount, updatedCount) {
+  const a = Number.isInteger(addedCount) && addedCount > 0 ? addedCount : 0;
+  const u = Number.isInteger(updatedCount) && updatedCount > 0 ? updatedCount : 0;
+  const parts = [];
+  if (a) parts.push(`${a} new`);
+  if (u) parts.push(`${u} updated`);
+  return parts.length ? parts.join(', ') : 'no program changes';
+}
+
+// The export PR body's change section(s): a "Newly added" list and/or an
+// "Updated" list, each shown only when non-empty, so a re-export that only
+// updates existing entries shows just "Updated" (and vice versa). Falls back to
+// an explicit line when neither is present, so the section is never blank. Lines
+// are formatted by renderRecordedIssues. (cncf/mentoring#1992)
+function renderExportChangeBody(added, updated) {
+  const sections = [];
+  if (added && added.length) sections.push(`**Newly added:**\n${renderRecordedIssues(added)}`);
+  if (updated && updated.length) sections.push(`**Updated:**\n${renderRecordedIssues(updated)}`);
+  return sections.length
+    ? sections.join('\n\n')
+    : '_No programs added or updated in this run (removals or regenerated files only)._';
+}
+
 module.exports = {
   recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision,
   findExportedProgram, exportTermLabel, readExports, locateExportedProgram,
   termMismatchWarning, recordedPrograms, renderRecordedIssues, recordedUrlNextSteps,
   changedRecordedPrograms, programCountLabel,
   populateRecordedUrls, upsertLfxUrlBlock, stripLfxUrlBlock,
+  exportChangeLabel, renderExportChangeBody,
   LFX_PROGRAM_URL_RE,
 };

--- a/programs/lfx-mentorship/automation/test/export-json.test.js
+++ b/programs/lfx-mentorship/automation/test/export-json.test.js
@@ -46,7 +46,7 @@ test('ignoreGenerated: strips the _generated line so content-equal exports match
 // adds or changes vs the export already on main, mirroring the /lfx-url
 // batch-list fix (#1949). Compares each program's full serialization keyed by
 // issue_number.
-const { changedExportPrograms } = require('../lib/export-json');
+const { changedExportPrograms, partitionExportChanges } = require('../lib/export-json');
 
 const prog = (n, over = {}) => ({ issue_number: n, program_name_full: `P${n}`, description: `d${n}`, lfx_url: '', ...over });
 const data = (...programs) => ({ _generated: 'NOW', _term: 'T', _count: programs.length, programs });
@@ -90,4 +90,73 @@ test('changedExportPrograms: comparison is independent of baseline ordering', ()
 test('changedExportPrograms: guards a missing/!array after programs list', () => {
   assert.deepEqual(changedExportPrograms(data(prog(1)), null), []);
   assert.deepEqual(changedExportPrograms(data(prog(1)), {}), []);
+});
+
+// ── partitionExportChanges: split changed programs into added vs updated ─────
+
+test('partitionExportChanges: a brand-new program is added, not updated', () => {
+  const before = data(prog(1));
+  const after = data(prog(1), prog(2));
+  const changes = partitionExportChanges(before, after);
+  assert.deepEqual(changes.added.map(p => p.issue_number), [2]);
+  assert.deepEqual(changes.updated, []);
+});
+
+test('partitionExportChanges: an existing program with changed maturity is updated, not added', () => {
+  const before = data(prog(1928, { cncf_project_maturity: 'incubating' }));
+  const after = data(prog(1928, { cncf_project_maturity: 'graduated' }));
+  const changes = partitionExportChanges(before, after);
+  assert.deepEqual(changes.added, []);
+  assert.deepEqual(changes.updated.map(p => p.issue_number), [1928]);
+});
+
+test('partitionExportChanges: an existing byte-identical program appears in neither list', () => {
+  const before = data(prog(1));
+  const after = data(prog(1));
+  assert.deepEqual(partitionExportChanges(before, after), { added: [], updated: [] });
+});
+
+test('partitionExportChanges: returns added and updated programs with order preserved per list', () => {
+  const before = data(prog(1), prog(2), prog(3));
+  const after = data(prog(1), prog(2, { description: 'edited' }), prog(3), prog(4), prog(5));
+  const changes = partitionExportChanges(before, after);
+  assert.deepEqual(changes.added.map(p => p.issue_number), [4, 5]);
+  assert.deepEqual(changes.updated.map(p => p.issue_number), [2]);
+});
+
+test('partitionExportChanges: null/empty/missing baseline treats every after-program as added', () => {
+  const after = data(prog(1), prog(2));
+  assert.deepEqual(partitionExportChanges(null, after), { added: after.programs, updated: [] });
+  assert.deepEqual(partitionExportChanges({}, after), { added: after.programs, updated: [] });
+  assert.deepEqual(partitionExportChanges({ programs: null }, after), { added: after.programs, updated: [] });
+});
+
+test('partitionExportChanges: empty/undefined afterData returns empty lists', () => {
+  const before = data(prog(1));
+  assert.deepEqual(partitionExportChanges(before, undefined), { added: [], updated: [] });
+  assert.deepEqual(partitionExportChanges(before, { programs: [] }), { added: [], updated: [] });
+});
+
+test('partitionExportChanges: ignores entries missing or with non-integer issue_number', () => {
+  const before = data(prog(1));
+  const after = data(
+    prog(1),
+    { program_name_full: 'missing issue number' },
+    { issue_number: '2', program_name_full: 'string issue number' },
+    { issue_number: 3.5, program_name_full: 'decimal issue number' },
+    null,
+    prog(2),
+  );
+  const changes = partitionExportChanges(before, after);
+  assert.deepEqual(changes.added.map(p => p.issue_number), [2]);
+  assert.deepEqual(changes.updated, []);
+});
+
+test('partitionExportChanges: changed programs match changedExportPrograms issue_numbers', () => {
+  const before = data(prog(1), prog(2), prog(3));
+  const after = data(prog(1), prog(2, { lfx_url: 'x' }), prog(3), prog(4), prog(5));
+  const changes = partitionExportChanges(before, after);
+  const partitioned = [...changes.added, ...changes.updated].map(p => p.issue_number).sort((a, b) => a - b);
+  const changed = changedExportPrograms(before, after).map(p => p.issue_number).sort((a, b) => a - b);
+  assert.deepEqual(partitioned, changed);
 });

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -7,6 +7,7 @@ const {
   exportTermLabel, readExports, locateExportedProgram, termMismatchWarning,
   recordedPrograms, renderRecordedIssues, recordedUrlNextSteps, populateRecordedUrls,
   changedRecordedPrograms, programCountLabel, upsertLfxUrlBlock, stripLfxUrlBlock,
+  exportChangeLabel, renderExportChangeBody,
 } = require('../lib/lfx-url');
 
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
@@ -611,4 +612,67 @@ test('stripLfxUrlBlock: is a no-op when there is no block', () => {
   const body = '### CNCF Project\n\nkubernetes';
   assert.equal(stripLfxUrlBlock(body), body);
   assert.equal(stripLfxUrlBlock(''), '');
+});
+
+// ── exportChangeLabel: the adaptive program-change count in the export PR title.
+//    Names only the buckets present: "5 new, 1 updated" when both; "5 new" or
+//    "1 updated" when only one; "no program changes" when neither (a removal-only
+//    or regenerated-files-only re-export still opens a PR). (cncf/mentoring#1992)
+test('exportChangeLabel: both buckets present', () => {
+  assert.equal(exportChangeLabel(5, 1), '5 new, 1 updated');
+});
+test('exportChangeLabel: only newly added', () => {
+  assert.equal(exportChangeLabel(5, 0), '5 new');
+});
+test('exportChangeLabel: only updated', () => {
+  assert.equal(exportChangeLabel(0, 1), '1 updated');
+});
+test('exportChangeLabel: neither -> no program changes', () => {
+  assert.equal(exportChangeLabel(0, 0), 'no program changes');
+});
+test('exportChangeLabel: guards non-integer / negative counts to zero', () => {
+  assert.equal(exportChangeLabel(-2, 2.5), 'no program changes');
+  assert.equal(exportChangeLabel(1, undefined), '1 new');
+  assert.equal(exportChangeLabel(undefined, 3), '3 updated');
+});
+test('exportChangeLabel: no em-dash', () => {
+  assert.ok(!exportChangeLabel(5, 1).includes('\u2014'));
+});
+
+// ── renderExportChangeBody: the export PR body's change section(s). A
+//    "Newly added" list and/or an "Updated" list, each shown only when
+//    non-empty; an explicit fallback line when neither is present. Lines are
+//    formatted by renderRecordedIssues. (cncf/mentoring#1992)
+test('renderExportChangeBody: both sections when both are non-empty', () => {
+  const added = [{ issue_number: 1, program_name_full: 'CNCF - A (T)' }];
+  const updated = [{ issue_number: 2, program_name_full: 'CNCF - B (T)' }];
+  assert.equal(
+    renderExportChangeBody(added, updated),
+    '**Newly added:**\n- #1 CNCF - A (T)\n\n**Updated:**\n- #2 CNCF - B (T)',
+  );
+});
+test('renderExportChangeBody: only the Newly added section when nothing was updated', () => {
+  const added = [{ issue_number: 1, program_name_full: 'CNCF - A (T)' }];
+  assert.equal(renderExportChangeBody(added, []), '**Newly added:**\n- #1 CNCF - A (T)');
+});
+test('renderExportChangeBody: only the Updated section when nothing was added', () => {
+  const updated = [{ issue_number: 2, program_name_full: 'CNCF - B (T)' }];
+  assert.equal(renderExportChangeBody([], updated), '**Updated:**\n- #2 CNCF - B (T)');
+});
+test('renderExportChangeBody: fallback line when neither section has entries', () => {
+  assert.equal(
+    renderExportChangeBody([], []),
+    '_No programs added or updated in this run (removals or regenerated files only)._',
+  );
+  assert.equal(
+    renderExportChangeBody(undefined, undefined),
+    '_No programs added or updated in this run (removals or regenerated files only)._',
+  );
+});
+test('renderExportChangeBody: no em-dash', () => {
+  const md = renderExportChangeBody(
+    [{ issue_number: 1, program_name_full: 'CNCF - A (T)' }],
+    [{ issue_number: 2, program_name_full: 'CNCF - B (T)' }],
+  );
+  assert.ok(!md.includes('\u2014'));
 });


### PR DESCRIPTION
## What

Split the LFX export PR's program list into **newly added** vs **updated**,
instead of a single flat "added or updated" count, and scope the export
notification to newly-added programs only.

## Why

The export PR conflated two different things: programs newly added to the export
this run, and already-exported programs whose serialized data merely changed. In
cncf/mentoring#1992 the title said "6 programs" when only 5 were new: Kubeflow
#1928 re-appeared solely because its `cncf_project_maturity` refreshed from
`incubating` to `graduated` via a landscape sync. That is worth surfacing, but as
an update, not a new export, and its mentors should not be re-pinged for it.

## How

- **`lib/export-json.js`:** `partitionExportChanges(before, after)` returns
  `{ added, updated }` (a refinement of `changedExportPrograms`, which is
  unchanged). `added` = issue not in the baseline; `updated` = existing issue
  whose serialized data changed.
- **`lib/lfx-url.js`:** two tested display helpers, `exportChangeLabel` (adaptive
  title count: "5 new, 1 updated", or "N new" / "N updated" when only one kind,
  or "no program changes") and `renderExportChangeBody` (a "Newly added" and/or
  "Updated" section, each shown only when non-empty).
- **`lfx-export.yml`:** uses those helpers for the title and body, and scopes the
  export notification comment to **newly-added programs only**, so a re-export
  that merely updates an existing entry (e.g. a maturity refresh) no longer
  re-pings its mentors.

## Validation

531 unit tests pass; the workflow YAML and every embedded `github-script` block
pass `node --check`. Full dev end-to-end (fork) is green across five scenarios:

1. New only -> title "1 new", "Newly added" section only, program notified once.
2. Materially edit + re-approve that program (drops it from the notified set).
3. Add a brand-new program.
4. Re-export -> title "1 new, 1 updated"; new program in "Newly added" and
   notified, edited program in "Updated" and **not** re-notified.
5. Edit + re-approve again with no new program -> title "1 updated", "Updated"
   section only, no "Newly added" section, and **nobody** notified (empty notify
   set).
