### PR TITLE
Add --resume to populate-term-board and tolerate board auto-add races

### DIFF
--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -141,6 +141,17 @@ your issue notifications to see what needs attention.
    `teardown` helper is a development-only safeguard and refuses to run against
    production), so a mistaken run has to be cleaned up by hand.
 
+   An interrupted run (crash, rate limit, network drop) is safe to continue
+   with `--resume`: issues the manifest recorded are skipped, the last recorded
+   one is re-verified (its nesting, board card, or dates may have been lost in
+   the crash), and the rest are created as usual. Two things to know about the
+   copied board: it can carry over **built-in workflows** from the source board
+   (e.g. "Auto-add sub-issues to project", which races the tool's own board
+   adds — the tool treats an already-added card as success), and the double-run
+   guard counts every issue carrying all four admin labels, so a hand-labelled
+   issue (like the term's scheduling issue) can trip it; `--force` is the
+   escape hatch once you've confirmed the count is explained.
+
 3. **Sync the dropdowns:** Run the **Sync CNCF Projects from Landscape**
    workflow manually (Actions → **Sync CNCF Projects from Landscape** → Run
    workflow), or wait for

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -144,10 +144,14 @@ your issue notifications to see what needs attention.
    `teardown` helper is a development-only safeguard and refuses to run against
    production), so a mistaken run has to be cleaned up by hand.
 
-   An interrupted run (crash, rate limit, network drop) is safe to continue
-   with `--resume`: issues the manifest recorded are skipped, the last recorded
-   one is re-verified (its nesting, board card, or dates may have been lost in
-   the crash), and the rest are created as usual. Two things to know about the
+   An interrupted run (crash, rate limit, network drop) can be continued
+   with `--resume`: issues the manifest recorded are skipped after being
+   verified against the current plan, the last recorded one is re-verified
+   (its nesting, board card, or dates may have been lost in the crash), and
+   the rest are created from the current files, as a fresh run would. If a
+   create succeeded but the crash prevented recording it, resume detects the
+   unrecorded issue and refuses with instructions to adopt or close it,
+   instead of creating a duplicate. Two things to know about the
    copied board: it can carry over **built-in workflows** from the source board
    (e.g. "Auto-add sub-issues to project", which races the tool's own board
    adds — the tool treats an already-added card as success), and the double-run

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -125,7 +125,10 @@ your issue notifications to see what needs attention.
       project view, so the tool can't (and doesn't) set them up. (First time only,
       with nothing to copy: create a board, add `Start Date` + `Due Date` **date**
       fields via `•••` → Customize fields → New field → Date, and add any views by
-      hand.) Copy the new board's URL.
+      hand.) Copy the new board's URL. Copying does not carry the source board's
+      repository links, so the new board won't appear on the repo's Projects tab
+      until you link it: `gh project link <number> --owner cncf --repo
+      cncf/mentoring`.
    2. Add `repo` (e.g. `cncf/mentoring`) and `project` (the board URL) to the
       term config, then populate:
 

--- a/programs/lfx-mentorship/automation/bin/populate-term-board.js
+++ b/programs/lfx-mentorship/automation/bin/populate-term-board.js
@@ -6,7 +6,11 @@
 // board the admin created from the template, and set Status + Start/Due dates.
 // Phase 3 of the term-setup tooling; see ADMIN_GUIDE.md.
 //
-//   node bin/populate-term-board.js <config.(yml|json)> [--repo-root DIR] [--dry-run] [--force]
+//   node bin/populate-term-board.js <config.(yml|json)> [--repo-root DIR] [--dry-run] [--force] [--resume]
+//
+// --resume continues an interrupted run from its manifest: recorded issues are
+// skipped, the last recorded one is re-verified (its nest/board/fields may have
+// been lost in the crash), and the rest are created as usual.
 //
 // The config must carry `repo` (owner/repo) and `project` (the board URL). This
 // is the impure glue: the plan, dates, board-field resolution and the client are
@@ -25,18 +29,19 @@ const { createGhClient } = require('../lib/gh-client');
 const { runManifestPath, openRunManifest } = require('../lib/run-manifest');
 
 const USAGE =
-  'Usage: node bin/populate-term-board.js <config.(yml|json)> [--repo-root DIR] [--dry-run] [--force]';
+  'Usage: node bin/populate-term-board.js <config.(yml|json)> [--repo-root DIR] [--dry-run] [--force] [--resume]';
 
 const FIELDS_QUERY =
   'query($id:ID!){node(id:$id){... on ProjectV2{fields(first:50){nodes{'
   + '... on ProjectV2FieldCommon{id name} ... on ProjectV2SingleSelectField{id name options{id name}}}}}}}';
 
 function parseArgs(argv) {
-  const opts = { config: null, repoRoot: null, dryRun: false, force: false };
+  const opts = { config: null, repoRoot: null, dryRun: false, force: false, resume: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--dry-run') opts.dryRun = true;
     else if (a === '--force') opts.force = true;
+    else if (a === '--resume') opts.resume = true;
     else if (a === '--repo-root') opts.repoRoot = argv[++i];
     else if (a === '-h' || a === '--help') opts.help = true;
     else if (a.startsWith('-')) throw new Error(`Unknown option: ${a}`);
@@ -95,9 +100,18 @@ function instrument(inner, manifest) {
   });
 }
 
-function dryRun(plan, schedule, repo) {
-  console.log(`[dry-run] would create ${plan.length} issues on ${repo} and add them to the board:\n`);
-  console.log(formatPlanPreview(plan, schedule).join('\n'));
+function dryRun(plan, schedule, repo, completed = []) {
+  if (completed.length > 0) {
+    const last = completed[completed.length - 1];
+    console.log(
+      `[dry-run] resuming: ${completed.length} of ${plan.length} issues already recorded; ` +
+      `would re-verify "${last.title}" (#${last.number}) and create the remaining ${plan.length - completed.length}:\n`,
+    );
+    console.log(formatPlanPreview(plan.slice(completed.length), schedule).join('\n'));
+  } else {
+    console.log(`[dry-run] would create ${plan.length} issues on ${repo} and add them to the board:\n`);
+    console.log(formatPlanPreview(plan, schedule).join('\n'));
+  }
   console.log('\n(no issues created; re-run without --dry-run to apply)');
 }
 
@@ -114,35 +128,58 @@ async function main(argv) {
   const issuesPath = path.join(repoRoot, 'programs/lfx-mentorship/automation/term-issues.yml');
   const plan = buildIssuePlan(parseIssues(fs.readFileSync(issuesPath, 'utf8')), identity);
 
+  const automationDir = path.join(repoRoot, 'programs/lfx-mentorship/automation');
+  const manifest = cfg.repo
+    ? openRunManifest({ path: runManifestPath(automationDir, identity, cfg.repo) })
+    : null;
+  const completed = opts.resume && manifest && manifest.exists() ? manifest.read() : [];
+  if (opts.resume && completed.length === 0) {
+    throw new Error(
+      '--resume needs an existing run manifest (and "repo" in the config); nothing to resume' +
+      (manifest ? ` at ${manifest.path}` : ''),
+    );
+  }
+
   if (opts.dryRun) {
-    dryRun(plan, cfg.schedule, cfg.repo || '<config.repo>');
+    dryRun(plan, cfg.schedule, cfg.repo || '<config.repo>', completed);
     return 0;
   }
 
   if (!cfg.repo) throw new Error('config is missing "repo" (e.g. nate-double-u/mentoring)');
   if (!cfg.project) throw new Error('config is missing "project" (the board URL the admin created)');
 
-  const automationDir = path.join(repoRoot, 'programs/lfx-mentorship/automation');
-  const manifest = openRunManifest({ path: runManifestPath(automationDir, identity, cfg.repo) });
-  if (manifest.exists()) {
-    throw new Error(
-      `A run manifest already exists at ${manifest.path}. Tear down that run first ` +
-      '(bin/teardown-term.js), or remove the manifest, before starting a new one.',
-    );
+  if (!opts.resume) {
+    if (manifest.exists()) {
+      throw new Error(
+        `A run manifest already exists at ${manifest.path}. Resume the interrupted run ` +
+        '(--resume), tear it down (bin/teardown-term.js), or remove the manifest, ' +
+        'before starting a new one.',
+      );
+    }
+    const labels = ['lfx mentorship', identity.label, identity.yearLabel, 'administration'];
+    const existingCount = await countExisting(cfg.repo, labels, ghExec);
+    assertSafeToCreate({ existingCount, force: opts.force });
   }
-
-  const labels = ['lfx mentorship', identity.label, identity.yearLabel, 'administration'];
-  const existingCount = await countExisting(cfg.repo, labels, ghExec);
-  assertSafeToCreate({ existingCount, force: opts.force });
 
   console.log(`Resolving board ${cfg.project} …`);
   const { projectId, fields } = await resolveBoard(cfg.project, ghExec);
 
-  console.log(`Creating ${plan.length} issues on ${cfg.repo} and populating the board:`);
+  if (completed.length > 0) {
+    const last = completed[completed.length - 1];
+    console.log(
+      `Resuming on ${cfg.repo}: ${completed.length - 1} issues already done, ` +
+      `re-verifying #${last.number}, creating the remaining ${plan.length - completed.length}:`,
+    );
+  } else {
+    console.log(`Creating ${plan.length} issues on ${cfg.repo} and populating the board:`);
+  }
   const client = instrument(createGhClient({ repo: cfg.repo, projectId, fields, exec: ghExec }), manifest);
-  const { created } = await populateTerm(plan, { schedule: cfg.schedule }, client);
+  const { created, repaired } = await populateTerm(plan, { schedule: cfg.schedule, completed }, client);
 
-  console.log(`\nDone: ${created} issues created, linked, and added to the board for ${identity.title}.`);
+  console.log(
+    `\nDone: ${created} issues created${repaired ? ` (+${repaired} re-verified)` : ''}, ` +
+    `linked, and added to the board for ${identity.title}.`,
+  );
   console.log(`Recorded in ${manifest.path}.`);
   console.log('Tip: run bin/teardown-term.js with the same config to remove exactly this run (dev cleanup).');
   return 0;

--- a/programs/lfx-mentorship/automation/bin/populate-term-board.js
+++ b/programs/lfx-mentorship/automation/bin/populate-term-board.js
@@ -86,20 +86,6 @@ async function countExisting(repo, labels, exec) {
   return JSON.parse(await exec(args)).length;
 }
 
-// Record each issue in the run manifest the instant it is created (before the
-// board add), and log progress. Recording at creation time means teardown can
-// always find an issue even if a later step crashes.
-function instrument(inner, manifest) {
-  return Object.assign({}, inner, {
-    async createIssue(a) {
-      const r = await inner.createIssue(a);
-      manifest.append({ number: r.number, title: a.title, nodeId: r.nodeId });
-      process.stdout.write(`  #${r.number}  ${a.title}\n`);
-      return r;
-    },
-  });
-}
-
 function dryRun(plan, schedule, repo, completed = []) {
   if (completed.length > 0) {
     const last = completed[completed.length - 1];
@@ -173,8 +159,19 @@ async function main(argv) {
   } else {
     console.log(`Creating ${plan.length} issues on ${cfg.repo} and populating the board:`);
   }
-  const client = instrument(createGhClient({ repo: cfg.repo, projectId, fields, exec: ghExec }), manifest);
-  const { created, repaired } = await populateTerm(plan, { schedule: cfg.schedule, completed }, client);
+  const client = createGhClient({ repo: cfg.repo, projectId, fields, exec: ghExec });
+  // Record each issue in the run manifest the instant it is created (before
+  // the board add), and log progress. Recording at creation time means resume
+  // and teardown can always find an issue even if a later step crashes.
+  const onCreated = (rec) => {
+    manifest.append(rec);
+    process.stdout.write(`  #${rec.number}  ${rec.title}\n`);
+  };
+  const { created, repaired } = await populateTerm(
+    plan,
+    { schedule: cfg.schedule, completed, onCreated },
+    client,
+  );
 
   console.log(
     `\nDone: ${created} issues created${repaired ? ` (+${repaired} re-verified)` : ''}, ` +

--- a/programs/lfx-mentorship/automation/lib/gh-client.js
+++ b/programs/lfx-mentorship/automation/lib/gh-client.js
@@ -54,6 +54,20 @@ function createGhClient({ repo, projectId, fields, exec }) {
       }
     },
 
+    async listIssues({ labels }) {
+      // REST label filtering is AND-semantics, so an item's full label set
+      // pins the search to this term. Issues only; the endpoint mixes in PRs.
+      const raw = JSON.parse(await exec([
+        'api', '--method', 'GET', `repos/${repo}/issues`,
+        '-f', `labels=${(labels || []).join(',')}`,
+        '-f', 'state=all',
+        '-f', 'per_page=100',
+      ]));
+      return raw
+        .filter((x) => !x.pull_request)
+        .map((x) => ({ number: x.number, title: x.title, nodeId: x.node_id }));
+    },
+
     async getIssue({ number }) {
       const issue = JSON.parse(await exec(['api', `repos/${repo}/issues/${number}`]));
       return { number: issue.number, id: issue.id, nodeId: issue.node_id };

--- a/programs/lfx-mentorship/automation/lib/gh-client.js
+++ b/programs/lfx-mentorship/automation/lib/gh-client.js
@@ -8,6 +8,8 @@
 
 const ADD_ITEM =
   'mutation($projectId:ID!,$contentId:ID!){addProjectV2ItemById(input:{projectId:$projectId,contentId:$contentId}){item{id}}}';
+const PROJECT_ITEMS =
+  'query($id:ID!){node(id:$id){... on Issue{projectItems(first:50){nodes{id project{id}}}}}}';
 const SET_SELECT =
   'mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!){updateProjectV2ItemFieldValue(input:{projectId:$projectId,itemId:$itemId,fieldId:$fieldId,value:{singleSelectOptionId:$optionId}}){projectV2Item{id}}}';
 const SET_DATE =
@@ -35,8 +37,31 @@ function createGhClient({ repo, projectId, fields, exec }) {
     },
 
     async addToBoard({ contentId }) {
-      const out = await gql(ADD_ITEM, { projectId, contentId });
-      return { itemId: JSON.parse(out).data.addProjectV2ItemById.item.id };
+      try {
+        const out = await gql(ADD_ITEM, { projectId, contentId });
+        return { itemId: JSON.parse(out).data.addProjectV2ItemById.item.id };
+      } catch (err) {
+        // A board automation (e.g. "Auto-add sub-issues to project", carried
+        // over when the admin copies last term's board) can add the issue
+        // between our create and this call. Recover the item it created so a
+        // lost race is not a failed run.
+        if (!/already exists/i.test(err.message)) throw err;
+        const out = await gql(PROJECT_ITEMS, { id: contentId });
+        const nodes = JSON.parse(out).data.node.projectItems.nodes || [];
+        const existing = nodes.find((n) => n.project && n.project.id === projectId);
+        if (!existing) throw err;
+        return { itemId: existing.id };
+      }
+    },
+
+    async getIssue({ number }) {
+      const issue = JSON.parse(await exec(['api', `repos/${repo}/issues/${number}`]));
+      return { number: issue.number, id: issue.id, nodeId: issue.node_id };
+    },
+
+    async getSubIssues({ parentNumber }) {
+      const subs = JSON.parse(await exec(['api', `repos/${repo}/issues/${parentNumber}/sub_issues`]));
+      return subs.map((s) => s.id);
     },
 
     async setFields({ itemId, status, start, due }) {

--- a/programs/lfx-mentorship/automation/lib/gh-client.js
+++ b/programs/lfx-mentorship/automation/lib/gh-client.js
@@ -56,11 +56,13 @@ function createGhClient({ repo, projectId, fields, exec }) {
 
     async listIssues({ labels }) {
       // REST label filtering is AND-semantics, so an item's full label set
-      // pins the search to this term. Issues only; the endpoint mixes in PRs.
+      // pins the search to this term. Open only: closing a stray is a
+      // documented recovery path, so it must drop out of the search. Issues
+      // only; the endpoint mixes in PRs.
       const raw = JSON.parse(await exec([
         'api', '--method', 'GET', `repos/${repo}/issues`,
         '-f', `labels=${(labels || []).join(',')}`,
-        '-f', 'state=all',
+        '-f', 'state=open',
         '-f', 'per_page=100',
       ]));
       return raw

--- a/programs/lfx-mentorship/automation/lib/populate.js
+++ b/programs/lfx-mentorship/automation/lib/populate.js
@@ -45,12 +45,20 @@ function assertSafeToCreate({ existingCount, force } = {}) {
 // loop, so those plan items are skipped (their numbers still seed the parent
 // map). The last record was created, but the crash window means its nest,
 // board add, or fields may be missing, so it is re-verified idempotently.
-// Records are matched to plan items by position and checked by title, so a
-// changed plan (edited term-issues.yml) refuses to resume rather than
-// mispairing issues.
+//
+// Records are matched to plan items by position and verified field-by-field:
+// title, scheduleKey, parent number, and the dates the current schedule
+// resolves must all equal what the recorded run used, so an edited
+// term-issues.yml or schedule refuses to resume rather than silently mixing
+// old and new plans. Fields absent from a record (a legacy manifest) skip
+// their checks. ctx.onCreated, when given, receives each created issue's full
+// record ({ number, title, nodeId, parentNumber, scheduleKey, start, due })
+// the moment it exists, so the runner can persist it before any later step
+// can crash; skipped and repaired issues are already recorded.
 async function populateTerm(plan, ctx, client) {
   const schedule = (ctx && ctx.schedule) || [];
   const completed = (ctx && ctx.completed) || [];
+  const onCreated = (ctx && ctx.onCreated) || null;
 
   if (completed.length > plan.length) {
     throw new Error(
@@ -58,17 +66,35 @@ async function populateTerm(plan, ctx, client) {
       'the plan must be the one the recorded run used',
     );
   }
-  completed.forEach((rec, i) => {
-    if (rec.title !== plan[i].title) {
-      throw new Error(
-        `manifest record ${i} ("${rec.title}") does not match the plan ("${plan[i].title}"); ` +
-        'the plan must be unchanged to resume',
-      );
-    }
-  });
 
   const numberById = new Map(); // plan id -> issue number (created or recorded)
   completed.forEach((rec, i) => numberById.set(plan[i].id, rec.number));
+
+  const refuse = (i, what) => {
+    throw new Error(`manifest record ${i} ("${completed[i].title}") ${what}; the plan must be unchanged to resume`);
+  };
+  completed.forEach((rec, i) => {
+    const item = plan[i];
+    if (rec.title !== item.title) {
+      refuse(i, `does not match the plan ("${item.title}")`);
+    }
+    const planKey = item.scheduleKey || null;
+    if (rec.scheduleKey !== undefined && rec.scheduleKey !== planKey) {
+      refuse(i, `was created with scheduleKey ${JSON.stringify(rec.scheduleKey)} but the plan now has ${JSON.stringify(planKey)}`);
+    }
+    if (rec.parentNumber !== undefined) {
+      const expected = item.parentId != null ? numberById.get(item.parentId) : null;
+      if (rec.parentNumber !== expected) {
+        refuse(i, `recorded parent ${rec.parentNumber === null ? 'none' : `#${rec.parentNumber}`} but the plan now expects ${expected === null ? 'none' : `#${expected}`}`);
+      }
+    }
+    if (rec.start !== undefined || rec.due !== undefined) {
+      const { start, due } = resolveDates(item.scheduleKey, schedule);
+      if (rec.start !== start || rec.due !== due) {
+        refuse(i, `recorded dates ${rec.start}/${rec.due} but the schedule now resolves ${start}/${due}`);
+      }
+    }
+  });
 
   let created = 0;
   let repaired = 0;
@@ -79,6 +105,19 @@ async function populateTerm(plan, ctx, client) {
     const item = plan[i];
     const repairing = i === completed.length - 1;
 
+    // Resolve the parent first, so a malformed plan fails before an orphan
+    // issue is created, and the created record can carry its parent number.
+    let parentNumber = null;
+    if (item.parentId !== null && item.parentId !== undefined) {
+      parentNumber = numberById.get(item.parentId);
+      if (parentNumber === undefined) {
+        throw new Error(
+          `plan is not in pre-order: parent "${item.parentId}" of "${item.id}" has not been created yet`,
+        );
+      }
+    }
+    const { start, due } = resolveDates(item.scheduleKey, schedule);
+
     let issue;
     if (repairing) {
       issue = await client.getIssue({ number: completed[i].number });
@@ -87,22 +126,26 @@ async function populateTerm(plan, ctx, client) {
       issue = await client.createIssue({ title: item.title, labels: item.labels });
       numberById.set(item.id, issue.number);
       created += 1;
+      if (onCreated) {
+        await onCreated({
+          number: issue.number,
+          title: item.title,
+          nodeId: issue.nodeId,
+          parentNumber,
+          scheduleKey: item.scheduleKey || null,
+          start,
+          due,
+        });
+      }
     }
 
-    if (item.parentId !== null && item.parentId !== undefined) {
-      const parentNumber = numberById.get(item.parentId);
-      if (parentNumber === undefined) {
-        throw new Error(
-          `plan is not in pre-order: parent "${item.parentId}" of "${item.id}" has not been created yet`,
-        );
-      }
+    if (parentNumber !== null) {
       const alreadyNested =
         repairing && (await client.getSubIssues({ parentNumber })).includes(issue.id);
       if (!alreadyNested) await client.addSubIssue({ parentNumber, childId: issue.id });
     }
 
     const boardItem = await client.addToBoard({ contentId: issue.nodeId });
-    const { start, due } = resolveDates(item.scheduleKey, schedule);
     await client.setFields({ itemId: boardItem.itemId, status: 'Todo', start, due });
   }
 

--- a/programs/lfx-mentorship/automation/lib/populate.js
+++ b/programs/lfx-mentorship/automation/lib/populate.js
@@ -8,6 +8,8 @@
 //
 // client interface (all async):
 //   createIssue({ title, labels })            -> { number, id, nodeId }
+//   getIssue({ number })                      -> { number, id, nodeId }
+//   getSubIssues({ parentNumber })            -> [childDatabaseId, ...]
 //   addSubIssue({ parentNumber, childId })    -> void
 //   addToBoard({ contentId })                 -> { itemId }
 //   setFields({ itemId, status, start, due }) -> void
@@ -37,15 +39,55 @@ function assertSafeToCreate({ existingCount, force } = {}) {
 // Create every issue in the plan (pre-order, so a parent exists before its
 // children), link each child as a sub-issue of its parent, add each to the
 // board, and set Status + resolved dates. Returns a small summary.
+//
+// Resume: ctx.completed carries the run manifest's records (creation = plan
+// order) from an interrupted run. Every record but the last finished its full
+// loop, so those plan items are skipped (their numbers still seed the parent
+// map). The last record was created, but the crash window means its nest,
+// board add, or fields may be missing, so it is re-verified idempotently.
+// Records are matched to plan items by position and checked by title, so a
+// changed plan (edited term-issues.yml) refuses to resume rather than
+// mispairing issues.
 async function populateTerm(plan, ctx, client) {
   const schedule = (ctx && ctx.schedule) || [];
-  const numberById = new Map(); // plan id -> created issue number
-  let created = 0;
+  const completed = (ctx && ctx.completed) || [];
 
-  for (const item of plan) {
-    const issue = await client.createIssue({ title: item.title, labels: item.labels });
-    numberById.set(item.id, issue.number);
-    created += 1;
+  if (completed.length > plan.length) {
+    throw new Error(
+      `manifest has ${completed.length} records but the plan has ${plan.length} issues; ` +
+      'the plan must be the one the recorded run used',
+    );
+  }
+  completed.forEach((rec, i) => {
+    if (rec.title !== plan[i].title) {
+      throw new Error(
+        `manifest record ${i} ("${rec.title}") does not match the plan ("${plan[i].title}"); ` +
+        'the plan must be unchanged to resume',
+      );
+    }
+  });
+
+  const numberById = new Map(); // plan id -> issue number (created or recorded)
+  completed.forEach((rec, i) => numberById.set(plan[i].id, rec.number));
+
+  let created = 0;
+  let repaired = 0;
+  const skipped = completed.length > 0 ? completed.length - 1 : 0;
+
+  for (let i = 0; i < plan.length; i++) {
+    if (i < completed.length - 1) continue; // finished on the recorded run
+    const item = plan[i];
+    const repairing = i === completed.length - 1;
+
+    let issue;
+    if (repairing) {
+      issue = await client.getIssue({ number: completed[i].number });
+      repaired += 1;
+    } else {
+      issue = await client.createIssue({ title: item.title, labels: item.labels });
+      numberById.set(item.id, issue.number);
+      created += 1;
+    }
 
     if (item.parentId !== null && item.parentId !== undefined) {
       const parentNumber = numberById.get(item.parentId);
@@ -54,7 +96,9 @@ async function populateTerm(plan, ctx, client) {
           `plan is not in pre-order: parent "${item.parentId}" of "${item.id}" has not been created yet`,
         );
       }
-      await client.addSubIssue({ parentNumber, childId: issue.id });
+      const alreadyNested =
+        repairing && (await client.getSubIssues({ parentNumber })).includes(issue.id);
+      if (!alreadyNested) await client.addSubIssue({ parentNumber, childId: issue.id });
     }
 
     const boardItem = await client.addToBoard({ contentId: issue.nodeId });
@@ -62,7 +106,7 @@ async function populateTerm(plan, ctx, client) {
     await client.setFields({ itemId: boardItem.itemId, status: 'Todo', start, due });
   }
 
-  return { created };
+  return { created, skipped, repaired };
 }
 
 // Render a human preview of the populate plan: one line per issue, children

--- a/programs/lfx-mentorship/automation/lib/populate.js
+++ b/programs/lfx-mentorship/automation/lib/populate.js
@@ -11,7 +11,7 @@
 //   getIssue({ number })                      -> { number, id, nodeId }
 //   getSubIssues({ parentNumber })            -> [childDatabaseId, ...]
 //   listIssues({ labels })                    -> [{ number, title, nodeId }, ...]
-//                                                (resume only; all states, every label required)
+//                                                (resume only; open issues, every label required)
 //   addSubIssue({ parentNumber, childId })    -> void
 //   addToBoard({ contentId })                 -> { itemId }
 //   setFields({ itemId, status, start, due }) -> void

--- a/programs/lfx-mentorship/automation/lib/populate.js
+++ b/programs/lfx-mentorship/automation/lib/populate.js
@@ -10,6 +10,8 @@
 //   createIssue({ title, labels })            -> { number, id, nodeId }
 //   getIssue({ number })                      -> { number, id, nodeId }
 //   getSubIssues({ parentNumber })            -> [childDatabaseId, ...]
+//   listIssues({ labels })                    -> [{ number, title, nodeId }, ...]
+//                                                (resume only; all states, every label required)
 //   addSubIssue({ parentNumber, childId })    -> void
 //   addToBoard({ contentId })                 -> { itemId }
 //   setFields({ itemId, status, start, due }) -> void
@@ -48,13 +50,22 @@ function assertSafeToCreate({ existingCount, force } = {}) {
 //
 // Records are matched to plan items by position and verified field-by-field:
 // title, scheduleKey, parent number, and the dates the current schedule
-// resolves must all equal what the recorded run used, so an edited
-// term-issues.yml or schedule refuses to resume rather than silently mixing
-// old and new plans. Fields absent from a record (a legacy manifest) skip
-// their checks. ctx.onCreated, when given, receives each created issue's full
-// record ({ number, title, nodeId, parentNumber, scheduleKey, start, due })
-// the moment it exists, so the runner can persist it before any later step
-// can crash; skipped and repaired issues are already recorded.
+// resolves must all equal what the recorded run used, so an edited record
+// prefix refuses to resume rather than silently mispairing existing issues.
+// Unrecorded plan items do not exist yet, so they are created from the
+// current plan exactly as a fresh run would; editing them between runs is
+// allowed. Fields absent from a record (a legacy manifest) skip their checks.
+//
+// A create can succeed remotely without being recorded (the response is lost
+// or the process dies before the manifest write). Resume closes that gap by
+// searching for an issue matching the next uncreated plan item; if one exists
+// outside the manifest, it refuses with instructions to adopt or close it
+// rather than creating a duplicate.
+//
+// ctx.onCreated, when given, receives each created issue's full record
+// ({ number, title, nodeId, parentNumber, scheduleKey, start, due }) the
+// moment it exists, so the runner can persist it before any later step can
+// crash; skipped and repaired issues are already recorded.
 async function populateTerm(plan, ctx, client) {
   const schedule = (ctx && ctx.schedule) || [];
   const completed = (ctx && ctx.completed) || [];
@@ -95,6 +106,24 @@ async function populateTerm(plan, ctx, client) {
       }
     }
   });
+
+  if (completed.length > 0 && completed.length < plan.length) {
+    const next = plan[completed.length];
+    const recorded = new Set(completed.map((rec) => rec.number));
+    const strays = (await client.listIssues({ labels: next.labels })).filter(
+      (x) => x.title === next.title && !recorded.has(x.number),
+    );
+    if (strays.length > 0) {
+      const s = strays[0];
+      const line = JSON.stringify({ number: s.number, title: s.title, nodeId: s.nodeId });
+      throw new Error(
+        `found issue #${s.number} ("${s.title}") matching the next uncreated plan item but ` +
+        'missing from the manifest; a create likely succeeded without being recorded. ' +
+        `To adopt it, append this line to the manifest and re-run with --resume: ${line} ` +
+        'Or close the issue and re-run with --resume to recreate it.',
+      );
+    }
+  }
 
   let created = 0;
   let repaired = 0;

--- a/programs/lfx-mentorship/automation/terms/2027-t1.yml
+++ b/programs/lfx-mentorship/automation/terms/2027-t1.yml
@@ -5,6 +5,10 @@ term:
   year: 2027
   number: 1
 
+# Board population (ADMIN_GUIDE.md "Populate the term admin board"):
+repo: cncf/mentoring
+project: https://github.com/orgs/cncf/projects/98
+
 schedule:
   - key: proposals_open
     label: Project Proposals Open

--- a/programs/lfx-mentorship/automation/test/gh-client.test.js
+++ b/programs/lfx-mentorship/automation/test/gh-client.test.js
@@ -129,7 +129,9 @@ test('setFields: throws when the board lacks the requested status option', async
   );
 });
 
-test('listIssues: queries all states with every label and maps issues, skipping PRs', async () => {
+test('listIssues: queries open issues with every label and maps them, skipping PRs', async () => {
+  // Open only: the gap-recovery instruction is "close the stray and re-run",
+  // so a closed issue must drop out of the search instead of refusing forever.
   const exec = fakeExec([JSON.stringify([
     { number: 42, title: 'Approve stipends', node_id: 'N42' },
     { number: 43, title: 'A pull request', node_id: 'N43', pull_request: { url: 'x' } },
@@ -138,7 +140,7 @@ test('listIssues: queries all states with every label and maps issues, skipping 
   assert.deepEqual(exec.calls[0], [
     'api', '--method', 'GET', 'repos/o/r/issues',
     '-f', 'labels=lfx mentorship,2026',
-    '-f', 'state=all',
+    '-f', 'state=open',
     '-f', 'per_page=100',
   ]);
   assert.deepEqual(found, [{ number: 42, title: 'Approve stipends', nodeId: 'N42' }]);

--- a/programs/lfx-mentorship/automation/test/gh-client.test.js
+++ b/programs/lfx-mentorship/automation/test/gh-client.test.js
@@ -5,10 +5,16 @@ const assert = require('node:assert/strict');
 const { createGhClient } = require('../lib/gh-client');
 
 // A fake exec records the arg arrays and returns canned stdout strings in order,
-// so we assert the exact `gh` calls without touching GitHub.
+// so we assert the exact `gh` calls without touching GitHub. An Error entry is
+// thrown instead of returned, for failure-recovery tests.
 function fakeExec(responses = []) {
   let i = 0;
-  const exec = async (args) => { exec.calls.push(args); return responses[i++] ?? '{}'; };
+  const exec = async (args) => {
+    exec.calls.push(args);
+    const r = responses[i++];
+    if (r instanceof Error) throw r;
+    return r ?? '{}';
+  };
   exec.calls = [];
   return exec;
 }
@@ -51,6 +57,48 @@ test('addToBoard: adds the content to the project and returns itemId', async () 
   assert.ok(args.some((a) => a.includes('addProjectV2ItemById')));
   assert.ok(args.includes('projectId=PVT_1'));
   assert.ok(args.includes('contentId=N42'));
+});
+
+test('addToBoard: recovers the existing itemId when the content is already on the board', async () => {
+  // A board automation (e.g. "Auto-add sub-issues to project" on a copied
+  // board) can add the issue first; the add then fails and the client must
+  // find the item the automation created.
+  const exec = fakeExec([
+    new Error('gh api graphql\nGraphQL: Content already exists in this project'),
+    '{"data":{"node":{"projectItems":{"nodes":[{"id":"ITEM_OTHER","project":{"id":"PVT_9"}},{"id":"ITEM_X","project":{"id":"PVT_1"}}]}}}}',
+  ]);
+  const r = await client(exec).addToBoard({ contentId: 'N42' });
+  assert.deepEqual(r, { itemId: 'ITEM_X' });
+  assert.ok(exec.calls[1].some((a) => a.includes('projectItems')));
+  assert.ok(exec.calls[1].includes('id=N42'));
+});
+
+test('addToBoard: rethrows when recovery cannot find the item on this board', async () => {
+  const exec = fakeExec([
+    new Error('Content already exists in this project'),
+    '{"data":{"node":{"projectItems":{"nodes":[{"id":"ITEM_OTHER","project":{"id":"PVT_9"}}]}}}}',
+  ]);
+  await assert.rejects(() => client(exec).addToBoard({ contentId: 'N42' }), /already exists/i);
+});
+
+test('addToBoard: rethrows unrelated errors without a recovery query', async () => {
+  const exec = fakeExec([new Error('boom')]);
+  await assert.rejects(() => client(exec).addToBoard({ contentId: 'N42' }), /boom/);
+  assert.equal(exec.calls.length, 1);
+});
+
+test('getIssue: fetches an issue by number and returns {number,id,nodeId}', async () => {
+  const exec = fakeExec(['{"number":7,"id":70,"node_id":"N7"}']);
+  const r = await client(exec).getIssue({ number: 7 });
+  assert.deepEqual(r, { number: 7, id: 70, nodeId: 'N7' });
+  assert.deepEqual(exec.calls[0], ['api', 'repos/o/r/issues/7']);
+});
+
+test("getSubIssues: lists the database ids of a parent's sub-issues", async () => {
+  const exec = fakeExec(['[{"id":10},{"id":20}]']);
+  const r = await client(exec).getSubIssues({ parentNumber: 7 });
+  assert.deepEqual(r, [10, 20]);
+  assert.deepEqual(exec.calls[0], ['api', 'repos/o/r/issues/7/sub_issues']);
 });
 
 test('setFields: sets status and both dates (three mutations)', async () => {

--- a/programs/lfx-mentorship/automation/test/gh-client.test.js
+++ b/programs/lfx-mentorship/automation/test/gh-client.test.js
@@ -128,3 +128,18 @@ test('setFields: throws when the board lacks the requested status option', async
     /Nope/,
   );
 });
+
+test('listIssues: queries all states with every label and maps issues, skipping PRs', async () => {
+  const exec = fakeExec([JSON.stringify([
+    { number: 42, title: 'Approve stipends', node_id: 'N42' },
+    { number: 43, title: 'A pull request', node_id: 'N43', pull_request: { url: 'x' } },
+  ])]);
+  const found = await client(exec).listIssues({ labels: ['lfx mentorship', '2026'] });
+  assert.deepEqual(exec.calls[0], [
+    'api', '--method', 'GET', 'repos/o/r/issues',
+    '-f', 'labels=lfx mentorship,2026',
+    '-f', 'state=all',
+    '-f', 'per_page=100',
+  ]);
+  assert.deepEqual(found, [{ number: 42, title: 'Approve stipends', nodeId: 'N42' }]);
+});

--- a/programs/lfx-mentorship/automation/test/populate.test.js
+++ b/programs/lfx-mentorship/automation/test/populate.test.js
@@ -138,6 +138,84 @@ test('populateTerm: fails fast when the plan is not in pre-order (parent not yet
   await assert.rejects(() => populateTerm(outOfOrder, { schedule: [] }, c), /pre-order/i);
 });
 
+// ── populateTerm resume (completed manifest records from an interrupted run) ─
+// The manifest records issues in creation (= plan) order. All records but the
+// last completed their full loop; the last one's nest/board/fields are unknown
+// (the crash window), so it is re-verified idempotently.
+function resumeClient({ subIssues = [] } = {}) {
+  const c = fakeClient();
+  c.getIssue = async ({ number }) => { c.calls.push(['getIssue', number]); return { number, id: number * 10, nodeId: `node-${number}` }; };
+  c.getSubIssues = async ({ parentNumber }) => { c.calls.push(['getSubIssues', parentNumber]); return subIssues; };
+  return c;
+}
+
+const COMPLETED = [
+  { number: 2000, title: '[LFX 2026 T3] 0. Key dates', nodeId: 'node-2000' },
+  { number: 2001, title: 'Project proposals open', nodeId: 'node-2001' },
+  { number: 2002, title: 'Mentorship Kick Off Call', nodeId: 'node-2002' },
+];
+
+test('populateTerm: resume skips completed records and creates only the rest', async () => {
+  const c = resumeClient({ subIssues: [20020] });
+  const r = await populateTerm(plan(), { schedule: SCHEDULE, completed: COMPLETED }, c);
+  const created = c.calls.filter((k) => k[0] === 'createIssue').map((k) => k[1]);
+  assert.deepEqual(created, [
+    '[LFX 2026 T3] 2. Proposals',
+    '[LFX 2026 T3] 2.1 [Announce] Applications open for candidates',
+    'Initial announcement',
+  ]);
+  assert.deepEqual(r, { created: 3, skipped: 2, repaired: 1 });
+});
+
+test('populateTerm: resume repairs the last record (board + fields, no re-nest when nested)', async () => {
+  const c = resumeClient({ subIssues: [20020] }); // 2002's id, already a sub-issue
+  await populateTerm(plan(), { schedule: SCHEDULE, completed: COMPLETED }, c);
+  assert.ok(c.calls.some((k) => k[0] === 'getIssue' && k[1] === 2002));
+  assert.ok(c.calls.some((k) => k[0] === 'getSubIssues' && k[1] === 2000));
+  assert.ok(!c.calls.some((k) => k[0] === 'addSubIssue' && k[2] === 20020));
+  assert.ok(c.calls.some((k) => k[0] === 'addToBoard' && k[1] === 'node-2002'));
+  const fields = c.calls.find((k) => k[0] === 'setFields' && k[1] === 'item-node-2002');
+  assert.deepEqual(fields.slice(2), ['Todo', null, null]); // kickoff is keyless
+});
+
+test('populateTerm: resume re-nests the last record when the parent lacks it', async () => {
+  const c = resumeClient({ subIssues: [] });
+  await populateTerm(plan(), { schedule: SCHEDULE, completed: COMPLETED }, c);
+  assert.ok(c.calls.some((k) => k[0] === 'addSubIssue' && k[1] === 2000 && k[2] === 20020));
+});
+
+test('populateTerm: resume repairs a top-level last record without a nest check, and later children nest under it', async () => {
+  const c = resumeClient();
+  await populateTerm(plan(), { schedule: SCHEDULE, completed: COMPLETED.slice(0, 1) }, c);
+  assert.ok(c.calls.some((k) => k[0] === 'getIssue' && k[1] === 2000));
+  assert.ok(!c.calls.some((k) => k[0] === 'getSubIssues'));
+  // "Project proposals open" is created fresh (number 1000) and nests under #2000
+  assert.ok(c.calls.some((k) => k[0] === 'addSubIssue' && k[1] === 2000 && k[2] === 10000));
+});
+
+test('populateTerm: resume rejects a manifest record that does not match the plan', async () => {
+  const bad = [{ number: 2000, title: 'Wrong title', nodeId: 'node-2000' }];
+  await assert.rejects(
+    () => populateTerm(plan(), { schedule: [], completed: bad }, resumeClient()),
+    /manifest/i,
+  );
+});
+
+test('populateTerm: resume rejects a manifest with more records than the plan', async () => {
+  const over = plan().map((p, i) => ({ number: 3000 + i, title: p.title, nodeId: `n${i}` }));
+  over.push({ number: 9999, title: 'Extra', nodeId: 'x' });
+  await assert.rejects(
+    () => populateTerm(plan(), { schedule: [], completed: over }, resumeClient()),
+    /manifest/i,
+  );
+});
+
+test('populateTerm: a fresh run reports zero skipped and repaired', async () => {
+  const c = fakeClient();
+  const r = await populateTerm(plan(), { schedule: SCHEDULE }, c);
+  assert.deepEqual(r, { created: 6, skipped: 0, repaired: 0 });
+});
+
 // ── assertSafeToCreate (pure guard against a double-run) ───────────────────
 test('assertSafeToCreate: throws when the term already has issues, unless forced', () => {
   assert.throws(() => assertSafeToCreate({ existingCount: 12, force: false }), /already|force/i);

--- a/programs/lfx-mentorship/automation/test/populate.test.js
+++ b/programs/lfx-mentorship/automation/test/populate.test.js
@@ -138,6 +138,45 @@ test('populateTerm: fails fast when the plan is not in pre-order (parent not yet
   await assert.rejects(() => populateTerm(outOfOrder, { schedule: [] }, c), /pre-order/i);
 });
 
+// ── populateTerm onCreated (rich manifest records) ─────────────────────────
+test('populateTerm: onCreated receives the full record for each created issue', async () => {
+  const c = fakeClient();
+  const records = [];
+  await populateTerm(plan(), { schedule: SCHEDULE, onCreated: (r) => records.push(r) }, c);
+  assert.equal(records.length, 6);
+  // top-level keyless section
+  assert.deepEqual(records[0], {
+    number: 1000, title: '[LFX 2026 T3] 0. Key dates', nodeId: 'node-1000',
+    parentNumber: null, scheduleKey: null, start: null, due: null,
+  });
+  // nested, scheduled child
+  assert.deepEqual(records[1], {
+    number: 1001, title: 'Project proposals open', nodeId: 'node-1001',
+    parentNumber: 1000, scheduleKey: 'proposals_open', start: '2026-07-01', due: '2026-07-28',
+  });
+});
+
+test('populateTerm: onCreated is not invoked for skipped or repaired records', async () => {
+  const c = resumeClient({ subIssues: [20020] });
+  const records = [];
+  await populateTerm(plan(), { schedule: SCHEDULE, completed: COMPLETED, onCreated: (r) => records.push(r) }, c);
+  assert.deepEqual(records.map((r) => r.title), [
+    '[LFX 2026 T3] 2. Proposals',
+    '[LFX 2026 T3] 2.1 [Announce] Applications open for candidates',
+    'Initial announcement',
+  ]);
+});
+
+test('populateTerm: does not create an issue whose parent is missing (pre-order checked first)', async () => {
+  const c = fakeClient();
+  const outOfOrder = [
+    { id: 'child', title: 'Child', labels: [], parentId: 'parent', scheduleKey: null, isParent: false },
+    { id: 'parent', title: 'Parent', labels: [], parentId: null, scheduleKey: null, isParent: true },
+  ];
+  await assert.rejects(() => populateTerm(outOfOrder, { schedule: [] }, c), /pre-order/i);
+  assert.equal(c.calls.filter((k) => k[0] === 'createIssue').length, 0);
+});
+
 // ── populateTerm resume (completed manifest records from an interrupted run) ─
 // The manifest records issues in creation (= plan) order. All records but the
 // last completed their full loop; the last one's nest/board/fields are unknown
@@ -208,6 +247,47 @@ test('populateTerm: resume rejects a manifest with more records than the plan', 
     () => populateTerm(plan(), { schedule: [], completed: over }, resumeClient()),
     /manifest/i,
   );
+});
+
+test('populateTerm: resume rejects a record whose scheduleKey no longer matches the plan', async () => {
+  const withKeys = [
+    { number: 2000, title: '[LFX 2026 T3] 0. Key dates', nodeId: 'node-2000', parentNumber: null, scheduleKey: null, start: null, due: null },
+    { number: 2001, title: 'Project proposals open', nodeId: 'node-2001', parentNumber: 2000, scheduleKey: 'other_key', start: '2026-07-01', due: '2026-07-28' },
+  ];
+  await assert.rejects(
+    () => populateTerm(plan(), { schedule: SCHEDULE, completed: withKeys }, resumeClient()),
+    /scheduleKey|schedule_key/i,
+  );
+});
+
+test('populateTerm: resume rejects a record whose parent number no longer matches the plan', async () => {
+  const reparented = [
+    { number: 2000, title: '[LFX 2026 T3] 0. Key dates', nodeId: 'node-2000', parentNumber: null, scheduleKey: null, start: null, due: null },
+    { number: 2001, title: 'Project proposals open', nodeId: 'node-2001', parentNumber: 9999, scheduleKey: 'proposals_open', start: '2026-07-01', due: '2026-07-28' },
+  ];
+  await assert.rejects(
+    () => populateTerm(plan(), { schedule: SCHEDULE, completed: reparented }, resumeClient()),
+    /parent/i,
+  );
+});
+
+test('populateTerm: resume rejects a record whose dates no longer resolve the same (schedule edited)', async () => {
+  const shifted = [
+    { number: 2000, title: '[LFX 2026 T3] 0. Key dates', nodeId: 'node-2000', parentNumber: null, scheduleKey: null, start: null, due: null },
+    { number: 2001, title: 'Project proposals open', nodeId: 'node-2001', parentNumber: 2000, scheduleKey: 'proposals_open', start: '2026-06-01', due: '2026-07-28' },
+  ];
+  await assert.rejects(
+    () => populateTerm(plan(), { schedule: SCHEDULE, completed: shifted }, resumeClient()),
+    /dates|start|due/i,
+  );
+});
+
+test('populateTerm: resume accepts legacy records without the verification fields', async () => {
+  // COMPLETED has only {number,title,nodeId} (the pre-verification manifest
+  // shape); missing fields skip their checks rather than failing.
+  const c = resumeClient({ subIssues: [20020] });
+  const r = await populateTerm(plan(), { schedule: SCHEDULE, completed: COMPLETED }, c);
+  assert.deepEqual(r, { created: 3, skipped: 2, repaired: 1 });
 });
 
 test('populateTerm: a fresh run reports zero skipped and repaired', async () => {

--- a/programs/lfx-mentorship/automation/test/populate.test.js
+++ b/programs/lfx-mentorship/automation/test/populate.test.js
@@ -181,10 +181,11 @@ test('populateTerm: does not create an issue whose parent is missing (pre-order 
 // The manifest records issues in creation (= plan) order. All records but the
 // last completed their full loop; the last one's nest/board/fields are unknown
 // (the crash window), so it is re-verified idempotently.
-function resumeClient({ subIssues = [] } = {}) {
+function resumeClient({ subIssues = [], issues = [] } = {}) {
   const c = fakeClient();
   c.getIssue = async ({ number }) => { c.calls.push(['getIssue', number]); return { number, id: number * 10, nodeId: `node-${number}` }; };
   c.getSubIssues = async ({ parentNumber }) => { c.calls.push(['getSubIssues', parentNumber]); return subIssues; };
+  c.listIssues = async ({ labels }) => { c.calls.push(['listIssues', labels]); return issues; };
   return c;
 }
 
@@ -288,6 +289,54 @@ test('populateTerm: resume accepts legacy records without the verification field
   const c = resumeClient({ subIssues: [20020] });
   const r = await populateTerm(plan(), { schedule: SCHEDULE, completed: COMPLETED }, c);
   assert.deepEqual(r, { created: 3, skipped: 2, repaired: 1 });
+});
+
+test('populateTerm: resume refuses when an unrecorded issue matches the next plan item', async () => {
+  // A create that succeeded without being recorded (crash in the create/record
+  // gap) must be surfaced, not silently duplicated.
+  const gapIssue = { number: 7777, title: '[LFX 2026 T3] 2. Proposals', nodeId: 'node-7777' };
+  const c = resumeClient({ issues: [gapIssue] });
+  await assert.rejects(
+    () => populateTerm(plan(), { schedule: SCHEDULE, completed: COMPLETED }, c),
+    (err) => {
+      assert.match(err.message, /#7777/);
+      assert.match(err.message, /missing from the manifest/);
+      assert.match(err.message, /\{"number":7777,"title":"\[LFX 2026 T3\] 2\. Proposals","nodeId":"node-7777"\}/);
+      return true;
+    },
+  );
+  assert.equal(c.calls.filter((k) => k[0] === 'createIssue').length, 0);
+});
+
+test('populateTerm: gap check queries with the next plan item labels', async () => {
+  const c = resumeClient({ subIssues: [20020] });
+  await populateTerm(plan(), { schedule: SCHEDULE, completed: COMPLETED }, c);
+  const listCalls = c.calls.filter((k) => k[0] === 'listIssues');
+  assert.deepEqual(listCalls, [['listIssues', plan()[COMPLETED.length].labels]]);
+});
+
+test('populateTerm: gap check ignores recorded issues and other titles', async () => {
+  const c = resumeClient({
+    subIssues: [20020],
+    issues: [
+      { number: 2002, title: '[LFX 2026 T3] 2. Proposals', nodeId: 'node-2002' }, // recorded number
+      { number: 8888, title: 'Some other issue', nodeId: 'node-8888' }, // different title
+    ],
+  });
+  const r = await populateTerm(plan(), { schedule: SCHEDULE, completed: COMPLETED }, c);
+  assert.deepEqual(r, { created: 3, skipped: 2, repaired: 1 });
+});
+
+test('populateTerm: gap check is skipped on fresh runs and complete manifests', async () => {
+  // fakeClient has no listIssues at all: a fresh run must not need it.
+  await populateTerm(plan(), { schedule: SCHEDULE }, fakeClient());
+  // A complete manifest (every plan item recorded) only repairs the last item;
+  // no gap is possible past the end of the plan.
+  const all = plan().map((p, i) => ({ number: 3000 + i, title: p.title, nodeId: `node-${3000 + i}` }));
+  const c = resumeClient({ subIssues: [(3000 + 5) * 10] });
+  delete c.listIssues;
+  const r = await populateTerm(plan(), { schedule: SCHEDULE, completed: all }, c);
+  assert.deepEqual(r, { created: 0, skipped: 5, repaired: 1 });
 });
 
 test('populateTerm: a fresh run reports zero skipped and repaired', async () => {


### PR DESCRIPTION
Dogfooding populate-term-board.js on the real 2027 Term 1 setup surfaced two failure modes; this hardens both.

## What happened

Populating [board 98](https://github.com/orgs/cncf/projects/98) failed at issue 35 of 62: the board (copied from the 2026 Term 3 board) carried over the enabled **"Auto-add sub-issues to project"** built-in workflow, which added the freshly nested issue to the board before the tool's own add, failing the run with `Content already exists in this project`.

## Changes

- **Tolerate board auto-add races:** when the board add reports the content already exists, recover the existing card's item id (via the issue's `projectItems`) and continue - a lost race is no longer a failed run
- **`--resume` flag:** continue an interrupted run from its manifest - recorded issues are skipped, the last recorded one is re-verified idempotently (nest, board card, fields - the crash window), and the rest are created as usual; refuses to resume if the plan no longer matches the manifest
- **ADMIN_GUIDE:** document the copied-board workflow carry-over and the double-run guard's sensitivity to hand-labelled issues (e.g. the term's scheduling issue carrying all four admin labels)
- **terms/2027-t1.yml:** record the `repo` and `project` board URL used for the populate run

Verified in production: `--resume` completed the interrupted 2027 Term 1 run (27 created, 1 re-verified, 62 total on the board). Tests: 603 pass.
