### PR TITLE
fix(lfx): reject placeholder LFIDs in mentor validation

### DIFF
--- a/programs/lfx-mentorship/automation/lib/validate.js
+++ b/programs/lfx-mentorship/automation/lib/validate.js
@@ -14,8 +14,11 @@ const { normalizeMentorEmail, parseIssueForm } = require('./parse.js');
 const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const urlRe = /^https?:\/\/\S+$/;
 const ghHandleRe = /^@[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
-// LF Username (LFID): a single token, no spaces, '@', or URL slashes.
-const lfidRe = /^[^\s@/]+$/;
+// LF Username (LFID): letters, digits, and . _ - only, starting with a letter
+// or digit — LFX/openprofile handles contain nothing else. The previous
+// whitelist (anything but space, '@', or a slash) admitted placeholder tokens
+// like "jkowall(?)", which then shipped to LFX in the term export.
+const lfidRe = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
 
 // Validate the Mentors field (pipe-separated, one mentor per line).
 // Returns { ok, count, errors }, where each error is { role, code, ... }.

--- a/programs/lfx-mentorship/automation/test/validate.test.js
+++ b/programs/lfx-mentorship/automation/test/validate.test.js
@@ -142,6 +142,13 @@ test('validateUpstreamUrl: whitespace fails the URL regex first (format, not mul
 test('lfidRe: accepts plain usernames and dot/dash/underscore', () => {
   assert.equal(lfidRe.test('janedoe'), true);
   assert.equal(lfidRe.test('jane.doe-1_x'), true);
+  assert.equal(lfidRe.test('05cc0d01-c938-4a18-951e-af71be282b2b'), true);
+});
+
+test('lfidRe: rejects placeholder punctuation like "jkowall(?)" (leaked into a 2026 T3 export)', () => {
+  assert.equal(lfidRe.test('jkowall(?)'), false);
+  assert.equal(lfidRe.test('jane?'), false);
+  assert.equal(lfidRe.test('(tbd)'), false);
 });
 
 test('lfidRe: rejects empty, spaces, emails, and URLs', () => {
@@ -149,6 +156,13 @@ test('lfidRe: rejects empty, spaces, emails, and URLs', () => {
   assert.equal(lfidRe.test('jane doe'), false);
   assert.equal(lfidRe.test('jane@example.com'), false);
   assert.equal(lfidRe.test('https://openprofile.dev/profile/janedoe'), false);
+});
+
+test('validateMentors: a placeholder LFID like "jkowall(?)" flags "lfid-format"', () => {
+  assert.deepEqual(
+    codes(validateMentors('Jonah Kowall | @jkowall | jkowall@kowall.net | jkowall(?)')),
+    ['lfid-format'],
+  );
 });
 
 test('emailRe / ghHandleRe / urlRe: basic accept and reject', () => {


### PR DESCRIPTION
## What
The LFID regex in lib/validate.js (lfidRe = /^[^\s@/]+$/) accepts any token without spaces, '@', or a slash. Placeholder strings such as `jkowall(?)` therefore pass proposal validation and are exported verbatim to LFX — this term's own 2026 T3 export contains exactly that value in the Jaeger program record (issue #2027), and the same permissive check governs every proposal in the term, including #2029.

Fix: constrain lfidRe to the character set LFX/openprofile handles actually use — letters, digits, '.', '_', '-' — starting with a letter or digit. Every legitimate LFID in the 59-program 2026 T3 export conforms (including dotted handles like `mia.grenell` and UUID-style handles), so the tightened regex rejects only genuine garbage. The pattern occurs in exactly one place (validate.js:18, used solely by validateMentors); no other instance exists in lib/, tests, or the workflows.

Tests: added rejection cases for placeholder punctuation (`jkowall(?)`, `jane?`, `(tbd)`), an acceptance case for UUID-shaped handles, and a validateMentors-level regression test asserting the placeholder now flags `lfid-format`. Existing expectations ('janedoe', 'jane.doe-1_x', empty/space/email/URL rejections) are unchanged and still pass.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #2029