### PR TITLE
fix: stop syncing the lfx-export term dropdown; validate at run time

### DIFF
--- a/.github/workflows/landscape-projects-sync.yml
+++ b/.github/workflows/landscape-projects-sync.yml
@@ -95,21 +95,16 @@ jobs:
             let formText = fs.readFileSync(formPath, 'utf8');
             formText = rewriteOptionsBlock(formText, 'id: cncf_project', projects.map((p) => p.name));
 
-            // Sync term dropdowns from terms.yml (single source of truth) into
-            // the issue form (id: term) and the export workflow (workflow_dispatch input)
+            // Sync the term dropdown from terms.yml (single source of truth)
+            // into the issue form (id: term). The export workflow is NOT
+            // synced: it validates its free-text term input against terms.yml
+            // at run time, because this job's GITHUB_TOKEN may never push
+            // changes to workflow files.
             const termsPath = 'programs/lfx-mentorship/automation/terms.yml';
             const termList = yaml.load(fs.readFileSync(termsPath, 'utf8')).terms || [];
             formText = rewriteOptionsBlock(formText, 'id: term', termList);
             fs.writeFileSync(formPath, formText);
-
-            const exportPath = '.github/workflows/lfx-export.yml';
-            const exportText = rewriteOptionsBlock(
-              fs.readFileSync(exportPath, 'utf8'),
-              'term:',
-              termList,
-            );
-            fs.writeFileSync(exportPath, exportText);
-            core.info(`Term dropdowns synced: ${termList.join(', ')}`);
+            core.info(`Term dropdown synced: ${termList.join(', ')}`);
 
             core.info('Files updated successfully');
 
@@ -137,7 +132,6 @@ jobs:
           add-paths: |
             programs/lfx-mentorship/automation/projects.yml
             .github/ISSUE_TEMPLATE/lfx-program-proposal.yml
-            .github/workflows/lfx-export.yml
           commit-message: |
             chore: sync CNCF project list from landscape
 

--- a/.github/workflows/lfx-export.yml
+++ b/.github/workflows/lfx-export.yml
@@ -5,12 +5,11 @@ on:
     inputs:
       term:
         description: >
-          Term to export (must match the dropdown value in the issue form,
-          e.g. "2026 Term 3 (Sep-Nov)")
+          Term to export — must exactly match an entry in
+          programs/lfx-mentorship/automation/terms.yml,
+          e.g. "2027 Term 1 (Mar-May)"
         required: true
-        type: choice
-        options:
-          - "2026 Term 3 (Sep-Nov)"
+        type: string
 
 permissions:
   contents: write
@@ -46,7 +45,20 @@ jobs:
             const { lookupProject } = _lib('projects.js');
             const { lfxTitle } = _lib('title.js');
             const { owner, repo } = context.repo;
-            const term = context.payload.inputs.term;
+            const { unknownTermMessage } = _lib('terms-file.js');
+
+            // Free-text input: a choice dropdown would hardcode the term list
+            // in this workflow file, which the landscape sync's GITHUB_TOKEN
+            // may never edit — so validate against terms.yml at run time.
+            const term = (context.payload.inputs.term || '').trim();
+            const termError = unknownTermMessage(
+              fs.readFileSync('programs/lfx-mentorship/automation/terms.yml', 'utf8'),
+              term,
+            );
+            if (termError) {
+              core.setFailed(termError);
+              return;
+            }
 
             console.log(`Exporting proposals for: ${term}`);
 

--- a/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
+++ b/programs/lfx-mentorship/automation/ADMIN_GUIDE.md
@@ -163,7 +163,8 @@ your issue notifications to see what needs attention.
    workflow manually (Actions → **Sync CNCF Projects from Landscape** → Run
    workflow), or wait for
    the Monday cron. This propagates the new `terms.yml` entry into the term
-   dropdown in both the issue form and the export workflow.
+   dropdown in the issue form. (The export workflow needs no sync — it
+   validates its term input against `terms.yml` when you run it.)
 
 4. **Announce the term:** Post to the CNCF blog, Slack (#mentoring), and
    social media. Include a link to the issue form.
@@ -177,7 +178,7 @@ the start of a new year) is still listed explicitly there.
 1. **Remove the term from `terms.yml`** so no new proposals can be filed
    for it.
 
-2. **Run the landscape sync** to update the dropdowns.
+2. **Run the landscape sync** to update the issue form dropdown.
 
 3. Existing open proposals for the closed term remain open — close them
    manually or leave them if they'll carry over to a future term.
@@ -234,7 +235,9 @@ Only users listed in `approvers.yml` under `global_approvers` can use
 The export workflow is triggered manually:
 
 1. Go to **Actions → LFX Export → Run workflow**
-2. Select the term from the dropdown
+2. Enter the term exactly as listed in
+   [`terms.yml`](./terms.yml), e.g. `2027 Term 1 (Mar-May)` — a typo fails
+   fast with an error listing the active terms
 3. Click **Run workflow**
 
 The workflow:
@@ -302,7 +305,7 @@ the existing branch if the previous PR wasn't merged).
 
 ### terms.yml
 
-Single source of truth for active term dropdowns. Format:
+Single source of truth for the active terms. Format:
 
 ```yaml
 terms:
@@ -311,7 +314,8 @@ terms:
 ```
 
 After editing, run the landscape sync workflow to propagate changes to the
-issue form and export workflow.
+issue form dropdown. The export workflow reads this file at run time, so it
+needs no sync.
 
 Opening a term adds its entry automatically (see [Opening a new
 term](#opening-a-new-term)); edit this file by hand only to retire a term or fix

--- a/programs/lfx-mentorship/automation/lib/terms-file.js
+++ b/programs/lfx-mentorship/automation/lib/terms-file.js
@@ -3,9 +3,10 @@
 // Maintain terms.yml — the LFX proposal term dropdown source — as a scaffold
 // output, so a new term is listed once (from its config) instead of by hand.
 //
-// terms.yml is a plain block list of quoted term strings under a `terms:` key,
-// and the landscape-projects-sync workflow reads it verbatim to render the
-// issue-form and export dropdowns. To keep that contract (and the comment
+// terms.yml is a plain block list of quoted term strings under a `terms:` key;
+// the landscape-projects-sync workflow reads it verbatim to render the
+// issue-form dropdown, and the export workflow validates its free-text term
+// input against it at run time. To keep that contract (and the comment
 // header) intact, entries are inserted as text rather than round-tripped
 // through a YAML dumper, which would drop comments and re-quote everything.
 
@@ -38,4 +39,18 @@ function addTermToDropdown(text, label) {
   return lines.join('\n');
 }
 
-module.exports = { addTermToDropdown, listedTerms };
+// Validation for the export workflow's free-text term input. The term choices
+// used to be hardcoded in lfx-export.yml, but the landscape sync could never
+// update them there: GITHUB_TOKEN pushes may not touch workflow files. Returns
+// null when `term` exactly matches a listed entry, otherwise a setFailed-ready
+// message naming the term and the active list.
+function unknownTermMessage(termsText, term) {
+  const active = listedTerms(termsText);
+  if (active.includes(term)) return null;
+  const listing = active.length
+    ? `Active terms in terms.yml: ${active.map((t) => `"${t}"`).join(', ')}`
+    : 'terms.yml lists no active terms';
+  return `Unknown term "${term}". ${listing}.`;
+}
+
+module.exports = { addTermToDropdown, listedTerms, unknownTermMessage };

--- a/programs/lfx-mentorship/automation/terms.yml
+++ b/programs/lfx-mentorship/automation/terms.yml
@@ -1,11 +1,12 @@
 # Active terms for LFX Mentorship proposals.
 #
-# This is the single source of truth for the term dropdown in the issue
-# form and the export workflow.  When you add or retire a term, edit this
-# file and run the landscape-projects-sync workflow (or wait for the
-# Monday cron) — it will update both:
+# This is the single source of truth for the LFX term list.  When you add
+# or retire a term, edit this file and run the landscape-projects-sync
+# workflow (or wait for the Monday cron) — it will update the issue form
+# dropdown:
 #   .github/ISSUE_TEMPLATE/lfx-program-proposal.yml  (id: term)
-#   .github/workflows/lfx-export.yml                  (workflow_dispatch input)
+# The export workflow (.github/workflows/lfx-export.yml) is not synced: it
+# reads this file at run time to validate its free-text term input.
 
 terms:
   - "2027 Term 1 (Mar-May)"

--- a/programs/lfx-mentorship/automation/test/terms-file.test.js
+++ b/programs/lfx-mentorship/automation/test/terms-file.test.js
@@ -2,7 +2,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
-const { addTermToDropdown, listedTerms } = require('../lib/terms-file');
+const { addTermToDropdown, listedTerms, unknownTermMessage } = require('../lib/terms-file');
 
 const SAMPLE = `# Active terms for LFX Mentorship proposals.
 #
@@ -44,4 +44,32 @@ test('listedTerms: returns the current entries, unquoted, in order', () => {
   assert.deepEqual(listedTerms(SAMPLE), ['2026 Term 3 (Sep-Nov)']);
   const grown = addTermToDropdown(SAMPLE, '2027 Term 1 (Mar-May)');
   assert.deepEqual(listedTerms(grown), ['2027 Term 1 (Mar-May)', '2026 Term 3 (Sep-Nov)']);
+});
+
+// ── unknownTermMessage ──
+// Backs the export workflow's free-text term input: the term dropdown used to
+// be hardcoded in lfx-export.yml, which the landscape sync could never update
+// (GITHUB_TOKEN pushes may not touch workflow files), so the input is now
+// validated here against terms.yml at run time.
+
+test('unknownTermMessage: null for an active term', () => {
+  assert.equal(unknownTermMessage(SAMPLE, '2026 Term 3 (Sep-Nov)'), null);
+});
+
+test('unknownTermMessage: names the bad term and lists the active ones', () => {
+  const grown = addTermToDropdown(SAMPLE, '2027 Term 1 (Mar-May)');
+  const msg = unknownTermMessage(grown, '2026 Term 3');
+  assert.match(msg, /Unknown term "2026 Term 3"/);
+  assert.match(msg, /"2027 Term 1 \(Mar-May\)"/);
+  assert.match(msg, /"2026 Term 3 \(Sep-Nov\)"/);
+});
+
+test('unknownTermMessage: exact match only — no trimming or case folding', () => {
+  assert.notEqual(unknownTermMessage(SAMPLE, ' 2026 Term 3 (Sep-Nov)'), null);
+  assert.notEqual(unknownTermMessage(SAMPLE, '2026 term 3 (sep-nov)'), null);
+});
+
+test('unknownTermMessage: says so when terms.yml lists nothing', () => {
+  const msg = unknownTermMessage('terms:\n', '2026 Term 3 (Sep-Nov)');
+  assert.match(msg, /no active terms/);
 });


### PR DESCRIPTION
GITHUB_TOKEN can't push workflow-file edits, so the landscape sync
fails whenever terms.yml changes.