### PR TITLE
feat(lfx): let universal approvers /confirm on a mentor's behalf

### DIFF
--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -48,7 +48,7 @@ jobs:
             const { parseIssueForm, parseMentors } = _lib('parse.js');
             const { parseCommands } = _lib('commands.js');
             const { resolveProjectMaintainer } = _lib('authorize.js');
-            const { computeConfirm } = _lib('confirm.js');
+            const { computeConfirm, confirmTargets } = _lib('confirm.js');
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams, maintainersCanApprove, buildProjectKeys } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
@@ -319,23 +319,58 @@ jobs:
                 return;
               }
 
-              // Authorization: commenter must be a listed mentor
+              // Roster + universal approvers. A bare /confirm confirms the
+              // commenter; /confirm @handle targets a specific mentor: the
+              // commenter's own slot, or (for a CNCF universal approver) another
+              // mentor on their behalf. Several /confirm lines in one comment all
+              // act, yielding a single consolidated reply.
               const mentorsRaw = get('Mentors');
               const confirmHandles = parseMentors(mentorsRaw).map(m => m.github_handle.toLowerCase());
+              const rosterList = confirmHandles.map(h => `@${h}`).join(', ') || '(none parsed)';
+              const me = commenter.toLowerCase();
 
-              if (!confirmHandles.includes(commenter.toLowerCase())) {
-                await reply('❌',
-                  `@${commenter} is not listed as a mentor on this proposal.\n\n` +
-                  `Only listed mentors can \`/confirm\`. ` +
-                  `Current mentors: ${confirmHandles.map(h => `@${h}`).join(', ') || '(none parsed)'}`);
+              let admins = [];
+              try {
+                admins = getGlobalApprovers(fs.readFileSync('programs/lfx-mentorship/automation/approvers.yml', 'utf8'));
+              } catch (e) {
+                console.log(`approvers.yml read failed: ${e.message}`);
+              }
+              const isAdmin = admins.includes(me);
+
+              // Classify each /confirm line into credited handles vs. problems,
+              // so a comment with several lines yields one consolidated reply and
+              // one valid line is never lost to another's error.
+              const credited = [];
+              const issues = [];
+              for (const t of confirmTargets(commentBody)) {
+                const subject = t === null ? me : t;
+                if (!confirmHandles.includes(subject)) {
+                  if (t !== null) {
+                    issues.push(`@${subject} is not a listed mentor on this proposal. Current mentors: ${rosterList}`);
+                  } else if (isAdmin) {
+                    issues.push(`@${commenter}, to confirm a mentor use \`/confirm @their-handle\`. Current mentors: ${rosterList}`);
+                  } else {
+                    issues.push(`@${commenter} is not listed as a mentor on this proposal. Only listed mentors can \`/confirm\`. Current mentors: ${rosterList}`);
+                  }
+                } else if (subject === me || isAdmin) {
+                  credited.push(subject);
+                } else {
+                  issues.push(`Only CNCF universal approvers can \`/confirm\` on behalf of another mentor. To confirm your own participation, comment \`/confirm\`.`);
+                }
+              }
+              const creditedUniq = [...new Set(credited)];
+              const uniqIssues = [...new Set(issues)];
+
+              // Nothing valid to record: reply with the problem(s) only.
+              if (creditedUniq.length === 0) {
+                await reply('❌', uniqIssues.join('\n\n') || 'No `/confirm` action was recognized.');
                 return;
               }
 
-              // Per-mentor confirmation: the gate flips only once EVERY listed
-              // mentor has confirmed. Gather confirmations from the issue's
-              // comment history (plus this one) and the issue author (a
-              // proposer who lists themselves as a mentor counts as confirmed),
-              // compared to the roster (tally logic in lib/confirm.js).
+              // Authoritative tally (recognizes on-behalf confirmations, tally
+              // logic in lib/confirm.js). Append this comment so a just-posted
+              // /confirm counts even before the API lists it; a proposer who
+              // lists themselves as a mentor counts as confirmed.
               let priorComments = [];
               try {
                 priorComments = await github.paginate(github.rest.issues.listComments, {
@@ -345,12 +380,19 @@ jobs:
                 core.warning(`Could not read prior confirmations: ${e.message}`);
               }
               const proposer = context.payload.issue.user?.login;
-              const { remaining, count, total } = computeConfirm(confirmHandles, commenter, priorComments, proposer);
+              const allComments = priorComments.concat([{ user: { login: commenter }, body: commentBody }]);
+              const { remaining, count, total } = computeConfirm(confirmHandles, commenter, allComments, proposer, admins);
+
+              const recorded = creditedUniq.map(h => `@${h}`).join(', ');
+              const head = (creditedUniq.length === 1 && creditedUniq[0] === me)
+                ? `Confirmation recorded from @${commenter}.`
+                : `Confirmation recorded for ${recorded} (by @${commenter}).`;
+              const note = uniqIssues.length ? `\n\n⚠️ ${uniqIssues.join('\n\n⚠️ ')}` : '';
+
               if (remaining.length) {
                 await reply('✅',
-                  `Confirmation recorded from @${commenter}. ` +
-                  `${count} of ${total} mentors have confirmed.\n\n` +
-                  `Still waiting on: ${remaining.map(h => `@${h}`).join(', ')}.`);
+                  `${head} ${count} of ${total} mentors have confirmed.\n\n` +
+                  `Still waiting on: ${remaining.map(h => `@${h}`).join(', ')}.${note}`);
                 return;
               }
 
@@ -358,7 +400,7 @@ jobs:
               await addLabel('Mentors Confirmed');
               await removeLabel('Awaiting Mentor Confirmation');
               await reply('✅',
-                `All ${total} listed mentor(s) have confirmed. Mentor confirmation is complete.`);
+                `${head} All ${total} listed mentor(s) have confirmed. Mentor confirmation is complete.${note}`);
               await checkBothGates();
               return;
             }

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -77,7 +77,7 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { isProposalTitle, looksLikeProposalForm } = _lib('labels.js');
             const { resolveProjectMaintainer } = _lib('authorize.js');
-            const { getProjectSection, maintainersCanApprove, buildProjectKeys } = _lib('approvers.js');
+            const { getProjectSection, maintainersCanApprove, buildProjectKeys, getGlobalApprovers } = _lib('approvers.js');
             const { computeConfirm } = _lib('confirm.js');
             const { gateLabelChanges } = _lib('gates.js');
             const { findRecordedApprovers } = _lib('approvals.js');
@@ -474,8 +474,18 @@ jobs:
               // unconfirmed mentor re-opens confirmation (and a removed/swapped
               // mentor resolves from persisted /confirm comments). Counts the
               // proposer's own slot. NOT monotonic — reflects the present roster.
+              // Universal approvers may /confirm @handle on a mentor's behalf;
+              // recognize those here too, or this recompute would drop them and
+              // revoke Mentors Confirmed on the next edit.
+              let globalApprovers = [];
+              try {
+                globalApprovers = getGlobalApprovers(
+                  fs.readFileSync('programs/lfx-mentorship/automation/approvers.yml', 'utf8'));
+              } catch (e) {
+                console.log(`approvers.yml read for confirm tally failed: ${e.message}`);
+              }
               const roster = parseMentors(mentorsRaw).map(m => m.github_handle);
-              confirmResult = computeConfirm(roster, null, issueComments, proposer);
+              confirmResult = computeConfirm(roster, null, issueComments, proposer, globalApprovers);
               mentorsConfirmed = confirmResult.flip;
               const normHandle = (h) => String(h || '').replace(/^@/, '').trim().toLowerCase();
               proposerIsMentor = roster.map(normHandle).includes(normHandle(proposer));

--- a/programs/lfx-mentorship/automation/lib/approvers.js
+++ b/programs/lfx-mentorship/automation/lib/approvers.js
@@ -13,7 +13,7 @@
 function getGlobalApprovers(raw) {
   const block = String(raw).match(/global_approvers:\s*\n((?:\s+-\s+\S+.*\n?)*)/);
   if (!block) return [];
-  return [...block[1].matchAll(/-\s+(\S+)/g)].map((m) => m[1].toLowerCase());
+  return [...block[1].matchAll(/-\s+(\S+)/g)].map((m) => m[1].replace(/^@+/, '').toLowerCase());
 }
 
 // The indented block for the first matching project key, or '' if none match.

--- a/programs/lfx-mentorship/automation/lib/confirm.js
+++ b/programs/lfx-mentorship/automation/lib/confirm.js
@@ -60,7 +60,16 @@ function computeConfirm(mentorHandles, commenter, comments, author, admins = [])
   const adminSet = new Set((admins || []).map(norm));
   const onRoster = (h) => h && roster.includes(norm(h));
   const confirmed = new Set();
-  if (onRoster(commenter)) confirmed.add(norm(commenter));
+  // Auto-credit the commenter's own slot only as a fallback for a just-posted
+  // self-confirm not yet reflected in `comments`. Once the commenter has a
+  // parsed /confirm line here (the handler appends the current comment), let
+  // that line govern, so an approver-mentor's `/confirm @other` credits only
+  // @other and never flips their own slot early (Copilot review, #212).
+  const cn = norm(commenter);
+  const commenterHasLine = cn && comments.some(
+    (c) => norm(c.user?.login) === cn && confirmTargets(c.body).length > 0,
+  );
+  if (onRoster(commenter) && !commenterHasLine) confirmed.add(cn);
   if (onRoster(author)) confirmed.add(norm(author));
   for (const c of comments) {
     const commentAuthor = norm(c.user?.login);

--- a/programs/lfx-mentorship/automation/lib/confirm.js
+++ b/programs/lfx-mentorship/automation/lib/confirm.js
@@ -23,9 +23,16 @@
 function confirmTargets(body) {
   const targets = [];
   for (const raw of String(body == null ? '' : body).split(/\r?\n/)) {
-    const m = raw.trim().match(/^\/confirm\b\s*(.*)$/);
+    // Require whitespace or end-of-line after `/confirm`, matching COMMAND_RE in
+    // lib/commands.js, so `/confirm-now`, `/confirmed`, and `/confirm@x` do not
+    // read as the command (a plain \b would admit `/confirm-now`).
+    const m = raw.trim().match(/^\/confirm(?=\s|$)\s*(.*)$/);
     if (!m) continue;
     const rest = (m[1] || '').trim();
+    // A leading @ marks a target handle; a handle-less `@` or any non-@ prose
+    // falls back to a bare self-confirm, so a mentor's intent is never lost to a
+    // typo. A line never confirms a third party by accident: that needs an
+    // explicit @handle.
     if (rest.startsWith('@')) {
       const handle = rest.split(/\s+/)[0].replace(/^@+/, '').toLowerCase();
       targets.push(handle || null);

--- a/programs/lfx-mentorship/automation/lib/confirm.js
+++ b/programs/lfx-mentorship/automation/lib/confirm.js
@@ -7,34 +7,69 @@
 // issue's comment history (plus the current commenter and the issue author)
 // and compared to the roster.
 //
+// A `/confirm` line confirms a SUBJECT: the `@handle` it names, or the comment
+// author when it names none. The subject is credited only when it is on the
+// roster AND the author is allowed to confirm it: the author IS the subject
+// (self-confirm), or the author is a CNCF universal approver acting on the
+// mentor's behalf (`admins`). This lets an approver run `/confirm @mentor` for
+// a mentor who never confirmed, while a mentor naming someone else confirms no
+// one. Trailing prose after `/confirm` is ignored, so intent survives a
+// friendly note; only a leading `@` marks a target handle.
+
+// Parse a comment body into one entry per `/confirm` line, in order: the
+// lowercased handle for `/confirm @handle`, or null for a bare `/confirm`
+// (any trailing prose ignored). A `/confirm` must lead its line (after
+// trimming); mid-sentence mentions never count.
+function confirmTargets(body) {
+  const targets = [];
+  for (const raw of String(body == null ? '' : body).split(/\r?\n/)) {
+    const m = raw.trim().match(/^\/confirm\b\s*(.*)$/);
+    if (!m) continue;
+    const rest = (m[1] || '').trim();
+    if (rest.startsWith('@')) {
+      const handle = rest.split(/\s+/)[0].replace(/^@+/, '').toLowerCase();
+      targets.push(handle || null);
+    } else {
+      targets.push(null);
+    }
+  }
+  return targets;
+}
+
 // mentorHandles: GitHub handles parsed from the Mentors field (with or without
 //   a leading '@'); deduplicated and lower-cased here.
 // commenter: the login of the mentor issuing this `/confirm` (may be null when
-//   evaluated outside a comment, e.g. at validation time).
+//   evaluated outside a comment, e.g. at validation time). Counted only for a
+//   bare self-confirm; on-behalf `/confirm @handle` flows through `comments`.
 // comments: prior issue comments, each { user: { login }, body }.
 // author: the issue author (proposer). Counted as a confirmation when on the
 //   roster — filing a proposal that lists yourself as a mentor is itself your
 //   commitment to mentor, so it counts as that mentor's `/confirm`.
-//
-// A comment counts as a confirmation only when its author is on the roster and
-// a line in its body starts with `/confirm` (mid-sentence mentions do not
-// count). The commenter and issue author are likewise only counted when they
-// are on the roster, so `count` never exceeds the roster.
-function computeConfirm(mentorHandles, commenter, comments, author) {
+// admins: CNCF universal (global) approvers, who may `/confirm @handle` on a
+//   mentor's behalf. Normalized here; defaults to none (additive).
+function computeConfirm(mentorHandles, commenter, comments, author, admins = []) {
   const norm = (h) => String(h || '').replace(/^@/, '').trim().toLowerCase();
   const roster = [...new Set(mentorHandles.map(norm))];
+  const adminSet = new Set((admins || []).map(norm));
   const onRoster = (h) => h && roster.includes(norm(h));
   const confirmed = new Set();
   if (onRoster(commenter)) confirmed.add(norm(commenter));
   if (onRoster(author)) confirmed.add(norm(author));
-  const hasConfirm = (body) => (body || '').split(/\r?\n/)
-    .some(l => /^\/confirm\b/.test(l.trim()));
   for (const c of comments) {
     const commentAuthor = norm(c.user?.login);
-    if (roster.includes(commentAuthor) && hasConfirm(c.body)) confirmed.add(commentAuthor);
+    for (const target of confirmTargets(c.body)) {
+      if (target === null) {
+        // Bare self-confirm: credits the author when on the roster.
+        if (roster.includes(commentAuthor)) confirmed.add(commentAuthor);
+      } else if (roster.includes(target) && (target === commentAuthor || adminSet.has(commentAuthor))) {
+        // Explicit @handle: the mentor themselves, or an approver on their
+        // behalf. The confirmed party is the handle, not the commenter.
+        confirmed.add(target);
+      }
+    }
   }
   const remaining = roster.filter(h => !confirmed.has(h));
   return { flip: remaining.length === 0, remaining, count: confirmed.size, total: roster.length };
 }
 
-module.exports = { computeConfirm };
+module.exports = { computeConfirm, confirmTargets };

--- a/programs/lfx-mentorship/automation/lib/confirm.js
+++ b/programs/lfx-mentorship/automation/lib/confirm.js
@@ -32,10 +32,11 @@ function confirmTargets(body) {
     // A leading @ marks a target handle; a handle-less `@` or any non-@ prose
     // falls back to a bare self-confirm, so a mentor's intent is never lost to a
     // typo. A line never confirms a third party by accident: that needs an
-    // explicit @handle.
+    // explicit @handle. The handle is the GitHub-username run after the @, so
+    // trailing punctuation or prose (`@alice, thanks`) is forgiven.
     if (rest.startsWith('@')) {
-      const handle = rest.split(/\s+/)[0].replace(/^@+/, '').toLowerCase();
-      targets.push(handle || null);
+      const h = rest.match(/^@+([A-Za-z0-9](?:-?[A-Za-z0-9])*)/);
+      targets.push(h ? h[1].toLowerCase() : null);
     } else {
       targets.push(null);
     }

--- a/programs/lfx-mentorship/automation/test/approvers.test.js
+++ b/programs/lfx-mentorship/automation/test/approvers.test.js
@@ -199,3 +199,10 @@ test('real approvers.yml: an unlisted project keeps the additive model (default)
     true,
   );
 });
+
+test('getGlobalApprovers: strips a leading @ and lowercases', () => {
+  assert.deepEqual(
+    getGlobalApprovers('global_approvers:\n  - @Nate-Double-U\n  - dkrook\n'),
+    ['nate-double-u', 'dkrook'],
+  );
+});

--- a/programs/lfx-mentorship/automation/test/confirm.test.js
+++ b/programs/lfx-mentorship/automation/test/confirm.test.js
@@ -290,3 +290,20 @@ test('confirmTargets ignores mid-sentence and non-command lines', () => {
   assert.deepEqual(confirmTargets('I will /confirm later'), []);
   assert.deepEqual(confirmTargets('Use `/confirm` to participate'), []);
 });
+
+// ── confirmTargets anchoring: consistent with COMMAND_RE (commands.js) ──
+// A hyphenated/longer/glued token must NOT read as /confirm, or a stray
+// `/confirm-now` in history would self-confirm its author via computeConfirm.
+
+test('confirmTargets ignores a hyphenated, longer, or glued command token', () => {
+  assert.deepEqual(confirmTargets('/confirm-now'), []);
+  assert.deepEqual(confirmTargets('/confirmed tomorrow'), []);
+  assert.deepEqual(confirmTargets('/confirm@alice'), []);
+});
+
+test('confirmTargets treats a handle-less /confirm @ as a bare self-confirm', () => {
+  // A malformed @ never targets a third party; it falls back to the author's
+  // own slot, so a mentor's intent survives the typo (only the author, if on
+  // the roster, is ever credited here).
+  assert.deepEqual(confirmTargets('/confirm @'), [null]);
+});

--- a/programs/lfx-mentorship/automation/test/confirm.test.js
+++ b/programs/lfx-mentorship/automation/test/confirm.test.js
@@ -362,3 +362,17 @@ test('an on-behalf /confirm with trailing punctuation still credits the mentor',
     { flip: false, remaining: ['b'], count: 1, total: 2 },
   );
 });
+
+// ── confirmTargets mirrors GitHub's username-mention grammar ───────────
+// A hyphen continues a handle ONLY when followed by an alphanumeric, exactly
+// as GitHub parses/renders a mention. So a malformed handle extracts the same
+// run GitHub would highlight: `@alice-` shows as @alice, `@a--b` as @a, and
+// `@-alice` is no mention. Crediting matches what the commenter sees; this is
+// intentional, not a partial-match bug.
+
+test('confirmTargets extracts the same run GitHub would render for malformed handles', () => {
+  assert.deepEqual(confirmTargets('/confirm @alice-'), ['alice']);
+  assert.deepEqual(confirmTargets('/confirm @a--b'), ['a']);
+  assert.deepEqual(confirmTargets('/confirm @-alice'), [null]);
+  assert.deepEqual(confirmTargets('/confirm @alice-bob'), ['alice-bob']);
+});

--- a/programs/lfx-mentorship/automation/test/confirm.test.js
+++ b/programs/lfx-mentorship/automation/test/confirm.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { computeConfirm } = require('../lib/confirm');
+const { computeConfirm, confirmTargets } = require('../lib/confirm');
 
 test('the first of three mentors confirming does not flip the gate', () => {
   assert.deepEqual(
@@ -166,4 +166,127 @@ test('an off-roster commenter is not counted (self-consistent contract)', () => 
     computeConfirm(['a', 'b'], 'zzz', []),
     { flip: false, remaining: ['a', 'b'], count: 0, total: 2 },
   );
+});
+
+// ── On-behalf confirmation: /confirm @handle by a universal approver ───
+// A CNCF global approver can confirm participation for a listed mentor who
+// hasn't run /confirm themselves. The confirmed party is the @handle, not the
+// commenter. A mentor may also confirm with their OWN @handle (no approver
+// needed), and trailing prose after /confirm never voids the intent. The
+// 5th arg is the global-approver (admin) roster, normalized here.
+
+test('a universal approver can confirm on behalf of a listed mentor', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [
+      { user: { login: 'admin1' }, body: '/confirm @a' },
+    ], null, ['admin1']),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('on-behalf confirmations can complete the roster and flip the gate', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [
+      { user: { login: 'admin1' }, body: '/confirm @a\n/confirm @b' },
+    ], null, ['admin1']),
+    { flip: true, remaining: [], count: 2, total: 2 },
+  );
+});
+
+test('a non-approver cannot confirm on behalf of another mentor', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [
+      { user: { login: 'randouser' }, body: '/confirm @a' },
+    ], null, []),
+    { flip: false, remaining: ['a', 'b'], count: 0, total: 2 },
+  );
+});
+
+test('a mentor /confirm @otherMentor does not silently self-confirm the author', () => {
+  // b (a mentor, not an approver) names a: neither is credited to b, and b is
+  // not authorized to confirm a. The handler surfaces the error; the tally is 0.
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [
+      { user: { login: 'b' }, body: '/confirm @a' },
+    ], null, []),
+    { flip: false, remaining: ['a', 'b'], count: 0, total: 2 },
+  );
+});
+
+test('a mentor confirming with their OWN @handle counts (no approver needed)', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [
+      { user: { login: 'a' }, body: '/confirm @a' },
+    ], null, []),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('trailing prose after a bare /confirm still counts the author', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [
+      { user: { login: 'a' }, body: '/confirm looking forward to mentoring!' },
+    ], null, []),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('trailing prose after /confirm @self still counts', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [
+      { user: { login: 'a' }, body: '/confirm @a thanks, happy to help' },
+    ], null, []),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('an on-behalf /confirm for a non-roster handle is ignored', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [
+      { user: { login: 'admin1' }, body: '/confirm @zzz' },
+    ], null, ['admin1']),
+    { flip: false, remaining: ['a', 'b'], count: 0, total: 2 },
+  );
+});
+
+test('the admins roster is matched case- and @-insensitively', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], null, [
+      { user: { login: 'Admin1' }, body: '/confirm @a' },
+    ], null, ['@admin1']),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('omitting the admins arg preserves prior bare-/confirm behavior', () => {
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'a', [{ user: { login: 'b' }, body: '/confirm' }]),
+    { flip: true, remaining: [], count: 2, total: 2 },
+  );
+});
+
+// ── confirmTargets: per-line parse shared by the tally and the handler ──
+// One entry per /confirm line: null for a bare self-confirm (trailing prose
+// ignored), or the lowercased handle for an explicit /confirm @handle.
+
+test('confirmTargets returns null for a bare /confirm and prose', () => {
+  assert.deepEqual(confirmTargets('/confirm'), [null]);
+  assert.deepEqual(confirmTargets('/confirm looking forward!'), [null]);
+});
+
+test('confirmTargets extracts a single leading @handle, lowercased', () => {
+  assert.deepEqual(confirmTargets('/confirm @Alice'), ['alice']);
+  assert.deepEqual(confirmTargets('/confirm @alice thanks!'), ['alice']);
+});
+
+test('confirmTargets returns one entry per /confirm line', () => {
+  assert.deepEqual(
+    confirmTargets('sure\n/confirm @a\n/confirm\n/confirm @b'),
+    ['a', null, 'b'],
+  );
+});
+
+test('confirmTargets ignores mid-sentence and non-command lines', () => {
+  assert.deepEqual(confirmTargets('I will /confirm later'), []);
+  assert.deepEqual(confirmTargets('Use `/confirm` to participate'), []);
 });

--- a/programs/lfx-mentorship/automation/test/confirm.test.js
+++ b/programs/lfx-mentorship/automation/test/confirm.test.js
@@ -307,3 +307,38 @@ test('confirmTargets treats a handle-less /confirm @ as a bare self-confirm', ()
   // the roster, is ever credited here).
   assert.deepEqual(confirmTargets('/confirm @'), [null]);
 });
+
+// ── Regression (#212): an approver who is ALSO a listed mentor, confirming
+// someone else on-behalf, must NOT self-confirm. The commenter is auto-credited
+// only as a fallback for a just-posted self-confirm not yet in `comments`; once
+// their line is present (the handler appends it), that line governs.
+
+test('an approver-mentor confirming another mentor on-behalf does not self-confirm', () => {
+  // 'a' is a listed mentor AND a universal approver; their comment names @b.
+  // Only b is credited; a is not flipped early off their own on-behalf line.
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'a', [
+      { user: { login: 'a' }, body: '/confirm @b' },
+    ], null, ['a']),
+    { flip: false, remaining: ['a'], count: 1, total: 2 },
+  );
+});
+
+test('the commenter is still credited when their self-confirm is not yet in comments', () => {
+  // Legacy fallback: commenter 'a' did a bare /confirm the API has not listed
+  // yet, so there is no line for them in `comments`; auto-credit still applies.
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'a', []),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});
+
+test('an approver-mentor may self-confirm AND confirm another in one comment', () => {
+  // 'a' writes both a bare /confirm (self) and /confirm @b (on-behalf): both count.
+  assert.deepEqual(
+    computeConfirm(['a', 'b'], 'a', [
+      { user: { login: 'a' }, body: '/confirm\n/confirm @b' },
+    ], null, ['a']),
+    { flip: true, remaining: [], count: 2, total: 2 },
+  );
+});

--- a/programs/lfx-mentorship/automation/test/confirm.test.js
+++ b/programs/lfx-mentorship/automation/test/confirm.test.js
@@ -342,3 +342,23 @@ test('an approver-mentor may self-confirm AND confirm another in one comment', (
     { flip: true, remaining: [], count: 2, total: 2 },
   );
 });
+
+// ── confirmTargets forgives punctuation right after the handle ─────────
+// GitHub handles are [A-Za-z0-9-]; trailing punctuation ("@alice, thanks")
+// must not become part of the handle, or the roster match silently fails.
+
+test('confirmTargets forgives punctuation immediately after the handle', () => {
+  assert.deepEqual(confirmTargets('/confirm @alice, thanks'), ['alice']);
+  assert.deepEqual(confirmTargets('/confirm @alice.'), ['alice']);
+  assert.deepEqual(confirmTargets('/confirm @alice!'), ['alice']);
+  assert.deepEqual(confirmTargets('/confirm @alice-bob, cheers'), ['alice-bob']);
+});
+
+test('an on-behalf /confirm with trailing punctuation still credits the mentor', () => {
+  assert.deepEqual(
+    computeConfirm(['alice', 'b'], null, [
+      { user: { login: 'admin1' }, body: '/confirm @alice, thanks!' },
+    ], null, ['admin1']),
+    { flip: false, remaining: ['b'], count: 1, total: 2 },
+  );
+});


### PR DESCRIPTION
## What

Universal (global) approvers can confirm a mentor's participation on their behalf with `/confirm @<handle>`, mirroring how `/approve` lets them act for a project. When a mentor confirms in a comment without using the command, an approver no longer has to hand-edit the label.

## Behavior

- `/confirm @<handle>` records the named mentor's slot; restricted to CNCF universal approvers.
- Mentors may `/confirm` (self) or `/confirm` with their own handle; trailing prose is forgiven, so a friendly note never voids intent.
- One handle per `/confirm`, but several `/confirm` lines in one comment all act, with a single consolidated reply. A valid line is never lost to another line's error.
- A mentor naming someone else gets a clear error rather than a silent miss.

## Why the two-workflow change

The confirmation tally (`lib/confirm.js`) is recomputed both in the `/confirm` handler and in validation on every issue edit. Validation revokes `Mentors Confirmed` when the tally drops, so both workflows must recognize on-behalf confirmations or the next edit would silently wipe them.

## Testing

- TDD; full unit suite passing; both workflows parse and every github-script block passes `node --check`.
- Verified end-to-end on the dev fork: an on-behalf `/confirm` flips the gate with a reply that names the mentor, a non-mentor handle is rejected, and the confirmation survives an issue edit (the revoke path).
