### PR TITLE
feat(lfx): sticky export - carry forward exported programs

### DIFF
--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -249,13 +249,16 @@ jobs:
             core.exportVariable('EXPORT_TERM', term);
             core.exportVariable('EXPORT_TERM_DIR', termDir);
             core.exportVariable('EXPORT_YEAR', year);
-            // The Exported label and board sync act on the full exported set
-            // (state, idempotent/guarded). The PR summary splits the changed set
-            // into newly-added vs updated (#1992); the notification comment goes
-            // ONLY to newly-added programs, so a re-export never re-lists the full
-            // term nor re-pings a program whose data merely refreshed (e.g. a
-            // project maturity change).
-            core.exportVariable('EXPORTED_ISSUES', programs.map(p => p.issue_number).join(','));
+            // The Exported label and board sync act on the currently-APPROVED
+            // programs, not the full sticky set: carried-forward frozen programs
+            // (whose approval lapsed) keep whatever labels/board state they
+            // already have and must not be re-touched, and re-labeling a program
+            // that isn't a live issue this run would fail the step (#2015). The PR
+            // summary splits the changed set into newly-added vs updated (#1992);
+            // the notification comment goes ONLY to newly-added programs, so a
+            // re-export never re-lists the full term nor re-pings a program whose
+            // data merely refreshed (e.g. a project maturity change).
+            core.exportVariable('EXPORTED_ISSUES', approvedPrograms.map(p => p.issue_number).join(','));
             core.exportVariable('NOTIFY_ISSUES', added.map(p => p.issue_number).join(','));
             core.exportVariable('EXPORT_PROGRAM_LABEL', exportChangeLabel(added.length, updated.length));
 

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -50,6 +50,17 @@ jobs:
 
             console.log(`Exporting proposals for: ${term}`);
 
+            // This export reads its baseline from the checked-out tree and opens
+            // its PR against the branch it runs on, so it must run on the default
+            // branch (main); dispatching elsewhere would carry forward a stale
+            // baseline (cncf/mentoring#2015 review).
+            const defaultBranch = context.payload.repository && context.payload.repository.default_branch;
+            const currentBranch = context.ref.replace('refs/heads/', '');
+            if (defaultBranch && currentBranch !== defaultBranch) {
+              core.setFailed(`lfx-export must run on the default branch (${defaultBranch}); it was dispatched on ${currentBranch}.`);
+              return;
+            }
+
             // ── Fetch all approved issues for this term ──
             const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner, repo, state: 'open',
@@ -155,12 +166,13 @@ jobs:
 
             const outPath = `${outDir}/lfx-export.json`;
 
-            // ── Read the export currently on main (the baseline) ──
-            // Read BEFORE building this run's data so an already-exported program
-            // whose CNCF-Approved label lapsed (e.g. a post-approval edit cleared
-            // it) is carried forward instead of silently dropped (#2015). A
-            // missing/malformed baseline yields no carry-forward and treats every
-            // program as new (a term's first export).
+            // ── Read the term's current export as the baseline ──
+            // Read from the checked-out tree (guarded to the default branch
+            // above, so this is main's export) BEFORE building this run's data, so
+            // an already-exported program whose CNCF-Approved label lapsed (e.g. a
+            // post-approval edit cleared it) is carried forward instead of silently
+            // dropped (#2015). A missing/malformed baseline yields no carry-forward
+            // and treats every program as new (a term's first export).
             const existingExport = fs.existsSync(outPath) ? fs.readFileSync(outPath, 'utf8') : null;
             let baselineExport = null;
             if (existingExport != null) {

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -40,7 +40,7 @@ jobs:
             const { standardPrerequisites } = _lib('prerequisites.js');
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
-            const { serializeExport, partitionExportChanges } = _lib('export-json.js');
+            const { serializeExport, partitionExportChanges, applyStickyExport } = _lib('export-json.js');
             const { parseRecordedLfxUrl, exportChangeLabel, renderExportChangeBody } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
             const { lookupProject } = _lib('projects.js');
@@ -64,16 +64,15 @@ jobs:
 
             console.log(`Found ${termIssues.length} approved proposals for ${term}`);
 
-            if (termIssues.length === 0) {
-              core.setFailed(`No CNCF-approved proposals found for term: ${term}`);
-              return;
-            }
+            // A term with zero approved proposals is not necessarily empty: the
+            // sticky merge below may still carry forward already-exported
+            // programs. The real emptiness guard runs after that merge.
 
             // ── Load projects.yml for metadata ──
             const projYaml = fs.readFileSync('programs/lfx-mentorship/automation/projects.yml', 'utf8');
 
-            // ── Build export records ──
-            const programs = [];
+            // ── Build export records for the currently-approved proposals ──
+            const approvedPrograms = [];
             for (const iss of termIssues) {
               const f = parseIssueForm(iss.body || '');
               const get = (k) => (f[k] || '').trim();
@@ -113,7 +112,7 @@ jobs:
               }
               const lfxUrl = parseRecordedLfxUrl(issueComments);
 
-              programs.push({
+              approvedPrograms.push({
                 issue_number: iss.number,
                 issue_url: iss.html_url,
                 cncf_project: project,
@@ -155,29 +154,49 @@ jobs:
             fs.mkdirSync(outDir, { recursive: true });
 
             const outPath = `${outDir}/lfx-export.json`;
+
+            // ── Read the export currently on main (the baseline) ──
+            // Read BEFORE building this run's data so an already-exported program
+            // whose CNCF-Approved label lapsed (e.g. a post-approval edit cleared
+            // it) is carried forward instead of silently dropped (#2015). A
+            // missing/malformed baseline yields no carry-forward and treats every
+            // program as new (a term's first export).
+            const existingExport = fs.existsSync(outPath) ? fs.readFileSync(outPath, 'utf8') : null;
+            let baselineExport = null;
+            if (existingExport != null) {
+              try { baselineExport = JSON.parse(existingExport); } catch { baselineExport = null; }
+            }
+
+            // ── Sticky merge: never silently drop an exported program (#2015) ──
+            // A baseline program no longer in the approved set is carried forward
+            // FROZEN (the record LFX holds) until a deliberate re-approval
+            // regenerates it. Nothing is auto-removed: once a program is exported
+            // (loaded into LFX) it stays, since dropping it is the failure this
+            // prevents. A withdrawal before posting is a rare manual edit.
+            const sticky = applyStickyExport(approvedPrograms, baselineExport);
+            const programs = sticky.programs;
+            console.log(`Sticky: ${approvedPrograms.length} approved, ${sticky.carriedForward.length} carried forward -> ${programs.length} total`);
+            if (programs.length === 0) {
+              core.setFailed(`No programs to export for term: ${term}`);
+              return;
+            }
+
+            // ── Serialize the export JSON ──
+            // Preserve the prior _generated when nothing else changed, so a
+            // re-run with no substantive change stays byte-identical and the
+            // change check below skips the no-op PR (#1944).
             const exportData = {
               _generated: new Date().toISOString(),
               _term: term,
               _count: programs.length,
               programs: programs,
             };
-
-            // Preserve the prior _generated when nothing else changed, so a
-            // re-run with no substantive change stays byte-identical and the
-            // change check below skips the no-op PR (#1944).
-            const existingExport = fs.existsSync(outPath) ? fs.readFileSync(outPath, 'utf8') : null;
             fs.writeFileSync(outPath, serializeExport(exportData, existingExport));
             console.log(`Wrote ${programs.length} programs to ${outPath}`);
 
-            // Diff against the export currently on main (existingExport, read
-            // above) so the PR summary and notifications reference only what THIS
-            // run adds or changes, not every already-exported program (#1949 did
-            // the same for the /lfx-url PR). A missing or malformed baseline
-            // yields every program, matching a term's first export.
-            let baselineExport = null;
-            if (existingExport != null) {
-              try { baselineExport = JSON.parse(existingExport); } catch { baselineExport = null; }
-            }
+            // Diff against the baseline so the PR summary/notifications reference
+            // only what THIS run adds or changes. Carried-forward frozen programs
+            // are byte-identical to the baseline, so they land in neither list.
             const { added, updated } = partitionExportChanges(baselineExport, exportData);
 
             // ── Generate README.md ──
@@ -218,10 +237,11 @@ jobs:
             core.exportVariable('NOTIFY_ISSUES', added.map(p => p.issue_number).join(','));
             core.exportVariable('EXPORT_PROGRAM_LABEL', exportChangeLabel(added.length, updated.length));
 
-            // PR body: a "Newly added" section and/or an "Updated" section, each
-            // shown only when non-empty, with a fallback line when neither is
-            // present (removals or regenerated files only). Rendering + the
-            // empty-section handling live in the tested lib helper.
+            // PR body: "Newly added" / "Updated" sections, each shown only when
+            // non-empty, with a fallback line when both are empty (regenerated
+            // files only). Updated programs are already in LFX, so the header
+            // carries a cue to sync the LFX copy. Rendering + empty-section
+            // handling live in the tested lib helper.
             core.exportVariable('PR_BODY_ISSUES', renderExportChangeBody(added, updated));
 
       - name: Check for changes

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -171,12 +171,22 @@ jobs:
             // above, so this is main's export) BEFORE building this run's data, so
             // an already-exported program whose CNCF-Approved label lapsed (e.g. a
             // post-approval edit cleared it) is carried forward instead of silently
-            // dropped (#2015). A missing/malformed baseline yields no carry-forward
-            // and treats every program as new (a term's first export).
+            // dropped (#2015). An ABSENT file is a term's first export (carry
+            // nothing); a PRESENT but corrupt file fails loudly rather than risk a
+            // destructive run that drops previously-exported programs (#2015 review).
             const existingExport = fs.existsSync(outPath) ? fs.readFileSync(outPath, 'utf8') : null;
             let baselineExport = null;
             if (existingExport != null) {
-              try { baselineExport = JSON.parse(existingExport); } catch { baselineExport = null; }
+              try {
+                baselineExport = JSON.parse(existingExport);
+              } catch (e) {
+                core.setFailed(`Baseline export ${outPath} exists but is not valid JSON: ${e.message}. Refusing a potentially destructive export on a corrupted baseline.`);
+                return;
+              }
+              if (!baselineExport || !Array.isArray(baselineExport.programs)) {
+                core.setFailed(`Baseline export ${outPath} exists but has no programs array. Refusing a potentially destructive export on a corrupted baseline.`);
+                return;
+              }
             }
 
             // ── Sticky merge: never silently drop an exported program (#2015) ──

--- a/programs/lfx-mentorship/automation/lib/export-json.js
+++ b/programs/lfx-mentorship/automation/lib/export-json.js
@@ -71,4 +71,32 @@ function partitionExportChanges(beforeData, afterData) {
   return { added, updated };
 }
 
-module.exports = { serializeExport, ignoreGenerated, changedExportPrograms, partitionExportChanges };
+// Merge the freshly-built approved programs with programs already in the term's
+// baseline export, so an exported program is never silently dropped when its
+// CNCF-Approved label lapses (e.g. a post-approval material edit cleared it;
+// cncf/mentoring#2015). A program in the baseline but absent from
+// `approvedPrograms` is carried forward FROZEN (the exact record LFX was loaded
+// with) until a deliberate re-approval regenerates it. An approved program always
+// uses its fresh record. Nothing is ever auto-removed: once exported (loaded into
+// LFX) a program stays, since dropping it is the very failure this prevents. The
+// returned programs are sorted by issue_number descending (the order the export
+// has always emitted, now deterministic across both sources). Returns
+// { programs, carriedForward }.
+function applyStickyExport(approvedPrograms, beforeData) {
+  const approved = new Map();
+  for (const p of approvedPrograms || []) {
+    if (p && Number.isInteger(p.issue_number)) approved.set(p.issue_number, p);
+  }
+  const baseline = beforeData && Array.isArray(beforeData.programs) ? beforeData.programs : [];
+  const carriedForward = [];
+  for (const p of baseline) {
+    if (!p || !Number.isInteger(p.issue_number)) continue;
+    if (approved.has(p.issue_number)) continue; // approved: fresh record wins
+    carriedForward.push(p);                      // lapsed approval: carry forward frozen
+  }
+  const programs = [...approved.values(), ...carriedForward]
+    .sort((a, b) => b.issue_number - a.issue_number);
+  return { programs, carriedForward };
+}
+
+module.exports = { serializeExport, ignoreGenerated, changedExportPrograms, partitionExportChanges, applyStickyExport };

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -314,9 +314,9 @@ function stripLfxUrlBlock(body) {
 
 // The adaptive program-change count in the export PR title. Names only the
 // buckets present: "5 new, 1 updated" when both, "5 new" or "1 updated" when
-// only one, and "no program changes" when neither (a removal-only or
-// regenerated-files-only re-export still opens a PR). "new"/"updated" are
-// adjectives, so no pluralization is needed. (cncf/mentoring#1992)
+// only one, and "no program changes" when neither (a regenerated-files-only
+// re-export still opens a PR). "new"/"updated" are adjectives, so no
+// pluralization is needed. (cncf/mentoring#1992)
 function exportChangeLabel(addedCount, updatedCount) {
   const a = Number.isInteger(addedCount) && addedCount > 0 ? addedCount : 0;
   const u = Number.isInteger(updatedCount) && updatedCount > 0 ? updatedCount : 0;
@@ -327,17 +327,18 @@ function exportChangeLabel(addedCount, updatedCount) {
 }
 
 // The export PR body's change section(s): a "Newly added" list and/or an
-// "Updated" list, each shown only when non-empty, so a re-export that only
-// updates existing entries shows just "Updated" (and vice versa). Falls back to
-// an explicit line when neither is present, so the section is never blank. Lines
-// are formatted by renderRecordedIssues. (cncf/mentoring#1992)
+// "Updated" list, each shown only when non-empty. Updated programs are already
+// in LFX, so the header carries a cue to sync the LFX copy (an exported program
+// is never dropped, so there is no "Removed" section; #2015). Falls back to an
+// explicit line when neither is present, so the section is never blank. Lines
+// are formatted by renderRecordedIssues. (cncf/mentoring#1992, #2015)
 function renderExportChangeBody(added, updated) {
   const sections = [];
   if (added && added.length) sections.push(`**Newly added:**\n${renderRecordedIssues(added)}`);
-  if (updated && updated.length) sections.push(`**Updated:**\n${renderRecordedIssues(updated)}`);
+  if (updated && updated.length) sections.push(`**Updated:** (update the LFX program copy to match)\n${renderRecordedIssues(updated)}`);
   return sections.length
     ? sections.join('\n\n')
-    : '_No programs added or updated in this run (removals or regenerated files only)._';
+    : '_No programs added or updated in this run (regenerated files only)._';
 }
 
 module.exports = {

--- a/programs/lfx-mentorship/automation/test/export-json.test.js
+++ b/programs/lfx-mentorship/automation/test/export-json.test.js
@@ -160,3 +160,61 @@ test('partitionExportChanges: changed programs match changedExportPrograms issue
   const changed = changedExportPrograms(before, after).map(p => p.issue_number).sort((a, b) => a - b);
   assert.deepEqual(partitioned, changed);
 });
+
+// ── applyStickyExport: an exported program is never silently dropped ─────────
+// Once a program is in the term's export (already loaded into LFX), a later run
+// must keep it even if its CNCF-Approved label lapsed (e.g. a post-approval edit
+// cleared it). Programs absent from the fresh approved set but present in the
+// baseline are carried forward FROZEN (the content LFX holds) until a deliberate
+// re-approval regenerates them. Approved programs always use their fresh record.
+// Nothing is ever auto-removed: dropping an exported program is the very bug this
+// prevents. (cncf/mentoring#2015)
+const { applyStickyExport } = require('../lib/export-json');
+
+test('applyStickyExport: no baseline -> just the approved set, sorted issue desc', () => {
+  const r = applyStickyExport([prog(1), prog(3), prog(2)], null);
+  assert.deepEqual(r.programs.map(p => p.issue_number), [3, 2, 1]);
+  assert.deepEqual(r.carriedForward, []);
+});
+
+test('applyStickyExport: a lapsed (no-longer-approved) exported program is carried forward frozen', () => {
+  const approved = [prog(2)];
+  const before = data(prog(1, { description: 'FROZEN d1' }), prog(2));
+  const r = applyStickyExport(approved, before);
+  assert.deepEqual(r.programs.map(p => p.issue_number), [2, 1]);
+  assert.deepEqual(r.carriedForward.map(p => p.issue_number), [1]);
+  // #1 is the baseline (frozen) record, byte-for-byte.
+  assert.deepEqual(r.programs.find(p => p.issue_number === 1), prog(1, { description: 'FROZEN d1' }));
+});
+
+test('applyStickyExport: an approved program uses its FRESH record, not the frozen baseline', () => {
+  const approved = [prog(1, { description: 'FRESH d1' })];
+  const before = data(prog(1, { description: 'OLD d1' }));
+  const r = applyStickyExport(approved, before);
+  assert.equal(r.programs.length, 1);
+  assert.equal(r.programs[0].description, 'FRESH d1');
+  assert.deepEqual(r.carriedForward, []);
+});
+
+test('applyStickyExport: a closed proposal already in the baseline stays (never auto-removed)', () => {
+  const approved = [prog(2)];              // #1 no longer approved (issue closed)
+  const before = data(prog(1), prog(2));
+  const r = applyStickyExport(approved, before);
+  assert.deepEqual(r.programs.map(p => p.issue_number), [2, 1]);
+  assert.deepEqual(r.carriedForward.map(p => p.issue_number), [1]);
+});
+
+test('applyStickyExport: mixed set carries every lapsed baseline program, sorted desc', () => {
+  const approved = [prog(5), prog(2)];
+  const before = data(prog(4), prog(3), prog(2), prog(1));
+  const r = applyStickyExport(approved, before);
+  assert.deepEqual(r.programs.map(p => p.issue_number), [5, 4, 3, 2, 1]);
+  assert.deepEqual(r.carriedForward.map(p => p.issue_number), [4, 3, 1]);
+});
+
+test('applyStickyExport: skips malformed entries lacking an integer issue_number', () => {
+  const approved = [prog(2), { foo: 'bar' }];
+  const before = { programs: [prog(1), null, { issue_number: 'x' }] };
+  const r = applyStickyExport(approved, before);
+  assert.deepEqual(r.programs.map(p => p.issue_number), [2, 1]);
+});

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -648,7 +648,7 @@ test('renderExportChangeBody: both sections when both are non-empty', () => {
   const updated = [{ issue_number: 2, program_name_full: 'CNCF - B (T)' }];
   assert.equal(
     renderExportChangeBody(added, updated),
-    '**Newly added:**\n- #1 CNCF - A (T)\n\n**Updated:**\n- #2 CNCF - B (T)',
+    '**Newly added:**\n- #1 CNCF - A (T)\n\n**Updated:** (update the LFX program copy to match)\n- #2 CNCF - B (T)',
   );
 });
 test('renderExportChangeBody: only the Newly added section when nothing was updated', () => {
@@ -657,16 +657,16 @@ test('renderExportChangeBody: only the Newly added section when nothing was upda
 });
 test('renderExportChangeBody: only the Updated section when nothing was added', () => {
   const updated = [{ issue_number: 2, program_name_full: 'CNCF - B (T)' }];
-  assert.equal(renderExportChangeBody([], updated), '**Updated:**\n- #2 CNCF - B (T)');
+  assert.equal(renderExportChangeBody([], updated), '**Updated:** (update the LFX program copy to match)\n- #2 CNCF - B (T)');
 });
 test('renderExportChangeBody: fallback line when neither section has entries', () => {
   assert.equal(
     renderExportChangeBody([], []),
-    '_No programs added or updated in this run (removals or regenerated files only)._',
+    '_No programs added or updated in this run (regenerated files only)._',
   );
   assert.equal(
     renderExportChangeBody(undefined, undefined),
-    '_No programs added or updated in this run (removals or regenerated files only)._',
+    '_No programs added or updated in this run (regenerated files only)._',
   );
 });
 test('renderExportChangeBody: no em-dash', () => {


### PR DESCRIPTION
## What

Make the LFX export **sticky**: once a program is exported (loaded into LFX), a
later export never silently drops it, even if its `CNCF Approved` label lapses.

## Why

Reviewing the Term 3 export (#2015) we found #1980 (Kyverno: Policy Decision Log)
had been approved, exported, and posted to LFX, then dropped from the next export.
Cause: a trivial post-approval edit cleared its CNCF approval (the material-change
gate), and the export rebuilt from *currently* approved issues only, so it
vanished while its record stayed in LFX.

## How

- **`lib/export-json.js`:** new `applyStickyExport(approvedPrograms, baseline)`
  returns `{ programs, carriedForward }`. A baseline program absent from the
  approved set is carried forward **frozen** (the exact record LFX holds) until a
  deliberate re-approval regenerates it. Approved programs use their fresh record.
  Sorted by issue number descending.
- **`lib/lfx-url.js`:** the export PR's **Updated** header gains a cue,
  `(update the LFX program copy to match)`, since an updated program is already in
  LFX and needs a manual sync there.
- **`lfx-export.yml`:** reads the baseline before rebuilding, applies the sticky
  merge, and threads the result through the title/body. The `Exported` label and
  board sync are scoped to currently-approved programs, so carried-forward frozen
  entries are not re-touched. Two guards from review: the export must run on the
  default branch (the baseline is read from the checked-out tree), and a
  present-but-corrupt baseline fails the run instead of dropping every program.

Nothing is ever auto-removed. Once exported, a program stays: dropping it is the
failure this prevents, and closing issues at term end must not gut the export.
`gates.js` and `/lfx-url` are unchanged.

## Validation

537 unit tests pass; the workflow YAML and every embedded `github-script` block
pass `node --check`. Dev end-to-end (`scratch/e2e-sticky-export.sh`) is green: a
program edited after export is carried forward frozen (not dropped) while a new
program is added; re-approving the edited program marks it "Updated" with the
LFX-copy cue.
