### PR TITLE
chore(lfx): label the /lfx-url record PRs administration

### DIFF
--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -604,6 +604,7 @@ jobs:
           author: ${{ env.BOT_IDENTITY }}
           committer: ${{ env.BOT_IDENTITY }}
           add-paths: programs/lfx-mentorship/${{ env.LFX_URL_YEAR }}/${{ env.LFX_URL_TERM_DIR }}
+          labels: administration
           commit-message: |
             chore: record LFX URLs for ${{ env.LFX_URL_TERM }}
 


### PR DESCRIPTION
## What

Adds the `administration` label to the "record LFX URLs" PRs that the `/lfx-url` command auto-generates, matching how the export PR is already labeled. Keeps the bot-generated administrative PRs filed together.

## Change

One line in `lfx-proposal-approvals.yml`: `labels: administration` on the create-pull-request step for the LFX-URL PR.
