### PR TITLE
fix(lfx): recognize TUF maintainers despite CSV name-order mismatch

### DIFF
--- a/programs/lfx-mentorship/automation/lib/maintainers.js
+++ b/programs/lfx-mentorship/automation/lib/maintainers.js
@@ -13,12 +13,29 @@
 const { parseCsvLine } = require('./csv.js');
 const yaml = require('js-yaml');
 
+// Per-project name accommodations between projects.yml (generated from
+// cncf/landscape) and the hand-maintained project-maintainers.csv. When the two
+// name a project differently enough that the prefix/substring match below misses
+// it, list the CSV's wording here, keyed by the projects.yml/proposal name
+// (lowercased). Add an entry per project as the divergences surface.
+//
+// TUF: projects.yml says "The Update Framework (TUF)"; the CSV swaps the
+// parenthetical to "TUF (The Update Framework)", which is neither a prefix nor a
+// substring of the former, so its maintainers went unrecognized. (#2028)
+const CSV_PROJECT_NAME_ALIASES = {
+  'the update framework (tuf)': ['TUF (The Update Framework)'],
+};
+
 // Return { authorized, project } for whether `handle` is listed as a
 // maintainer of `project` in the CSV text. Matching is case-insensitive.
 function findMaintainerInCsv(csvText, project, handle) {
   const wanted = String(project || '').trim().toLowerCase();
   const who = String(handle || '').trim().toLowerCase();
   if (!wanted || !who) return { authorized: false, project: '' };
+
+  // The project name plus any known CSV aliases for it; a CSV group matches when
+  // it prefix/substring-matches ANY of these. Non-aliased projects are unchanged.
+  const wantedNames = [wanted, ...(CSV_PROJECT_NAME_ALIASES[wanted] || []).map((a) => a.toLowerCase())];
 
   let group = '';  // Project column, forward-filled from each group's first row
   for (const line of String(csvText).split('\n').slice(1)) {
@@ -29,7 +46,7 @@ function findMaintainerInCsv(csvText, project, handle) {
     const rowHandle = (cols[4] || '').trim().toLowerCase();
     if (!rowHandle) continue;
     const p = group.toLowerCase();
-    if (rowHandle === who && (p.startsWith(wanted) || p.includes(wanted))) {
+    if (rowHandle === who && wantedNames.some((w) => p.startsWith(w) || p.includes(w))) {
       return { authorized: true, project: group };
     }
   }

--- a/programs/lfx-mentorship/automation/test/maintainers.test.js
+++ b/programs/lfx-mentorship/automation/test/maintainers.test.js
@@ -15,6 +15,9 @@ const CSV = [
   'Graduated,Kubernetes,Someone Steering,Google,steersperson,https://git.k8s.io/steering#members',
   ',Kubernetes maintainers,Adolfo García Veytia,"Carabiner Systems, Inc",puerco,',
   ',,Carlos Tadeu Panato Jr.,"Chainguard, Inc",cpanato,',
+  // TUF: the CSV orders the parenthetical the other way from projects.yml, which
+  // names it "The Update Framework (TUF)". Covered by the alias table (#2028).
+  'Graduated,TUF (The Update Framework),Justin Cappos,NYU,JustinCappos,https://github.com/theupdateframework/community/blob/main/MAINTAINERS.md',
 ].join('\n');
 
 test('authorizes a project group-header maintainer', () => {
@@ -59,6 +62,21 @@ test('does not leak a maintainer across group boundaries', () => {
 test('rejects on blank project or handle', () => {
   assert.equal(findMaintainerInCsv(CSV, '', 'aliok').authorized, false);
   assert.equal(findMaintainerInCsv(CSV, 'Knative', '').authorized, false);
+});
+
+// Project-name accommodations (#2028): projects.yml (from cncf/landscape) and the
+// hand-maintained project-maintainers.csv sometimes name a project differently,
+// so the substring matcher misses real maintainers. An explicit per-project alias
+// table bridges the known cases. TUF is the first: projects.yml says
+// "The Update Framework (TUF)" while the CSV says "TUF (The Update Framework)".
+test('authorizes a TUF maintainer despite the projects.yml/CSV name-order mismatch (#2028)', () => {
+  const hit = findMaintainerInCsv(CSV, 'The Update Framework (TUF)', 'JustinCappos');
+  assert.equal(hit.authorized, true);
+  assert.equal(hit.project, 'TUF (The Update Framework)');
+});
+
+test('the TUF alias still rejects a non-maintainer for TUF', () => {
+  assert.equal(findMaintainerInCsv(CSV, 'The Update Framework (TUF)', 'nobody').authorized, false);
 });
 
 // ── isProjectMaintainer: tier-1 {org}/.project/maintainers.yaml ──────────


### PR DESCRIPTION
## What

TUF maintainer-proposers (e.g. @JustinCappos on #2028) weren't getting proposer-implied auto-approval. `projects.yml` names the project "The Update Framework (TUF)" while `project-maintainers.csv` says "TUF (The Update Framework)". The swapped parenthetical is neither a prefix nor a substring of the other, so the CSV lookup missed it and treated TUF's maintainers as unlisted.

## Fix

An explicit, extensible per-project name-alias table in `lib/maintainers.js`. TUF is the first entry; future divergences are a one-line addition. Non-aliased projects are unchanged.

## Testing

- New unit tests (red before, green after); full suite 539 passing.
- Verified against the live cncf/foundation CSV: `findMaintainerInCsv("The Update Framework (TUF)", "JustinCappos")` now returns `authorized: true`, and a non-maintainer for TUF is still rejected.
- No workflow change. The validate workflow reaches this via `resolveProjectMaintainer`, whose tier-1-404 to CSV fallthrough is already covered by existing tests.
