### PR TITLE
refactor(lfx): remove dead fallback_teams approver path

### DIFF
--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -51,7 +51,7 @@ jobs:
             const { computeConfirm, confirmTargets } = _lib('confirm.js');
             const { replyReaction } = _lib('reactions.js');
             const { lookupProject } = _lib('projects.js');
-            const { getGlobalApprovers, getProjectSection, getFallbackHandles, getFallbackTeams, maintainersCanApprove, buildProjectKeys } = _lib('approvers.js');
+            const { getGlobalApprovers, getProjectSection, getFallbackHandles, maintainersCanApprove, buildProjectKeys } = _lib('approvers.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
             const { lfxUrlDecision, recordedLfxUrlComment, readExports, locateExportedProgram, exportTermLabel, termMismatchWarning, renderRecordedIssues, recordedUrlNextSteps, changedRecordedPrograms, programCountLabel, populateRecordedUrls, upsertLfxUrlBlock } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
@@ -232,34 +232,11 @@ jobs:
               // (approvers.yml and the project section were read once, above.)
               if (!authorized) {
                 try {
-                  // 3a. Per-project fallback handles and teams
+                  // 3a. Per-project fallback handles
                   if (projectSection) {
-                    // Check fallback_handles
                     if (getFallbackHandles(projectSection).includes(commenter.toLowerCase())) {
                       authorized = true;
                       authSource = 'approvers.yml (fallback handle)';
-                    }
-                    // Check fallback_teams
-                    if (!authorized) {
-                      for (const team of getFallbackTeams(projectSection)) {
-                        const [org, slug] = team.split('/');
-                        if (!org || !slug) continue;
-                        try {
-                          const { data } = await github.rest.teams.getMembershipForUserInOrg({
-                            org, team_slug: slug, username: commenter,
-                          });
-                          if (data.state === 'active') {
-                            authorized = true;
-                            authSource = `approvers.yml (team ${team})`;
-                            break;
-                          }
-                        } catch (e) {
-                          // Likely a cross-org team: the repo token can't read
-                          // membership outside this org, so the team authorizes
-                          // no one. Use fallback_handles for cross-org approvers.
-                          console.log(`Could not verify team ${team} for ${commenter}: ${e.message}`);
-                        }
-                      }
                     }
                   }
 

--- a/programs/lfx-mentorship/automation/approvers.yml
+++ b/programs/lfx-mentorship/automation/approvers.yml
@@ -4,7 +4,7 @@
 # The approvals workflow checks authorization in this order:
 #   1. {org}/.project/maintainers.yaml (project-maintainers team)
 #   2. cncf/foundation/project-maintainers.csv
-#   3. This file — per-project fallback_teams and fallback_handles
+#   3. This file — per-project fallback_handles
 #   4. This file — global_approvers (can /approve for any project)
 #
 # Format:
@@ -14,11 +14,6 @@
 #   <project-key>:                # match by GitHub org (e.g. open-telemetry), the
 #                                 # lowercased/hyphenated name, or the projects.yml
 #                                 # slug; any of the three works.
-#     fallback_teams:             # DEPRECATED, practically dead (slated for removal):
-#       - org/team-name           # only cncf-org teams resolve (the token can't read
-#                                 # cross-org membership), and there are no CNCF-org
-#                                 # mentor/maintainer teams, so global_approvers already
-#                                 # covers that case. Use fallback_handles instead.
 #     fallback_handles:           # individual GitHub handles (works for any org)
 #       - username
 

--- a/programs/lfx-mentorship/automation/lib/approvers.js
+++ b/programs/lfx-mentorship/automation/lib/approvers.js
@@ -38,25 +38,17 @@ function getFallbackHandles(section) {
   return [...block[1].matchAll(/-\s+(\S+)/g)].map((m) => m[1].toLowerCase());
 }
 
-// fallback_teams within a project section: raw "org/team" strings (case kept,
-// since GitHub team slugs are matched by the API downstream).
-function getFallbackTeams(section) {
-  const block = String(section).match(/fallback_teams:\s*\n((?:\s+-\s+\S+.*\n?)*)/);
-  if (!block) return [];
-  return [...block[1].matchAll(/-\s+(\S+)/g)].map((m) => m[1]);
-}
-
 // Whether project maintainers may /approve for a project, read from its
 // approvers.yml section text (as returned by getProjectSection). Defaults to
-// true: the additive model where a project's maintainers, its fallback
-// handles/teams, and global_approvers can all /approve. A project sets
-// `maintainers_can_approve: false` to make its fallback_handles/fallback_teams
-// (plus global_approvers) the EXCLUSIVE approver set, so its individual
-// maintainer rosters are skipped (e.g. Kubernetes routes approvals through SIG
-// ContribEx, not per-maintainer). Only an explicit `false` disables it; a
-// missing, commented, or malformed value keeps the default true. The value must
-// be a bare boolean token (optionally followed by whitespace or a # comment to
-// end of line); trailing junk like `false-positive` is malformed, not false.
+// true: the additive model where a project's maintainers, its fallback handles,
+// and global_approvers can all /approve. A project sets
+// `maintainers_can_approve: false` to make its fallback_handles (plus
+// global_approvers) the EXCLUSIVE approver set, so its individual maintainer
+// rosters are skipped (e.g. Kubernetes routes approvals through SIG ContribEx,
+// not per-maintainer). Only an explicit `false` disables it; a missing,
+// commented, or malformed value keeps the default true. The value must be a bare
+// boolean token (optionally followed by whitespace or a # comment to end of
+// line); trailing junk like `false-positive` is malformed, not false.
 function maintainersCanApprove(section) {
   const m = String(section == null ? '' : section)
     .match(/^[ \t]*maintainers_can_approve:[ \t]*(true|false)[ \t]*(#.*)?$/im);
@@ -79,7 +71,6 @@ module.exports = {
   getGlobalApprovers,
   getProjectSection,
   getFallbackHandles,
-  getFallbackTeams,
   maintainersCanApprove,
   buildProjectKeys,
 };

--- a/programs/lfx-mentorship/automation/test/approvers.test.js
+++ b/programs/lfx-mentorship/automation/test/approvers.test.js
@@ -6,14 +6,13 @@ const {
   getGlobalApprovers,
   getProjectSection,
   getFallbackHandles,
-  getFallbackTeams,
   maintainersCanApprove,
   buildProjectKeys,
 } = require('../lib/approvers');
 
 // Fixture mirrors the real approvers.yml shape: a global_approvers list plus
-// per-project sections keyed by GitHub org, with fallback_teams and an optional
-// commented fallback_handles entry.
+// per-project sections keyed by GitHub org, each with fallback_handles and an
+// optional maintainers_can_approve flag.
 const YAML = `# comment header
 global_approvers:
   - nate-double-u
@@ -21,12 +20,12 @@ global_approvers:
   - Swil78
 
 kubernetes:
-  fallback_teams:
-    - kubernetes/sig-contribex
+  maintainers_can_approve: false
+  fallback_handles:
+    - kaslin
+    - MadhavJivrajani
 
 open-telemetry:
-  fallback_teams:
-    - open-telemetry/governance-committee
   fallback_handles:
     - maryliag    # GC liaison for mentorship
 `;
@@ -41,14 +40,14 @@ test('getGlobalApprovers: returns [] when the key is absent', () => {
 
 test('getProjectSection: returns the block for the first matching key', () => {
   const section = getProjectSection(YAML, ['nope', 'kubernetes']);
-  assert.match(section, /fallback_teams:/);
-  assert.match(section, /kubernetes\/sig-contribex/);
+  assert.match(section, /fallback_handles:/);
+  assert.match(section, /kaslin/);
   // Must stop before the next top-level key.
   assert.doesNotMatch(section, /open-telemetry/);
 });
 
 test('getProjectSection: key matching is case-insensitive', () => {
-  assert.match(getProjectSection(YAML, ['KUBERNETES']), /sig-contribex/);
+  assert.match(getProjectSection(YAML, ['KUBERNETES']), /kaslin/);
 });
 
 test('getProjectSection: a key that is only a prefix does not match', () => {
@@ -67,31 +66,15 @@ test('getFallbackHandles: lowercased, ignoring trailing comments', () => {
 });
 
 test('getFallbackHandles: returns [] for a section without fallback_handles', () => {
-  const section = getProjectSection(YAML, ['kubernetes']);
-  assert.deepEqual(getFallbackHandles(section), []);
-});
-
-test('getFallbackTeams: returns raw org/team strings with case preserved', () => {
-  assert.deepEqual(
-    getFallbackTeams(getProjectSection(YAML, ['kubernetes'])),
-    ['kubernetes/sig-contribex'],
-  );
-  assert.deepEqual(
-    getFallbackTeams(getProjectSection(YAML, ['open-telemetry'])),
-    ['open-telemetry/governance-committee'],
-  );
-});
-
-test('getFallbackTeams: returns [] for a section without fallback_teams', () => {
-  assert.deepEqual(getFallbackTeams('fallback_handles:\n    - someone\n'), []);
+  assert.deepEqual(getFallbackHandles('  maintainers_can_approve: false\n'), []);
 });
 
 // ── maintainersCanApprove: the per-project "exclusive approvers" flag ─────────
 // Default true = the additive model (project maintainers + fallbacks + global
 // approvers can /approve). A project sets `maintainers_can_approve: false` to
-// make its fallback_handles/fallback_teams (+ global_approvers) the EXCLUSIVE
-// approver set, so its individual maintainers cannot /approve (e.g. Kubernetes
-// routes approvals through SIG ContribEx, not per-maintainer).
+// make its fallback_handles (+ global_approvers) the EXCLUSIVE approver set, so
+// its individual maintainers cannot /approve (e.g. Kubernetes routes approvals
+// through SIG ContribEx, not per-maintainer).
 
 test('maintainersCanApprove: false when the section sets it false', () => {
   assert.equal(maintainersCanApprove('  maintainers_can_approve: false\n  fallback_handles:\n    - a\n'), false);
@@ -102,7 +85,7 @@ test('maintainersCanApprove: true when the section sets it true', () => {
 });
 
 test('maintainersCanApprove: defaults to true when the key is absent', () => {
-  assert.equal(maintainersCanApprove('  fallback_teams:\n    - a/b\n'), true);
+  assert.equal(maintainersCanApprove('  fallback_handles:\n    - a\n'), true);
 });
 
 test('maintainersCanApprove: defaults to true for an empty or nullish section', () => {


### PR DESCRIPTION
## What

Removes the dead `fallback_teams` approver path. It was already deprecated and inert: only same-org (cncf-org) teams resolve, because the workflow token can't read cross-org membership, and there are no CNCF-org mentor/maintainer teams. So `global_approvers` already covers that case, and `fallback_handles` covers individual cross-org approvers.

## Changes

- `lib/approvers.js`: drop `getFallbackTeams`.
- `lfx-proposal-approvals.yml`: drop the tier-3 fallback-team membership loop from `/approve` authorization.
- `approvers.yml`: remove the `fallback_teams` documentation.
- Tests: drop the `fallback_teams` cases.

## Testing

Full unit suite passing; the workflow parses and its github-script blocks pass `node --check`. No behavior change for real approvers: the removed path authorized no one.
