### PR TITLE
feat(lfx): harden proposal validation and restructure custom prerequisite

### DIFF
--- a/.github/ISSUE_TEMPLATE/lfx-program-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/lfx-program-proposal.yml
@@ -417,8 +417,7 @@ body:
     attributes:
       label: Coding Challenge URL
       description: >
-        If you checked Coding Challenge above, provide the URL.
-        Leave blank otherwise.
+        Required if you selected Coding Challenge above; leave blank otherwise.
       placeholder: "https://example.com/challenge"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/lfx-program-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/lfx-program-proposal.yml
@@ -408,8 +408,6 @@ body:
           required: false
         - label: "Coding Challenge"
           required: false
-        - label: "Custom Prerequisite (fill in details below)"
-          required: false
 
   # ── Coding Challenge URL ──────────────────────────────────────────
   - type: input
@@ -421,6 +419,18 @@ body:
       placeholder: "https://example.com/challenge"
     validations:
       required: false
+
+  # ── Custom Prerequisites ──────────────────────────────────────────
+  - type: checkboxes
+    id: custom_prerequisites
+    attributes:
+      label: Custom Prerequisites
+      description: >
+        Add a project-specific prerequisite beyond the standard toggles
+        above. Check the box, then fill in the name and description below.
+      options:
+        - label: "Custom Prerequisite (fill in details below)"
+          required: false
 
   # ── Custom Prerequisite Name ──────────────────────────────────────
   - type: input

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -98,7 +98,7 @@ jobs:
               const skills = skillsSame ? technologies : get('Required/Desirable Skills');
 
               const prerequisites = parseCheckboxes(get('Application Prerequisites'));
-              const customPrereqChecked = prerequisites.includes(
+              const customPrereqChecked = parseCheckboxes(get('Custom Prerequisites')).includes(
                 'Custom Prerequisite (fill in details below)'
               );
               const customFileUpload = (get('Custom Prerequisite — File Upload') || '')

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -36,7 +36,7 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
-            const { parseIssueForm, parseCheckboxes, parseMentors } = _lib('parse.js');
+            const { parseIssueForm, parseCheckboxes, parseMentors, customPrerequisiteChecked } = _lib('parse.js');
             const { standardPrerequisites } = _lib('prerequisites.js');
             const { buildReadme, renderAcceptedProgramsBody } = _lib('readme.js');
             const { renderTrackingCsv } = _lib('csv.js');
@@ -98,9 +98,8 @@ jobs:
               const skills = skillsSame ? technologies : get('Required/Desirable Skills');
 
               const prerequisites = parseCheckboxes(get('Application Prerequisites'));
-              const customPrereqChecked = parseCheckboxes(get('Custom Prerequisites')).includes(
-                'Custom Prerequisite (fill in details below)'
-              );
+              const customPrereqChecked = customPrerequisiteChecked(
+                get('Custom Prerequisites'), get('Application Prerequisites'));
               const customFileUpload = (get('Custom Prerequisite — File Upload') || '')
                 .match(/\[x\]/i);
 

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -73,7 +73,7 @@ jobs:
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
             const { parseIssueForm, parseMentors, parseCheckboxes, formFieldsChanged } = _lib('parse.js');
-            const { validateMentors, validateUpstreamUrl, mentorCountWarning, validateCustomPrerequisite, CUSTOM_PREREQ_NAME_MAX, CUSTOM_PREREQ_DESC_MAX, findDuplicateUpstreamIssues } = _lib('validate.js');
+            const { validateMentors, validateUpstreamUrl, mentorCountWarning, validateCustomPrerequisite, CUSTOM_PREREQ_NAME_MAX, CUSTOM_PREREQ_DESC_MAX, findDuplicateUpstreamIssues, expectedFormSections, missingSections, validateCodingChallenge } = _lib('validate.js');
             const { lookupProject } = _lib('projects.js');
             const { isProposalTitle, looksLikeProposalForm } = _lib('labels.js');
             const { resolveProjectMaintainer } = _lib('authorize.js');
@@ -286,6 +286,56 @@ jobs:
             }
             if (customPrereqChecked && customPrereq.ok) {
               passed.push(`Custom Prerequisite: name ${customName.trim().length}/${CUSTOM_PREREQ_NAME_MAX} chars, description ${customDesc.trim().length}/${CUSTOM_PREREQ_DESC_MAX} chars`);
+            }
+
+            // Coding Challenge URL is required by LFX when the Coding Challenge
+            // prerequisite is checked; a URL left with the box unchecked is
+            // dropped by the export. Decision in lib/validate.js.
+            const codingChallengeChecked = parseCheckboxes(get('Application Prerequisites'))
+              .includes('Coding Challenge');
+            const codingChallengeUrl = get('Coding Challenge URL');
+            const codingChallenge = validateCodingChallenge({ checked: codingChallengeChecked, url: codingChallengeUrl });
+            for (const e of codingChallenge.errors) {
+              switch (e.code) {
+                case 'url-missing':
+                  errors.push(
+                    'You selected "Coding Challenge" as a prerequisite, but the Coding ' +
+                    'Challenge URL is empty. LFX requires the challenge URL. Add it, or ' +
+                    'uncheck Coding Challenge.');
+                  break;
+                case 'url-invalid':
+                  errors.push(`Coding Challenge URL \`${e.value}\` is not a valid URL.`);
+                  break;
+                case 'unchecked-with-url':
+                  errors.push(
+                    'A Coding Challenge URL is filled in, but the Coding Challenge box is ' +
+                    'not checked, so it will not be sent to LFX. Check the box to include ' +
+                    'it, or clear the URL.');
+                  break;
+              }
+            }
+            if (codingChallengeChecked && codingChallenge.ok) {
+              passed.push('Coding Challenge URL: provided');
+            }
+
+            // Structural completeness: a submitted issue form writes every
+            // template field as a "### <label>" section, so a missing heading
+            // means the body was altered. Fail on any missing section, but
+            // grandfather already-approved proposals (CNCF Approved or Exported),
+            // which may predate a later template field. (#1928)
+            const proposalLabels = (context.payload.issue.labels || []).map(l => l.name);
+            if (!proposalLabels.includes('CNCF Approved') && !proposalLabels.includes('Exported')) {
+              try {
+                const tmpl = fs.readFileSync('.github/ISSUE_TEMPLATE/lfx-program-proposal.yml', 'utf8');
+                const missing = missingSections(body, expectedFormSections(tmpl));
+                if (missing.length) {
+                  errors.push(
+                    `This proposal is missing required template section(s): ${missing.map(s => `**${s}**`).join(', ')}. ` +
+                    `Please re-submit with the current proposal template instead of removing sections.`);
+                }
+              } catch (e) {
+                console.log(`template section check skipped: ${e.message}`);
+              }
             }
 
             // ── 10. Same project + term scan (shared) ──

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -254,7 +254,7 @@ jobs:
             // lfx-export.yml), so copy left with the box unchecked is flagged
             // too, and every problem is reported together. Decision in
             // lib/validate.js; prose stays here.
-            const customPrereqChecked = parseCheckboxes(get('Application Prerequisites'))
+            const customPrereqChecked = parseCheckboxes(get('Custom Prerequisites'))
               .includes('Custom Prerequisite (fill in details below)');
             const customName = get('Custom Prerequisite Name');
             const customDesc = get('Custom Prerequisite Description');

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -72,7 +72,7 @@ jobs:
             const fs = require('fs');
             const path = require('path');
             const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
-            const { parseIssueForm, parseMentors, parseCheckboxes, formFieldsChanged } = _lib('parse.js');
+            const { parseIssueForm, parseMentors, parseCheckboxes, formFieldsChanged, customPrerequisiteChecked } = _lib('parse.js');
             const { validateMentors, validateUpstreamUrl, mentorCountWarning, validateCustomPrerequisite, CUSTOM_PREREQ_NAME_MAX, CUSTOM_PREREQ_DESC_MAX, findDuplicateUpstreamIssues, expectedFormSections, missingSections, validateCodingChallenge } = _lib('validate.js');
             const { lookupProject } = _lib('projects.js');
             const { isProposalTitle, looksLikeProposalForm } = _lib('labels.js');
@@ -254,8 +254,8 @@ jobs:
             // lfx-export.yml), so copy left with the box unchecked is flagged
             // too, and every problem is reported together. Decision in
             // lib/validate.js; prose stays here.
-            const customPrereqChecked = parseCheckboxes(get('Custom Prerequisites'))
-              .includes('Custom Prerequisite (fill in details below)');
+            const customPrereqChecked = customPrerequisiteChecked(
+              get('Custom Prerequisites'), get('Application Prerequisites'));
             const customName = get('Custom Prerequisite Name');
             const customDesc = get('Custom Prerequisite Description');
             const customPrereq = validateCustomPrerequisite({

--- a/.github/workflows/lfx-proposal-validate.yml
+++ b/.github/workflows/lfx-proposal-validate.yml
@@ -320,22 +320,18 @@ jobs:
 
             // Structural completeness: a submitted issue form writes every
             // template field as a "### <label>" section, so a missing heading
-            // means the body was altered. Fail on any missing section, but
-            // grandfather already-approved proposals (CNCF Approved or Exported),
-            // which may predate a later template field. (#1928)
-            const proposalLabels = (context.payload.issue.labels || []).map(l => l.name);
-            if (!proposalLabels.includes('CNCF Approved') && !proposalLabels.includes('Exported')) {
-              try {
-                const tmpl = fs.readFileSync('.github/ISSUE_TEMPLATE/lfx-program-proposal.yml', 'utf8');
-                const missing = missingSections(body, expectedFormSections(tmpl));
-                if (missing.length) {
-                  errors.push(
-                    `This proposal is missing required template section(s): ${missing.map(s => `**${s}**`).join(', ')}. ` +
-                    `Please re-submit with the current proposal template instead of removing sections.`);
-                }
-              } catch (e) {
-                console.log(`template section check skipped: ${e.message}`);
+            // means the body predates a later template field or was hand-edited.
+            // Run on every proposal; a program that changes should be checked. (#1928)
+            try {
+              const tmpl = fs.readFileSync('.github/ISSUE_TEMPLATE/lfx-program-proposal.yml', 'utf8');
+              const missing = missingSections(body, expectedFormSections(tmpl));
+              if (missing.length) {
+                errors.push(
+                  `This proposal is missing required template section(s): ${missing.map(s => `**${s}**`).join(', ')}. ` +
+                  `Please re-submit using the current proposal template.`);
               }
+            } catch (e) {
+              console.log(`template section check skipped: ${e.message}`);
             }
 
             // ── 10. Same project + term scan (shared) ──

--- a/programs/lfx-mentorship/automation/lib/parse.js
+++ b/programs/lfx-mentorship/automation/lib/parse.js
@@ -54,7 +54,7 @@ function parseMentors(raw) {
       return {
         name: parts[0],
         github_handle: parts[1].replace(/^@/, ''),
-        email: parts[2],
+        email: normalizeMentorEmail(parts[2]),
         lfid: parts[3] || '',
         role: i === 0 ? 'primary' : 'co-mentor',
       };
@@ -62,7 +62,18 @@ function parseMentors(raw) {
     .filter(Boolean);
 }
 
-module.exports = { parseIssueForm, parseCheckboxes, parseMentors, formFieldsChanged };
+// Unwrap common auto-linked forms so a mentor's email validates and exports as
+// a bare address: an editor or paste can store a typed email as a Markdown
+// mailto link `[addr](mailto:addr)`, an angle-bracket autolink `<addr>`, or a
+// bare `mailto:` prefix. A plain address is returned unchanged. (#1987)
+function normalizeMentorEmail(raw) {
+  const s = String(raw == null ? '' : raw).trim();
+  const md = s.match(/^\[[^\]]*\]\(mailto:([^)]+)\)$/i);
+  if (md) return md[1].trim();
+  return s.replace(/^<(.*)>$/, '$1').replace(/^mailto:/i, '').trim();
+}
+
+module.exports = { parseIssueForm, parseCheckboxes, parseMentors, normalizeMentorEmail, formFieldsChanged };
 
 // True when two issue-form bodies differ in any parsed field value — i.e. the
 // edit was "material" (a field's content changed), not merely cosmetic

--- a/programs/lfx-mentorship/automation/lib/parse.js
+++ b/programs/lfx-mentorship/automation/lib/parse.js
@@ -73,7 +73,17 @@ function normalizeMentorEmail(raw) {
   return s.replace(/^<(.*)>$/, '$1').replace(/^mailto:/i, '').trim();
 }
 
-module.exports = { parseIssueForm, parseCheckboxes, parseMentors, normalizeMentorEmail, formFieldsChanged };
+// The custom-prerequisite checkbox moved from the "Application Prerequisites"
+// field to its own "Custom Prerequisites" section (#2009 template cleanup).
+// Detect it in the new section first, then fall back to the old location so
+// proposals created before the change still parse correctly (back-compat).
+function customPrerequisiteChecked(customPrereqSection, applicationPrereqSection) {
+  const LABEL = 'Custom Prerequisite (fill in details below)';
+  return parseCheckboxes(customPrereqSection || '').includes(LABEL)
+    || parseCheckboxes(applicationPrereqSection || '').includes(LABEL);
+}
+
+module.exports = { parseIssueForm, parseCheckboxes, parseMentors, normalizeMentorEmail, customPrerequisiteChecked, formFieldsChanged };
 
 // True when two issue-form bodies differ in any parsed field value — i.e. the
 // edit was "material" (a field's content changed), not merely cosmetic

--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -8,6 +8,9 @@
 // functions that return structured error codes (presentation stays in the
 // workflow). Error codes, not prose, are the stable contract.
 
+const yaml = require('js-yaml');
+const { normalizeMentorEmail, parseIssueForm } = require('./parse.js');
+
 const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const urlRe = /^https?:\/\/\S+$/;
 const ghHandleRe = /^@[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
@@ -43,7 +46,8 @@ function validateMentors(raw) {
       return;
     }
 
-    const [name, handle, email, lfid] = parts;
+    const [name, handle, rawEmail, lfid] = parts;
+    const email = normalizeMentorEmail(rawEmail);
 
     if (!name) errors.push({ role, code: 'name' });
     if (!ghHandleRe.test(handle)) errors.push({ role, code: 'handle', value: handle });
@@ -181,6 +185,50 @@ function validateCustomPrerequisite({ checked, name, description } = {}) {
   return { ok: errors.length === 0, errors };
 }
 
+// ── Structural completeness of the submitted issue form ─────────────────
+// A GitHub issue form writes every field as a "### <label>" section (empty ones
+// as "_No response_"), so a missing heading means the body was hand-altered.
+// expectedFormSections reads the intended section labels from the issue
+// template (skipping markdown blocks, which have no heading); missingSections
+// returns the expected labels that are absent from a body. The workflow treats
+// a non-empty result as a validation error (grandfathering already-approved
+// proposals, which may predate a later template field). (#1928)
+function expectedFormSections(templateYaml) {
+  let doc;
+  try { doc = yaml.load(templateYaml); } catch (e) { return []; }
+  const body = doc && Array.isArray(doc.body) ? doc.body : [];
+  const out = [];
+  for (const el of body) {
+    if (!el || el.type === 'markdown') continue;
+    const label = el.attributes && el.attributes.label;
+    if (label != null && String(label).trim()) out.push(String(label).trim());
+  }
+  return out;
+}
+
+function missingSections(body, expected) {
+  const present = parseIssueForm(body);
+  return (expected || []).filter((label) => !(label in present));
+}
+
+// LFX requires a Coding Challenge URL when the "Coding Challenge" prerequisite
+// is checked. A URL left with the box unchecked is dropped by the export (it
+// keys off the box), so that mismatch is flagged too. Mirrors
+// validateCustomPrerequisite. Codes: 'url-missing', 'url-invalid',
+// 'unchecked-with-url'.
+function validateCodingChallenge({ checked, url } = {}) {
+  const errors = [];
+  const u = (url || '').trim();
+  if (!checked && !u) return { ok: true, errors };
+  if (!checked) {
+    errors.push({ code: 'unchecked-with-url' });
+    return { ok: false, errors };
+  }
+  if (!u) errors.push({ code: 'url-missing' });
+  else if (!urlRe.test(u)) errors.push({ code: 'url-invalid', value: u });
+  return { ok: errors.length === 0, errors };
+}
+
 module.exports = {
   emailRe,
   urlRe,
@@ -191,8 +239,11 @@ module.exports = {
   mentorCountWarning,
   MIN_PREFERRED_MENTORS,
   validateCustomPrerequisite,
+  validateCodingChallenge,
   CUSTOM_PREREQ_NAME_MAX,
   CUSTOM_PREREQ_DESC_MAX,
   normalizeUpstreamUrl,
+  expectedFormSections,
+  missingSections,
   findDuplicateUpstreamIssues,
 };

--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -191,11 +191,12 @@ function validateCustomPrerequisite({ checked, name, description } = {}) {
 // expectedFormSections reads the intended section labels from the issue
 // template (skipping markdown blocks, which have no heading); missingSections
 // returns the expected labels that are absent from a body. The workflow treats
-// a non-empty result as a validation error (grandfathering already-approved
-// proposals, which may predate a later template field). (#1928)
+// a non-empty result as a validation error. (#1928)
 function expectedFormSections(templateYaml) {
-  let doc;
-  try { doc = yaml.load(templateYaml); } catch (e) { return []; }
+  // Let a YAML parse error throw; the workflow wraps this call in try/catch and
+  // logs, so swallowing it here would make the missing-section check a silent
+  // no-op on a broken template.
+  const doc = yaml.load(templateYaml);
   const body = doc && Array.isArray(doc.body) ? doc.body : [];
   const out = [];
   for (const el of body) {

--- a/programs/lfx-mentorship/automation/test/parse.test.js
+++ b/programs/lfx-mentorship/automation/test/parse.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { parseIssueForm, parseCheckboxes, parseMentors } = require('../lib/parse');
+const { parseIssueForm, parseCheckboxes, parseMentors, normalizeMentorEmail } = require('../lib/parse');
 
 test('parseIssueForm: splits ### sections into a label->value map', () => {
   const body = [
@@ -145,4 +145,23 @@ test('formFieldsChanged: adding the /lfx-url block is not a material edit', () =
   const body = '### CNCF Project\n\nKubernetes\n\n### Upstream Issue URL\n\nhttps://example.test/1';
   const withBlock = upsertLfxUrlBlock(body, { title: 'CNCF - Kubernetes: X (2026 Term 3)', url: A_LFX_URL });
   assert.equal(formFieldsChanged(body, withBlock), false);
+});
+
+// ── normalizeMentorEmail: unwrap auto-linked email forms (#1987) ────────
+// A typed email can arrive Markdown mailto-linked, angle-bracket autolinked,
+// or bare-mailto-prefixed; the stored/validated address should be the bare one.
+
+test('normalizeMentorEmail unwraps autolink forms to a bare address', () => {
+  assert.equal(normalizeMentorEmail('[a@x.com](mailto:a@x.com)'), 'a@x.com');
+  assert.equal(normalizeMentorEmail('<a@x.com>'), 'a@x.com');
+  assert.equal(normalizeMentorEmail('mailto:a@x.com'), 'a@x.com');
+  assert.equal(normalizeMentorEmail('a@x.com'), 'a@x.com');
+  assert.equal(normalizeMentorEmail('  a@x.com  '), 'a@x.com');
+});
+
+test('parseMentors: strips a Markdown mailto autolink from the email (#1987)', () => {
+  assert.deepEqual(
+    parseMentors('Jane Doe | @janedoe | [jane@example.com](mailto:jane@example.com) | janedoe'),
+    [{ name: 'Jane Doe', github_handle: 'janedoe', email: 'jane@example.com', lfid: 'janedoe', role: 'primary' }],
+  );
 });

--- a/programs/lfx-mentorship/automation/test/parse.test.js
+++ b/programs/lfx-mentorship/automation/test/parse.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { parseIssueForm, parseCheckboxes, parseMentors, normalizeMentorEmail } = require('../lib/parse');
+const { parseIssueForm, parseCheckboxes, parseMentors, normalizeMentorEmail, customPrerequisiteChecked } = require('../lib/parse');
 
 test('parseIssueForm: splits ### sections into a label->value map', () => {
   const body = [
@@ -35,6 +35,32 @@ test('parseCheckboxes: keeps only checked items, stripping the box', () => {
 
 test('parseCheckboxes: empty input yields empty array', () => {
   assert.deepEqual(parseCheckboxes(''), []);
+});
+
+// The custom-prerequisite checkbox moved from "Application Prerequisites" to its
+// own "Custom Prerequisites" section (#2009 template cleanup). The reader must
+// still detect it on proposals created before that change (back-compat).
+test('customPrerequisiteChecked: true when checked in the new Custom Prerequisites section', () => {
+  const custom = '- [x] Custom Prerequisite (fill in details below)';
+  const app = '- [x] Resume\n- [ ] Coding Challenge';
+  assert.equal(customPrerequisiteChecked(custom, app), true);
+});
+
+test('customPrerequisiteChecked: back-compat true when checked in the old Application Prerequisites location', () => {
+  const custom = '';
+  const app = '- [x] Resume\n- [x] Custom Prerequisite (fill in details below)';
+  assert.equal(customPrerequisiteChecked(custom, app), true);
+});
+
+test('customPrerequisiteChecked: false when unchecked in both locations', () => {
+  const custom = '- [ ] Custom Prerequisite (fill in details below)';
+  const app = '- [x] Resume\n- [ ] Coding Challenge';
+  assert.equal(customPrerequisiteChecked(custom, app), false);
+});
+
+test('customPrerequisiteChecked: false when both sections are empty or absent', () => {
+  assert.equal(customPrerequisiteChecked('', ''), false);
+  assert.equal(customPrerequisiteChecked(undefined, undefined), false);
 });
 
 test('parseMentors: a 4-field line yields lfid and strips @', () => {

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -9,6 +9,8 @@ const {
   validateCustomPrerequisite,
   CUSTOM_PREREQ_NAME_MAX, CUSTOM_PREREQ_DESC_MAX,
   normalizeUpstreamUrl, findDuplicateUpstreamIssues,
+  expectedFormSections, missingSections,
+  validateCodingChallenge,
 } = require('../lib/validate');
 
 const codes = (result) => result.errors.map(e => e.code);
@@ -361,4 +363,74 @@ test('findDuplicateUpstreamIssues: preserves input order and handles missing/emp
     { number: 3, url: 'https://github.com/a/b/issues/1' },
   ];
   assert.deepEqual(findDuplicateUpstreamIssues('https://github.com/a/b/issues/1', others), [9, 3]);
+});
+
+// A mentor's email that arrived Markdown mailto-linked still validates (#1987).
+test('validateMentors: accepts a Markdown mailto-autolinked email', () => {
+  assert.deepEqual(
+    validateMentors('Jane Doe | @janedoe | [jane@example.com](mailto:jane@example.com) | janedoe'),
+    { ok: true, count: 1, errors: [] },
+  );
+});
+
+// ── Structural completeness: expected template sections (#1928) ─────────
+// A submitted issue form includes every template field as a "### <label>"
+// section; a removed heading means the body was altered.
+
+test('expectedFormSections returns non-markdown field labels in order', () => {
+  const tmpl = [
+    'name: Test',
+    'body:',
+    '  - type: markdown',
+    '    attributes:',
+    '      value: "Intro, no heading"',
+    '  - type: dropdown',
+    '    attributes:',
+    '      label: CNCF Project',
+    '  - type: input',
+    '    attributes:',
+    '      label: Program Name',
+    '  - type: checkboxes',
+    '    attributes:',
+    '      label: Application Prerequisites',
+  ].join('\n');
+  assert.deepEqual(expectedFormSections(tmpl), ['CNCF Project', 'Program Name', 'Application Prerequisites']);
+});
+
+test('missingSections returns expected labels absent from the body', () => {
+  const body = '### CNCF Project\n\nA\n\n### Program Name\n\nFoo\n';
+  assert.deepEqual(
+    missingSections(body, ['CNCF Project', 'Program Name', 'Application Prerequisites']),
+    ['Application Prerequisites'],
+  );
+});
+
+test('missingSections is empty when every section is present, even if empty', () => {
+  const body = '### A\n\n_No response_\n\n### B\n\ny\n';
+  assert.deepEqual(missingSections(body, ['A', 'B']), []);
+});
+
+// ── Coding Challenge URL required when the prerequisite is checked (#2009) ──
+// LFX requires the challenge URL when "Coding Challenge" is selected; a URL
+// left with the box unchecked is dropped by the export. Mirrors the custom
+// prerequisite check.
+
+test('validateCodingChallenge: unchecked and empty passes', () => {
+  assert.deepEqual(validateCodingChallenge({ checked: false, url: '' }), { ok: true, errors: [] });
+});
+
+test('validateCodingChallenge: checked with a valid URL passes', () => {
+  assert.deepEqual(validateCodingChallenge({ checked: true, url: 'https://github.com/x/y/issues/1' }), { ok: true, errors: [] });
+});
+
+test('validateCodingChallenge: checked but empty URL flags url-missing', () => {
+  assert.deepEqual(validateCodingChallenge({ checked: true, url: '' }).errors, [{ code: 'url-missing' }]);
+});
+
+test('validateCodingChallenge: checked with a malformed URL flags url-invalid', () => {
+  assert.deepEqual(validateCodingChallenge({ checked: true, url: 'not a url' }).errors, [{ code: 'url-invalid', value: 'not a url' }]);
+});
+
+test('validateCodingChallenge: URL filled but box unchecked flags unchecked-with-url', () => {
+  assert.deepEqual(validateCodingChallenge({ checked: false, url: 'https://x.com/c' }).errors, [{ code: 'unchecked-with-url' }]);
 });

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -397,6 +397,10 @@ test('expectedFormSections returns non-markdown field labels in order', () => {
   assert.deepEqual(expectedFormSections(tmpl), ['CNCF Project', 'Program Name', 'Application Prerequisites']);
 });
 
+test('expectedFormSections lets a YAML parse error surface (no silent no-op)', () => {
+  assert.throws(() => expectedFormSections('[unterminated flow sequence'));
+});
+
 test('missingSections returns expected labels absent from the body', () => {
   const body = '### CNCF Project\n\nA\n\n### Program Name\n\nFoo\n';
   assert.deepEqual(


### PR DESCRIPTION
## What

Harden LFX proposal validation, restructure the custom-prerequisite fields in the proposal form, and keep older proposals parsing correctly.

## Changes

**Validation hardening**
- Accept a mentor email that arrived as a Markdown mailto link, unwrapping it to a bare address before validating.
- Require the Coding Challenge URL when that prerequisite is checked, and flag a URL left with the box unchecked.
- Fail validation when a proposal is missing template sections (the expected sections are read from the issue template). This runs on every proposal.

**Template restructure**
- Move the custom-prerequisite checkbox out of Application Prerequisites into a new Custom Prerequisites section, so the Coding Challenge URL sits with its checkbox and the custom-prerequisite fields group together.

**Back-compat**
- Read the custom-prerequisite checkbox from the new section first, then fall back to the old location, so proposals created before the restructure still validate and export their custom prerequisite instead of dropping it.

## Verification

- Unit suite green (580 tests); both workflows' script blocks compile; template parses.
- End-to-end run against the dev fork covers all three hardening cases plus the custom-prerequisite path (checked prerequisite read from the new section).

## Note on existing proposals

- The missing-section check runs on every proposal and fires when an issue is edited. Current proposals predate the new Custom Prerequisites section, so editing one prompts a re-submit with the current template. Programs already posted to LFX are not edited and see no change.
- The custom-prerequisite back-compat preserves the 17 currently-exported programs that carry one.
