### PR TITLE
fix(lfx): restore notifications and lock copy contracts

### DIFF
--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -314,6 +314,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const path = require('path');
+            const _lib = (m) => require(path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'programs/lfx-mentorship/automation/lib', m));
+            const { exportInclusionComment } = _lib('lfx-url.js');
             const { owner, repo } = context.repo;
             const issues = process.env.EXPORTED_ISSUES.split(',').filter(Boolean);
             const notify = new Set((process.env.NOTIFY_ISSUES || '').split(',').filter(Boolean).map(Number));
@@ -339,12 +342,10 @@ jobs:
                 continue;
               }
 
-              // Comment linking to the export
+              // Comment linking to the export (copy in lib/lfx-url.js, tested)
               await github.rest.issues.createComment({
                 owner, repo, issue_number,
-                body: `📦 This proposal has been included in the **${term}** export.\n\n` +
-                  `Export files: [\`programs/lfx-mentorship/${year}/${termDir}/\`](/${owner}/${repo}/tree/automation/lfx-export-${year}-${termDir}/programs/lfx-mentorship/${year}/${termDir}/)\n\n` +
-                  `The export PR is awaiting review. Once merged and posted to LFX, this issue will be updated again.`,
+                body: exportInclusionComment({ owner, repo, term, year, termDir }),
               });
 
               console.log(`Notified issue #${issue_number}`);

--- a/.github/workflows/lfx-proposal-approvals.yml
+++ b/.github/workflows/lfx-proposal-approvals.yml
@@ -52,6 +52,7 @@ jobs:
             const { replyReaction } = _lib('reactions.js');
             const { lookupProject } = _lib('projects.js');
             const { getGlobalApprovers, getProjectSection, getFallbackHandles, maintainersCanApprove, buildProjectKeys } = _lib('approvers.js');
+            const { maintainerApprovalComment, cncfApprovalComment } = _lib('approvals.js');
             const { cncfApproveDecision } = _lib('cncf-approve.js');
             const { lfxUrlDecision, recordedLfxUrlComment, readExports, locateExportedProgram, exportTermLabel, termMismatchWarning, renderRecordedIssues, recordedUrlNextSteps, changedRecordedPrograms, programCountLabel, populateRecordedUrls, upsertLfxUrlBlock } = _lib('lfx-url.js');
             const { termPaths } = _lib('term-paths.js');
@@ -278,8 +279,7 @@ jobs:
 
               await addLabel('Maintainer/Contribex Approved');
               await removeLabel('Awaiting Maintainer/Contribex Approval');
-              await reply('✅',
-                `Maintainer approval recorded from @${commenter} (${authSource}).`);
+              await reply('✅', maintainerApprovalComment({ commenter, source: authSource }));
               await checkBothGates();
               return;
             }
@@ -438,9 +438,7 @@ jobs:
 
               await addLabel('CNCF Approved');
               await removeLabel('Awaiting CNCF Admin Approval');
-              await reply('✅',
-                `CNCF admin approval granted by @${commenter}.\n\n` +
-                `This proposal is approved and will be included in the next LFX export.`);
+              await reply('✅', cncfApprovalComment({ commenter }));
               return;
             }
 

--- a/programs/lfx-mentorship/automation/lib/approvals.js
+++ b/programs/lfx-mentorship/automation/lib/approvals.js
@@ -4,10 +4,11 @@
 // /cncf-approve handlers post (lfx-proposal-approvals.yml), so the validation
 // workflow can @-tag the people whose approval it clears after a material edit.
 //
-// Coupled to those confirmation-comment strings — if the approvals workflow
-// changes the wording, update these patterns (and their tests) with it. Only
-// github-actions[bot] comments are scanned, so a user quoting the phrase can't
-// spoof an approver.
+// The emitters (maintainerApprovalComment / cncfApprovalComment below) are the
+// single source of truth for this copy; the workflow posts them and the parser
+// reads them back, and round-trip tests keep the two in lockstep so a wording
+// change can't silently break approval tallying. Only github-actions[bot]
+// comments are scanned, so a user quoting the phrase can't spoof an approver.
 
 const MAINTAINER_RE = /Maintainer approval recorded from @([A-Za-z0-9-]+)/g;
 const CNCF_RE = /CNCF admin approval granted by @([A-Za-z0-9-]+)/g;
@@ -33,4 +34,16 @@ function findRecordedApprovers(comments) {
   return { maintainers, cncfAdmins };
 }
 
-module.exports = { findRecordedApprovers };
+// The approval-record comments the /approve and /cncf-approve handlers post.
+// findRecordedApprovers parses these exact strings back, so they are defined
+// here (not inline in the workflow) and locked by round-trip tests.
+function maintainerApprovalComment({ commenter, source } = {}) {
+  return `Maintainer approval recorded from @${commenter} (${source}).`;
+}
+
+function cncfApprovalComment({ commenter } = {}) {
+  return `CNCF admin approval granted by @${commenter}.\n\n` +
+    `This proposal is approved and will be included in the next LFX export.`;
+}
+
+module.exports = { findRecordedApprovers, maintainerApprovalComment, cncfApprovalComment };

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -247,7 +247,18 @@ async function populateRecordedUrls(programs, { currentIssue, currentUrl, fetchC
       prog.lfx_url = currentUrl;
       continue;
     }
-    const url = parseRecordedLfxUrl(await fetchComments(prog.issue_number));
+    // A program whose issue is gone/inaccessible (404) keeps its existing
+    // recorded url instead of crashing the run; a merged url is never
+    // regressed (§ above). Anything other than "not found" is unexpected, so
+    // re-throw rather than silently masking a real failure.
+    let comments;
+    try {
+      comments = await fetchComments(prog.issue_number);
+    } catch (e) {
+      if (e && e.status === 404) continue;
+      throw e;
+    }
+    const url = parseRecordedLfxUrl(comments);
     if (url) prog.lfx_url = url;
   }
   return programs;

--- a/programs/lfx-mentorship/automation/lib/lfx-url.js
+++ b/programs/lfx-mentorship/automation/lib/lfx-url.js
@@ -352,12 +352,24 @@ function renderExportChangeBody(added, updated) {
     : '_No programs added or updated in this run (regenerated files only)._';
 }
 
+// The comment posted to each newly-exported proposal when the export PR opens.
+// The files link targets `main` (the durable location once the PR merges), not
+// the export branch, which is deleted on merge and would leave a dead link.
+// Extracted from lfx-export.yml and unit-tested so the link target and copy
+// can't silently drift, as the inline version did. (#252)
+function exportInclusionComment({ owner, repo, term, year, termDir } = {}) {
+  const path = `programs/lfx-mentorship/${year}/${termDir}/`;
+  return `\u{1F4E6} This proposal has been included in the **${term}** export.\n\n` +
+    `Export files: [\`${path}\`](/${owner}/${repo}/tree/main/${path})\n\n` +
+    `The export PR is awaiting review. Once merged and posted to LFX, this issue will be updated again.`;
+}
+
 module.exports = {
   recordedLfxUrlComment, parseRecordedLfxUrl, lfxUrlDecision,
   findExportedProgram, exportTermLabel, readExports, locateExportedProgram,
   termMismatchWarning, recordedPrograms, renderRecordedIssues, recordedUrlNextSteps,
   changedRecordedPrograms, programCountLabel,
   populateRecordedUrls, upsertLfxUrlBlock, stripLfxUrlBlock,
-  exportChangeLabel, renderExportChangeBody,
+  exportChangeLabel, renderExportChangeBody, exportInclusionComment,
   LFX_PROGRAM_URL_RE,
 };

--- a/programs/lfx-mentorship/automation/lib/notify.js
+++ b/programs/lfx-mentorship/automation/lib/notify.js
@@ -4,12 +4,15 @@
 // so it can be unit-tested while the workflow's side effects stay thin.
 
 // Extract the issue numbers the export workflow records in the PR body as
-// "- #<n> — <name>" (emitted by lfx-export.yml). The em-dash (U+2014) is a
-// functional delimiter: this regex must match the line format lfx-export.yml
-// emits, so changing that output means changing this too. Returns an array of
+// "- #<n> <name>" list items (emitted by renderExportChangeBody in lfx-url.js).
+// That line format is a contract shared with the renderer; test/notify.test.js
+// round-trips the two so they cannot drift. (They did once: an em-dash
+// delimiter was dropped from the renderer but not from this parser, which
+// silently broke the merge notification.) Line-anchored so a "- #n" inside a
+// free-text program name is not mistaken for a list item. Returns an array of
 // numbers (order preserved, no de-dup).
 function parseExportedIssueNumbers(body) {
-  return [...String(body || '').matchAll(/-\s+#(\d+)\s+—/g)].map(m => parseInt(m[1], 10));
+  return [...String(body || '').matchAll(/^\s*-\s+#(\d+)\b/gm)].map(m => parseInt(m[1], 10));
 }
 
 // True when ref is a branch the export workflow created. Guards the

--- a/programs/lfx-mentorship/automation/test/approvals.test.js
+++ b/programs/lfx-mentorship/automation/test/approvals.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { findRecordedApprovers } = require('../lib/approvals');
+const { findRecordedApprovers, maintainerApprovalComment, cncfApprovalComment } = require('../lib/approvals');
 
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
 
@@ -37,4 +37,19 @@ test('de-dupes case-insensitively, preserving first-seen casing', () => {
     bot('✅ Maintainer approval recorded from @carlesarnal (again).'),
   ];
   assert.deepEqual(findRecordedApprovers(comments), { maintainers: ['CarlesArnal'], cncfAdmins: [] });
+});
+
+// ── Copy contract: the /approve and /cncf-approve handlers (approvals.yml) emit
+// these comments, and findRecordedApprovers (read by the validate workflow)
+// parses them back to tally approvers. Emitter and parser live in different
+// workflows, so a wording drift would silently break approval tallying. These
+// round-trips tie the emitted copy to the parser so neither can drift alone.
+test('findRecordedApprovers round-trips maintainerApprovalComment (copy contract)', () => {
+  const c = [bot(maintainerApprovalComment({ commenter: 'alice', source: 'Foo/.project/maintainers.yaml' }))];
+  assert.deepEqual(findRecordedApprovers(c), { maintainers: ['alice'], cncfAdmins: [] });
+});
+
+test('findRecordedApprovers round-trips cncfApprovalComment (copy contract)', () => {
+  const c = [bot(cncfApprovalComment({ commenter: 'bob' }))];
+  assert.deepEqual(findRecordedApprovers(c), { maintainers: [], cncfAdmins: ['bob'] });
 });

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -506,6 +506,36 @@ test('populateRecordedUrls: preserves an existing sibling url when it has no rec
   assert.equal(programs[1].lfx_url, `${PROJ}/aaaaaaaa-0000-4000-8000-000000000002`);
 });
 
+test('populateRecordedUrls: a sibling whose comments fail to load (e.g. 404) keeps its existing url and the run continues', async () => {
+  const programs = [
+    { issue_number: 1, lfx_url: `${PROJ}/aaaaaaaa-0000-4000-8000-000000000001` }, // baseline url; its issue will 404
+    { issue_number: 2, lfx_url: '' },                                             // current
+    { issue_number: 3, lfx_url: '' },                                             // later sibling with a recorded comment
+  ];
+  const notFound = Object.assign(new Error('Not Found'), { status: 404 });
+  const comments = { 3: [recComment(`${PROJ}/aaaaaaaa-0000-4000-8000-000000000003`)] };
+  await populateRecordedUrls(programs, {
+    currentIssue: 2,
+    currentUrl: `${PROJ}/aaaaaaaa-0000-4000-8000-000000000002`,
+    fetchComments: async (n) => { if (n === 1) throw notFound; return comments[n] || []; },
+  });
+  assert.equal(programs[0].lfx_url, `${PROJ}/aaaaaaaa-0000-4000-8000-000000000001`, 'unreadable sibling keeps its existing url');
+  assert.equal(programs[1].lfx_url, `${PROJ}/aaaaaaaa-0000-4000-8000-000000000002`, 'current still set');
+  assert.equal(programs[2].lfx_url, `${PROJ}/aaaaaaaa-0000-4000-8000-000000000003`, 'later sibling still processed after the failure');
+});
+
+test('populateRecordedUrls: a non-404 fetch error propagates (do not mask real failures)', async () => {
+  const programs = [{ issue_number: 1, lfx_url: '' }, { issue_number: 2, lfx_url: '' }];
+  const boom = Object.assign(new Error('Server Error'), { status: 500 });
+  await assert.rejects(
+    populateRecordedUrls(programs, {
+      currentIssue: 2, currentUrl: `${PROJ}/aaaaaaaa-0000-4000-8000-000000000002`,
+      fetchComments: async () => { throw boom; },
+    }),
+    /Server Error/,
+  );
+});
+
 test('populateRecordedUrls: empty program list makes no fetches', async () => {
   let called = 0;
   const out = await populateRecordedUrls([], { currentIssue: 1, currentUrl: 'x', fetchComments: async () => { called++; return []; } });

--- a/programs/lfx-mentorship/automation/test/lfx-url.test.js
+++ b/programs/lfx-mentorship/automation/test/lfx-url.test.js
@@ -7,7 +7,7 @@ const {
   exportTermLabel, readExports, locateExportedProgram, termMismatchWarning,
   recordedPrograms, renderRecordedIssues, recordedUrlNextSteps, populateRecordedUrls,
   changedRecordedPrograms, programCountLabel, upsertLfxUrlBlock, stripLfxUrlBlock,
-  exportChangeLabel, renderExportChangeBody,
+  exportChangeLabel, renderExportChangeBody, exportInclusionComment,
 } = require('../lib/lfx-url');
 
 const bot = (body) => ({ user: { login: 'github-actions[bot]' }, body });
@@ -705,4 +705,28 @@ test('renderExportChangeBody: no em-dash', () => {
     [{ issue_number: 2, program_name_full: 'CNCF - B (T)' }],
   );
   assert.ok(!md.includes('\u2014'));
+});
+
+// ── exportInclusionComment: the "included in the export" comment posted to each
+// newly-exported proposal when the export PR opens. The files link must target
+// `main` (durable once the PR merges), never the export branch (deleted on
+// merge, which breaks the link). Extracted from lfx-export.yml and tested so the
+// link target and copy can't silently drift, as the inline version did. (#252)
+test('exportInclusionComment: links the export files to main, not the export branch', () => {
+  const body = exportInclusionComment({
+    owner: 'cncf', repo: 'mentoring',
+    term: '2026 Term 3 (Sep-Nov)', year: '2026', termDir: '03-Sep-Nov',
+  });
+  assert.match(body, /\(\/cncf\/mentoring\/tree\/main\/programs\/lfx-mentorship\/2026\/03-Sep-Nov\/\)/);
+  assert.doesNotMatch(body, /tree\/automation/);
+});
+
+test('exportInclusionComment: names the term and shows the export files path', () => {
+  const body = exportInclusionComment({
+    owner: 'o', repo: 'r',
+    term: '2026 Term 3 (Sep-Nov)', year: '2026', termDir: '03-Sep-Nov',
+  });
+  assert.match(body, /included in the \*\*2026 Term 3 \(Sep-Nov\)\*\* export/);
+  assert.match(body, /`programs\/lfx-mentorship\/2026\/03-Sep-Nov\/`/);
+  assert.match(body, /awaiting review/);
 });

--- a/programs/lfx-mentorship/automation/test/notify.test.js
+++ b/programs/lfx-mentorship/automation/test/notify.test.js
@@ -3,20 +3,26 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const { parseExportedIssueNumbers, isExportBranch, exportPathForBranch, exportedIssueNumbers, newIssueNumbers } = require('../lib/notify');
+const { renderExportChangeBody } = require('../lib/lfx-url');
 
 // parseExportedIssueNumbers extracts the issue numbers the export workflow
-// writes into the PR body as "- #<n> — <name>". The em-dash (U+2014) is a
-// functional delimiter shared with lfx-export.yml: it must match exactly.
+// writes into the PR body as "- #<n> <name>" list items (see
+// renderExportChangeBody). The writer/reader format contract is enforced by the
+// round-trip test below; these cases pin the parser's own behavior.
 test('parseExportedIssueNumbers: single issue', () => {
   assert.deepEqual(
-    parseExportedIssueNumbers('- #29 — CNCF - OpenTelemetry: Testing (2026 Term 3)'),
+    parseExportedIssueNumbers('- #29 CNCF - OpenTelemetry: Testing (2026 Term 3)'),
     [29]
   );
 });
 
 test('parseExportedIssueNumbers: multiple issues across lines', () => {
-  const body = '**Exported proposals:**\n- #12 — Foo\n- #34 — Bar\n';
+  const body = '**Newly added:**\n- #12 Foo\n- #34 Bar\n';
   assert.deepEqual(parseExportedIssueNumbers(body), [12, 34]);
+});
+
+test('parseExportedIssueNumbers: a bare "- #<n>" line (no name) still matches', () => {
+  assert.deepEqual(parseExportedIssueNumbers('- #42'), [42]);
 });
 
 test('parseExportedIssueNumbers: empty string yields none', () => {
@@ -28,10 +34,37 @@ test('parseExportedIssueNumbers: null/undefined yields none', () => {
   assert.deepEqual(parseExportedIssueNumbers(undefined), []);
 });
 
-test('parseExportedIssueNumbers: only the em-dash delimiter matches', () => {
-  // hyphen-minus and en-dash must not be treated as the delimiter
-  assert.deepEqual(parseExportedIssueNumbers('- #5 - Foo'), []);
-  assert.deepEqual(parseExportedIssueNumbers('- #5 \u2013 Foo'), []);
+test('parseExportedIssueNumbers: only list items match, not inline refs', () => {
+  // an issue ref in prose or mid-line (not a "- #<n>" list item) is ignored
+  assert.deepEqual(parseExportedIssueNumbers('See #5 for context.'), []);
+  assert.deepEqual(parseExportedIssueNumbers('a name that mentions #5 mid-line'), []);
+});
+
+test('parseExportedIssueNumbers: ignores the "Export files" backtick list', () => {
+  // the real export PR body carries a "- `path`" file list; only "- #<n>" counts
+  const body = [
+    '**Newly added:**', '- #12 CNCF - Foo', '',
+    '**Export files:**',
+    '- `programs/lfx-mentorship/2026/03-Sep-Nov/lfx-export.json`: JSON',
+    '- `programs/lfx-mentorship/2026/03-Sep-Nov/README.md`: list', '',
+  ].join('\n');
+  assert.deepEqual(parseExportedIssueNumbers(body), [12]);
+});
+
+// ── Format contract (the test that was missing) ──────────────────────────────
+// parseExportedIssueNumbers (notify.js) reads the export PR body that
+// renderExportChangeBody (lfx-url.js) writes. They share a line format; testing
+// each against its own hand-written fixture let them silently drift (#1945
+// dropped the em-dash from the renderer but not the parser), which killed the
+// merge notification in prod. This round-trip fails if either side drifts.
+test('parseExportedIssueNumbers round-trips renderExportChangeBody output (format contract)', () => {
+  const added = [
+    { issue_number: 218, program_name_full: 'CNCF - Backstage: Knative eventing' },
+    { issue_number: 219, program_name_full: 'CNCF - Kyverno: Policy log' },
+  ];
+  const updated = [{ issue_number: 220, program_name_full: 'CNCF - Meshery: Registry' }];
+  const body = renderExportChangeBody(added, updated);
+  assert.deepEqual(parseExportedIssueNumbers(body), [218, 219, 220]);
 });
 
 test('parseExportedIssueNumbers: requires the leading list dash', () => {

--- a/programs/lfx-mentorship/automation/test/notify.test.js
+++ b/programs/lfx-mentorship/automation/test/notify.test.js
@@ -68,11 +68,11 @@ test('parseExportedIssueNumbers round-trips renderExportChangeBody output (forma
 });
 
 test('parseExportedIssueNumbers: requires the leading list dash', () => {
-  assert.deepEqual(parseExportedIssueNumbers('#7 — no leading dash'), []);
+  assert.deepEqual(parseExportedIssueNumbers('#7 no leading dash'), []);
 });
 
 test('parseExportedIssueNumbers: does not de-duplicate (captures current behaviour)', () => {
-  assert.deepEqual(parseExportedIssueNumbers('- #5 — A\n- #5 — A again'), [5, 5]);
+  assert.deepEqual(parseExportedIssueNumbers('- #5 A\n- #5 A again'), [5, 5]);
 });
 
 // isExportBranch guards the destructive branch delete: only branches the


### PR DESCRIPTION
## What

Fix two silent-notification bugs in the LFX export/approval automation and lock every "copy we emit then parse back" contract with round-trip tests, so this class of drift can't recur unnoticed.

## Changes

**Restore the export merge notification**
The merge-notify workflow parses the export PR body to find which proposals to notify, but the parser still required an em-dash delimiter the renderer had stopped emitting. It matched nothing and notified no one. Align the parser with the current format and add a renderer/parser round-trip test.

**Keep recording URLs when a sibling issue is unreadable**
`populateRecordedUrls` reads every term program's comments to preserve recorded URLs. A single deleted or inaccessible issue (404) aborted the whole `/lfx-url` run. Skip a not-found sibling; re-throw anything else so real failures still surface.

**Point the export-files notice at main**
The export-inclusion comment linked its files to the export branch, which is deleted on merge, leaving a dead link. Point it at `main`, and extract the comment into a tested lib function.

**Lock the approval-record copy contract**
The `/approve` and `/cncf-approve` handlers emitted their approval-record comments as inline strings that a separate workflow parses back to tally approvers. Nothing tied the two. Move the copy into lib functions and add round-trip tests, so a wording change can't silently break approval tallying.

## Verification

- 589 unit tests green, including new round-trip contract tests for the export-body, export-files-link, and approval-record copy.
- Every workflow script block compiles; emitted strings are byte-identical to the prior inline copy.
