### PR TITLE
feat(lfx): route etcd and Headlamp approvals through SIG ContribEx

### DIFF
--- a/programs/lfx-mentorship/automation/approvers.yml
+++ b/programs/lfx-mentorship/automation/approvers.yml
@@ -46,6 +46,32 @@ kubernetes:
     - MadhavJivrajani
     - Priyankasaggu11929
 
+# Kubernetes SUBPROJECTS route mentorship approvals through SIG ContribEx too,
+# exactly like Kubernetes itself, so their own maintainer rosters are skipped and
+# only the SIG ContribEx handles (plus global_approvers) can /approve. The roster
+# below is duplicated from the `kubernetes` entry above; if SIG ContribEx
+# leadership changes, update all three entries (kubernetes, etcd, headlamp) in
+# lockstep. (cncf/mentoring#1995)
+etcd:
+  # kubernetes subproject (etcd-io/etcd)
+  maintainers_can_approve: false
+  fallback_handles:
+    - kaslin
+    - mfahlandt
+    - palnabarun
+    - MadhavJivrajani
+    - Priyankasaggu11929
+
+headlamp:
+  # kubernetes subproject (kubernetes-sigs/headlamp)
+  maintainers_can_approve: false
+  fallback_handles:
+    - kaslin
+    - mfahlandt
+    - palnabarun
+    - MadhavJivrajani
+    - Priyankasaggu11929
+
 open-telemetry:
   # OTel governance (per @maryliag, cncf/mentoring#1930): each SIG has an
   # assigned GC liaison who ideally reviews that SIG's proposal, but any


### PR DESCRIPTION
## What

Route LFX mentorship approvals for **etcd** and **Headlamp** through SIG
Contributor Experience, the same as Kubernetes itself.

## Why

etcd (`etcd-io/etcd`) and Headlamp (`kubernetes-sigs/headlamp`) are Kubernetes
subprojects. Their mentorship proposals follow Kubernetes governance: approval
comes from SIG ContribEx, not from the subproject's own maintainers. Until now
the automation treated them as standalone projects and would have accepted an
`/approve` from their maintainer rosters.

## How

Add an `approvers.yml` entry for each, mirroring the existing `kubernetes` entry:
`maintainers_can_approve: false` plus the SIG ContribEx roster. That skips the
project-maintainer tiers, so only SIG ContribEx (and `global_approvers`) can
`/approve`. The roster is duplicated across the three entries; a comment notes
they must be updated in lockstep.

Config-only: no workflow or library changes. Existing `lib/approvers.js` tests
(531 total) still pass, and the real `approvers.yml` resolves as intended via
those helpers (etcd and Headlamp both -> maintainers skipped + SIG ContribEx
roster; unrelated projects stay on the default additive model).

Refs: #1995
