### PR TITLE
Set up LFX 2027 Term 1 (Mar-May)

### DIFF
--- a/programs/lfx-mentorship/2027/01-Mar-May/README.md
+++ b/programs/lfx-mentorship/2027/01-Mar-May/README.md
@@ -11,7 +11,7 @@ Mentorship duration - three months (full-time schedule)
 | Project Proposals Open | Wed, Jan 6 – Wed, Jan 27, 18:00 UTC |
 | Mentor/Maintainer Info Sessions | Tue, Jan 12, Times TBD (will be multiple timezone options) |
 | Mentee Candidate Info Sessions | Thu, Jan 28, Times TBD (will be multiple timezone options) |
-| Mentee Applications Open | Wed, Feb 3 – Tue, Feb 16, 23:59 UTC |
+| Mentee Applications Open | Wed, Feb 3, 00:00 UTC - Tue, Feb 16, 23:59 UTC |
 | Application Review Period | Wed, Feb 17 – Tue, Mar 2, 18:00 UTC |
 | Selection Notifications | Wed, Mar 3 – Fri, Mar 5 *(notifications may take a few days to reach all mentees)* |
 | Mentorship Program Begins | Mon, Mar 8 |

--- a/programs/lfx-mentorship/2027/01-Mar-May/README.md
+++ b/programs/lfx-mentorship/2027/01-Mar-May/README.md
@@ -1,0 +1,33 @@
+# Term 01 - 2027 March - May
+
+Status: Planning
+
+Mentorship duration - three months (full-time schedule)
+
+### Timeline
+
+| Activity | Dates (2027) |
+|----------|--------------|
+| Project Proposals Open | Wed, Jan 6 – Wed, Jan 27, 18:00 UTC |
+| Mentor/Maintainer Info Sessions | Tue, Jan 12, Times TBD (will be multiple timezone options) |
+| Mentee Candidate Info Sessions | Thu, Jan 28, Times TBD (will be multiple timezone options) |
+| Mentee Applications Open | Wed, Feb 3 – Tue, Feb 16, 23:59 UTC |
+| Application Review Period | Wed, Feb 17 – Tue, Mar 2, 18:00 UTC |
+| Selection Notifications | Wed, Mar 3 – Fri, Mar 5 *(notifications may take a few days to reach all mentees)* |
+| Mentorship Program Begins | Mon, Mar 8 |
+| Mentorship Kick Off Call | Tue, Mar 9, Times TBD (will be multiple timezone options) |
+| Midterm Mentee Evaluations | Tue, Apr 20, 18:00 UTC |
+| First Stipend Payments | Wed, Apr 21 |
+| Final Mentee Evaluations | Tue, May 25, 18:00 UTC |
+| Second Stipend Payments | Wed, May 26 |
+| Last Day of Term | Fri, May 28 |
+
+### Project instructions
+
+Project maintainers and potential mentors propose programs by opening an issue with the [LFX Mentorship Program Proposal form](https://github.com/cncf/mentoring/issues/new?template=lfx-program-proposal.yml), by January 27, 2027. Submit one issue per program, and please limit proposals to 4-5 per CNCF project. See [How to propose a program](https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md#how-to-propose-a-program) for the full process and what happens after you submit.
+
+### Application instructions
+
+Mentee application instructions can be found on the [Program Guidelines](https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md#program-guidelines) page.
+
+---

--- a/programs/lfx-mentorship/2027/01-Mar-May/README.md
+++ b/programs/lfx-mentorship/2027/01-Mar-May/README.md
@@ -8,12 +8,12 @@ Mentorship duration - three months (full-time schedule)
 
 | Activity | Dates (2027) |
 |----------|--------------|
-| Project Proposals Open | Wed, Jan 6 – Wed, Jan 27, 18:00 UTC |
+| Project Proposals Open | Wed, Jan 6 - Wed, Jan 27, 18:00 UTC |
 | Mentor/Maintainer Info Sessions | Tue, Jan 12, Times TBD (will be multiple timezone options) |
 | Mentee Candidate Info Sessions | Thu, Jan 28, Times TBD (will be multiple timezone options) |
 | Mentee Applications Open | Wed, Feb 3, 00:00 UTC - Tue, Feb 16, 23:59 UTC |
-| Application Review Period | Wed, Feb 17 – Tue, Mar 2, 18:00 UTC |
-| Selection Notifications | Wed, Mar 3 – Fri, Mar 5 *(notifications may take a few days to reach all mentees)* |
+| Application Review Period | Wed, Feb 17 - Tue, Mar 2, 18:00 UTC |
+| Selection Notifications | Wed, Mar 3 - Fri, Mar 5 *(notifications may take a few days to reach all mentees)* |
 | Mentorship Program Begins | Mon, Mar 8 |
 | Mentorship Kick Off Call | Tue, Mar 9, Times TBD (will be multiple timezone options) |
 | Midterm Mentee Evaluations | Tue, Apr 20, 18:00 UTC |

--- a/programs/lfx-mentorship/2027/01-Mar-May/project_ideas.md
+++ b/programs/lfx-mentorship/2027/01-Mar-May/project_ideas.md
@@ -1,0 +1,8 @@
+# Project proposals have moved
+
+LFX Mentorship program proposals for this term are no longer submitted as a
+pull request to this file.
+
+Open an issue with the [LFX Mentorship Program Proposal form](https://github.com/cncf/mentoring/issues/new?template=lfx-program-proposal.yml)
+instead. See [How to propose a program](https://github.com/cncf/mentoring/blob/main/programs/lfx-mentorship/README.md#how-to-propose-a-program)
+for the full process.

--- a/programs/lfx-mentorship/automation/lib/config.js
+++ b/programs/lfx-mentorship/automation/lib/config.js
@@ -11,7 +11,7 @@
 // Shape:
 //   {
 //     term:     { year: 2026, number: 3 },
-//     schedule: [ { key, label, start, end?, time?, note? }, ... ],
+//     schedule: [ { key, label, start, start_time?, end?, time?, end_time?, note? }, ... ],
 //     // optional, used by later phases:
 //     repo?: 'cncf/mentoring', project?: 91
 //   }
@@ -72,6 +72,15 @@ function validateConfig(raw) {
     }
     if (e.end != null && e.end < e.start) {
       throw new Error(`schedule "${e.key}" has end date ${e.end} before start date ${e.start}`);
+    }
+    if (e.start_time != null && e.end == null) {
+      throw new Error(`schedule "${e.key}" has a "start_time" but no "end" date (use "time" for a single date)`);
+    }
+    if (e.end_time != null && e.end == null) {
+      throw new Error(`schedule "${e.key}" has an "end_time" but no "end" date (use "time" for a single date)`);
+    }
+    if (e.end_time != null && e.time != null) {
+      throw new Error(`schedule "${e.key}" has both "time" and "end_time" (they render in the same place; pick one)`);
     }
     if (seen.has(e.key)) throw new Error(`schedule has a duplicate key: ${e.key}`);
     seen.add(e.key);

--- a/programs/lfx-mentorship/automation/lib/scaffold.js
+++ b/programs/lfx-mentorship/automation/lib/scaffold.js
@@ -16,8 +16,6 @@
 
 const { parseISO } = require('./dates');
 
-const EN_DASH = '\u2013';
-
 const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 const MONTHS_LONG = ['January', 'February', 'March', 'April', 'May', 'June',
@@ -36,13 +34,19 @@ function fmtLong(iso) {
 }
 
 // Compose a Timeline "Dates" cell from a schedule entry:
-//   { start, end?, time?, note? }
-// -> "Wed, Jul 1 – Tue, Jul 28, 18:00 UTC" (+ " <note>" appended verbatim so the
-// runner controls any italics/parenthetical wording).
-function dateCell({ start, end, time, note }) {
+//   { start, start_time?, end?, time?, end_time?, note? }
+// -> "Wed, Jul 1 - Tue, Jul 28, 18:00 UTC" (+ " <note>" appended verbatim so the
+// runner controls any italics/parenthetical wording). A window that opens and
+// closes at stated times pairs start_time with end_time, comma-appended to
+// their dates ("Wed, Feb 3, 00:00 UTC - Tue, Feb 16, 23:59 UTC"); time is the
+// same trailing suffix for entries without that symmetry ("18:00 UTC",
+// "Times TBD (...)").
+function dateCell({ start, start_time, end, time, end_time, note }) {
   let cell = fmtShort(start);
-  if (end) cell += ` ${EN_DASH} ${fmtShort(end)}`;
-  if (time) cell += `, ${time}`;
+  if (start_time) cell += `, ${start_time}`;
+  if (end) cell += ` - ${fmtShort(end)}`;
+  const suffix = end_time || time;
+  if (suffix) cell += `, ${suffix}`;
   if (note) cell += ` ${note}`;
   return cell;
 }

--- a/programs/lfx-mentorship/automation/term-setup.example.yml
+++ b/programs/lfx-mentorship/automation/term-setup.example.yml
@@ -16,6 +16,10 @@
 #            omitted from the timeline until you add a date and re-run.
 #   end      optional, YYYY-MM-DD for a date range (needs a start).
 #   time     optional, comma-appended suffix, e.g. "18:00 UTC" or "Times TBD (...)".
+#   start_time optional, comma-appended to the range start, e.g. "00:00 UTC"
+#            when a window opens and closes at stated times (needs an end).
+#   end_time optional, comma-appended to the range end, e.g. "23:59 UTC"; pairs
+#            with start_time (needs an end, and replaces time on that entry).
 #   note     optional, space-appended suffix, e.g. an italic "*(...)*" aside.
 #   timeline optional, set false to keep a board-only anchor out of the README.
 

--- a/programs/lfx-mentorship/automation/terms.yml
+++ b/programs/lfx-mentorship/automation/terms.yml
@@ -8,4 +8,4 @@
 #   .github/workflows/lfx-export.yml                  (workflow_dispatch input)
 
 terms:
-  - "2026 Term 3 (Sep-Nov)"
+  - "2027 Term 1 (Mar-May)"

--- a/programs/lfx-mentorship/automation/terms/2027-t1.yml
+++ b/programs/lfx-mentorship/automation/terms/2027-t1.yml
@@ -1,0 +1,60 @@
+# LFX Mentorship 2027 Term 1 (Mar-May) schedule.
+# Source: https://github.com/cncf/mentoring/issues/2060
+
+term:
+  year: 2027
+  number: 1
+
+schedule:
+  - key: proposals_open
+    label: Project Proposals Open
+    start: 2027-01-06
+    end: 2027-01-27
+    time: 18:00 UTC
+  - key: mentor_info_sessions
+    label: Mentor/Maintainer Info Sessions
+    start: 2027-01-12
+    time: Times TBD (will be multiple timezone options)
+  - key: candidate_info_sessions
+    label: Mentee Candidate Info Sessions
+    start: 2027-01-28
+    time: Times TBD (will be multiple timezone options)
+  - key: applications_open
+    label: Mentee Applications Open
+    start: 2027-02-03
+    end: 2027-02-16
+    time: 23:59 UTC
+  - key: application_review
+    label: Application Review Period
+    start: 2027-02-17
+    end: 2027-03-02
+    time: 18:00 UTC
+  - key: selection_notify
+    label: Selection Notifications
+    start: 2027-03-03
+    end: 2027-03-05
+    note: "*(notifications may take a few days to reach all mentees)*"
+  - key: term_start
+    label: Mentorship Program Begins
+    start: 2027-03-08
+  - key: kickoff_call
+    label: Mentorship Kick Off Call
+    start: 2027-03-09
+    time: Times TBD (will be multiple timezone options)
+  - key: midterm_evals
+    label: Midterm Mentee Evaluations
+    start: 2027-04-20
+    time: 18:00 UTC
+  - key: first_stipends
+    label: First Stipend Payments
+    start: 2027-04-21
+  - key: final_evals
+    label: Final Mentee Evaluations
+    start: 2027-05-25
+    time: 18:00 UTC
+  - key: second_stipends
+    label: Second Stipend Payments
+    start: 2027-05-26
+  - key: term_end
+    label: Last Day of Term
+    start: 2027-05-28

--- a/programs/lfx-mentorship/automation/terms/2027-t1.yml
+++ b/programs/lfx-mentorship/automation/terms/2027-t1.yml
@@ -22,8 +22,9 @@ schedule:
   - key: applications_open
     label: Mentee Applications Open
     start: 2027-02-03
+    start_time: 00:00 UTC
     end: 2027-02-16
-    time: 23:59 UTC
+    end_time: 23:59 UTC
   - key: application_review
     label: Application Review Period
     start: 2027-02-17

--- a/programs/lfx-mentorship/automation/test/config.test.js
+++ b/programs/lfx-mentorship/automation/test/config.test.js
@@ -78,6 +78,32 @@ test('validateConfig: rejects an end date with no start', () => {
   assert.throws(() => validateConfig(raw), /end/i);
 });
 
+test('validateConfig: rejects a start_time with no end date (use time instead)', () => {
+  const raw = validRaw();
+  raw.schedule[1].start_time = '00:00 UTC'; // term_start is a single date
+  assert.throws(() => validateConfig(raw), /start_time/i);
+
+  const ok = validRaw();
+  ok.schedule[0].start_time = '00:00 UTC'; // proposals_open is a range
+  assert.doesNotThrow(() => validateConfig(ok));
+});
+
+test('validateConfig: rejects an end_time with no end date, or combined with time', () => {
+  const raw = validRaw();
+  raw.schedule[1].end_time = '23:59 UTC'; // term_start is a single date
+  assert.throws(() => validateConfig(raw), /end_time/i);
+
+  const both = validRaw();
+  both.schedule[0].end_time = '23:59 UTC'; // proposals_open already has time
+  assert.throws(() => validateConfig(both), /end_time/i);
+
+  const ok = validRaw();
+  delete ok.schedule[0].time;
+  ok.schedule[0].start_time = '00:00 UTC';
+  ok.schedule[0].end_time = '23:59 UTC';
+  assert.doesNotThrow(() => validateConfig(ok));
+});
+
 test('validateConfig: rejects a malformed date', () => {
   const raw = validRaw();
   raw.schedule[1].start = '2026-13-40';

--- a/programs/lfx-mentorship/automation/test/scaffold.test.js
+++ b/programs/lfx-mentorship/automation/test/scaffold.test.js
@@ -12,8 +12,6 @@ const {
 } = require('../lib/scaffold');
 const { termIdentity } = require('../lib/term');
 
-const EN_DASH = '\u2013';
-
 test('fmtShort: ISO date -> "Ddd, Mon D" (UTC, no leading zero)', () => {
   assert.equal(fmtShort('2026-07-01'), 'Wed, Jul 1');
   assert.equal(fmtShort('2026-09-07'), 'Mon, Sep 7');
@@ -29,15 +27,19 @@ test('dateCell: single date, range, time and note compose predictably', () => {
   assert.equal(dateCell({ start: '2026-09-07' }), 'Mon, Sep 7');
   assert.equal(
     dateCell({ start: '2026-07-01', end: '2026-07-28' }),
-    `Wed, Jul 1 ${EN_DASH} Tue, Jul 28`,
+    'Wed, Jul 1 - Tue, Jul 28',
   );
   assert.equal(
     dateCell({ start: '2026-07-01', end: '2026-07-28', time: '18:00 UTC' }),
-    `Wed, Jul 1 ${EN_DASH} Tue, Jul 28, 18:00 UTC`,
+    'Wed, Jul 1 - Tue, Jul 28, 18:00 UTC',
+  );
+  assert.equal(
+    dateCell({ start: '2027-02-03', start_time: '00:00 UTC', end: '2027-02-16', end_time: '23:59 UTC' }),
+    'Wed, Feb 3, 00:00 UTC - Tue, Feb 16, 23:59 UTC',
   );
   assert.equal(
     dateCell({ start: '2026-09-02', end: '2026-09-04', note: '*(notifications may take a few days)*' }),
-    `Wed, Sep 2 ${EN_DASH} Fri, Sep 4 *(notifications may take a few days)*`,
+    'Wed, Sep 2 - Fri, Sep 4 *(notifications may take a few days)*',
   );
 });
 
@@ -50,7 +52,7 @@ test('renderTimeline: builds the ### Timeline block with a year-stamped header',
   const out = renderTimeline(schedule, 2026);
   assert.match(out, /^### Timeline\n/);
   assert.match(out, /\| Activity \| Dates \(2026\) \|/);
-  assert.match(out, /\| Project Proposals Open \| Wed, Jul 1 \u2013 Tue, Jul 28, 18:00 UTC \|/);
+  assert.match(out, /\| Project Proposals Open \| Wed, Jul 1 - Tue, Jul 28, 18:00 UTC \|/);
   assert.match(out, /\| Mentorship Program Begins \| Mon, Sep 7 \|/);
   assert.match(out, /\| Last Day of Term \| Fri, Nov 27 \|/);
 });


### PR DESCRIPTION
Sets up the LFX Mentorship 2027 Term 1 (Mar-May) program folder with the schedule agreed in the scheduling issue.

Closes #2060

## Changes

- Add `programs/lfx-mentorship/2027/01-Mar-May/` (README with term timeline, project_ideas signpost), generated with `scaffold-term.js`
- Add `automation/terms/2027-t1.yml` term config
- Update `automation/terms.yml`: open **2027 Term 1 (Mar-May)** proposals, retire **2026 Term 3 (Sep-Nov)**
- Tool fixes found while dogfooding: timeline date ranges now use plain hyphens, and a new optional `start_time` field renders a window's opening time (e.g. `Wed, Feb 3, 00:00 UTC - Tue, Feb 16, 23:59 UTC`), so a regenerated README no longer drops it

## Post-merge

Run the **landscape-projects-sync** workflow to propagate the terms dropdown to the proposal issue form and lfx-export inputs (or wait for the Monday cron).
