### PR TITLE
fix(lfx): stop the confused reaction on commands; warm up /confirm acks

### DIFF
--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -49,6 +49,7 @@ jobs:
             const { parseCommands } = _lib('commands.js');
             const { resolveProjectMaintainer } = _lib('authorize.js');
             const { computeConfirm, confirmTargets } = _lib('confirm.js');
+            const { replyReaction } = _lib('reactions.js');
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams, maintainersCanApprove, buildProjectKeys } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
@@ -104,18 +105,20 @@ jobs:
 
             // ── Feedback helper ──
             async function reply(emoji, message) {
-              const reaction = emoji === '✅' ? '+1' : emoji === '❌' ? '-1' : 'confused';
+              const reaction = replyReaction(emoji);
               // Best-effort reaction: it is cosmetic, so a failure here must never
               // block the comment (the command's actual acknowledgement) or, in
               // the multi-command loop, a later command. Adding the same reaction
               // twice is idempotent (the API returns 200, not an error), so a
               // repeated +1 across commands is fine; this guards other failures.
-              try {
-                await github.rest.reactions.createForIssueComment({
-                  owner, repo, comment_id: comment.id, content: reaction,
-                });
-              } catch (e) {
-                console.log(`Could not add ${reaction} reaction: ${e.message}`);
+              if (reaction) {
+                try {
+                  await github.rest.reactions.createForIssueComment({
+                    owner, repo, comment_id: comment.id, content: reaction,
+                  });
+                } catch (e) {
+                  console.log(`Could not add ${reaction} reaction: ${e.message}`);
+                }
               }
               await github.rest.issues.createComment({
                 owner, repo, issue_number, body: `${emoji} ${message}`,
@@ -314,10 +317,9 @@ jobs:
                   `\`/confirm\` requires the proposal to pass validation first.`);
                 return;
               }
-              if (currentLabels.includes('Mentors Confirmed')) {
-                await reply('ℹ️', 'Mentor confirmation is already recorded for this proposal.');
-                return;
-              }
+              // A mentor confirming their participation always gets the same warm
+              // acknowledgement, whether or not the roster was already complete.
+              const alreadyComplete = currentLabels.includes('Mentors Confirmed');
 
               // Roster + universal approvers. A bare /confirm confirms the
               // commenter; /confirm @handle targets a specific mentor: the
@@ -383,24 +385,39 @@ jobs:
               const allComments = priorComments.concat([{ user: { login: commenter }, body: commentBody }]);
               const { remaining, count, total } = computeConfirm(confirmHandles, commenter, allComments, proposer, admins);
 
+              // Warm, participation-first acknowledgement. Self-confirm thanks the
+              // mentor; on-behalf records the named mentor(s) with thanks.
               const recorded = creditedUniq.map(h => `@${h}`).join(', ');
-              const head = (creditedUniq.length === 1 && creditedUniq[0] === me)
-                ? `Confirmation recorded from @${commenter}.`
-                : `Confirmation recorded for ${recorded} (by @${commenter}).`;
+              const bySelf = creditedUniq.length === 1 && creditedUniq[0] === me;
+              let head;
+              if (bySelf) {
+                head = alreadyComplete
+                  ? `Thanks for confirming your participation, @${commenter}!`
+                  : `Thanks for confirming, @${commenter}!`;
+              } else {
+                head = creditedUniq.length === 1
+                  ? `Recorded @${creditedUniq[0]}'s confirmation (by @${commenter}). Thanks!`
+                  : `Recorded confirmation for ${recorded} (by @${commenter}). Thanks!`;
+              }
               const note = uniqIssues.length ? `\n\n⚠️ ${uniqIssues.join('\n\n⚠️ ')}` : '';
 
+              // Already complete: warm per-mentor ack, no re-announcement.
+              if (alreadyComplete) {
+                await reply('✅', `${head}${note}`);
+                return;
+              }
+              // Still waiting on other mentors.
               if (remaining.length) {
                 await reply('✅',
-                  `${head} ${count} of ${total} mentors have confirmed.\n\n` +
+                  `${head} That's ${count} of ${total} mentor${total === 1 ? '' : 's'} so far. ` +
                   `Still waiting on: ${remaining.map(h => `@${h}`).join(', ')}.${note}`);
                 return;
               }
-
-              // Every listed mentor has now confirmed.
+              // This /confirm completes the roster.
               await addLabel('Mentors Confirmed');
               await removeLabel('Awaiting Mentor Confirmation');
               await reply('✅',
-                `${head} All ${total} listed mentor(s) have confirmed. Mentor confirmation is complete.${note}`);
+                `${head} All ${total} listed mentor${total === 1 ? '' : 's'} have confirmed.${note}`);
               await checkBothGates();
               return;
             }

--- a/programs/lfx-mentorship/automation/lib/reactions.js
+++ b/programs/lfx-mentorship/automation/lib/reactions.js
@@ -1,0 +1,18 @@
+'use strict';
+
+// The GitHub reaction the bot adds to a command comment for a given reply
+// emoji, used by the reply() helper in lfx-proposal-approvals.yml. A success
+// gets a thumbs up, a failure a thumbs down, and everything else (an
+// informational reply) gets NO reaction.
+//
+// It deliberately never returns 'confused'. Stamping a confused face on a
+// comment where someone used a command as intended (e.g. a mentor confirming
+// their participation) reads as discouraging, which is the opposite of what
+// this automation is for.
+function replyReaction(emoji) {
+  if (emoji === '✅') return '+1';
+  if (emoji === '❌') return '-1';
+  return null;
+}
+
+module.exports = { replyReaction };

--- a/programs/lfx-mentorship/automation/test/reactions.test.js
+++ b/programs/lfx-mentorship/automation/test/reactions.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { replyReaction } = require('../lib/reactions');
+
+test('replyReaction maps a success reply to a thumbs up', () => {
+  assert.equal(replyReaction('✅'), '+1');
+});
+
+test('replyReaction maps a failure reply to a thumbs down', () => {
+  assert.equal(replyReaction('❌'), '-1');
+});
+
+test('replyReaction adds no reaction for an informational reply', () => {
+  assert.equal(replyReaction('ℹ️'), null);
+});
+
+test('replyReaction never returns confused for ANY input', () => {
+  // Reacting with a confused face to someone using a command (e.g. a mentor
+  // confirming participation) is discouraging; the bot must never do it.
+  for (const e of ['✅', '❌', 'ℹ️', '🎯', '🎉', '', ' ', undefined, null, 42]) {
+    assert.notEqual(replyReaction(e), 'confused');
+  }
+});


### PR DESCRIPTION
## What

The bot reacted 😕 (confused) to slash commands whose state was already settled, including a mentor running `/confirm` to confirm their participation. Reacting with a confused face to someone doing exactly what we asked is discouraging. This removes that reaction entirely and warms up the `/confirm` acknowledgment.

## Changes

- New `lib/reactions.js`: `replyReaction(emoji)` maps a reply to 👍 / 👎 / no reaction, and never returns `confused`. A unit test locks that guarantee for every input.
- `reply()` uses it and skips adding a reaction when there is none, so the three informational "already…" replies (`/confirm`, `/approve`, `/cncf-approve`) no longer stamp a 😕.
- `/confirm` now always gives a warm, participation-first acknowledgment and drops the dismissive "already recorded". A confirming mentor gets the same welcoming reply whether or not the roster was already complete. Gating is unchanged.

## Reaction surface

The bot can now only add 👀 (processing), 👍 (success), or 👎 (a genuine problem). 😕 is gone from the codebase.

## Testing

TDD for the reaction mapping; full unit suite passing; the workflow parses and its github-script blocks pass `node --check`.
